### PR TITLE
refactor(theme): prefix all semantic CSS variables with --line-*

### DIFF
--- a/packages/theme/src/schemas/amber.css
+++ b/packages/theme/src/schemas/amber.css
@@ -1,35 +1,35 @@
 :where(.schema-amber) {
-  --background: var(--amber-1);            /* App background (-1) */
-  --subtle-background: var(--amber-2);     /* Subtle background (-2) */
-  --ui-background: var(--amber-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--amber-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--amber-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--amber-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--amber-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--amber-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--amber-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--amber-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--amber-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--amber-12);        /* High-contrast text (-12) */
-  --light: var(--amber-1);                 /* Light text */
-  --dark: var(--amber-12);                 /* Dark text */
+  --line-background: var(--amber-1);            /* App background (-1) */
+  --line-subtle-background: var(--amber-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--amber-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--amber-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--amber-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--amber-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--amber-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--amber-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--amber-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--amber-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--amber-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--amber-12);        /* High-contrast text (-12) */
+  --line-light: var(--amber-1);                 /* Light text */
+  --line-dark: var(--amber-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-amber)   {
-  --background: var(--amber-12);           /* App background (-1) */
-  --subtle-background: var(--amber-11);    /* Subtle background (-2) */
-  --ui-background: var(--amber-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--amber-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--amber-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--amber-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--amber-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--amber-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--amber-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--amber-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--amber-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--amber-1);         /* High-contrast text (-12) */
-  --light: var(--amber-12);                /* Light text */
-  --dark: var(--amber-1);                  /* Dark text */
+  --line-background: var(--amber-12);           /* App background (-1) */
+  --line-subtle-background: var(--amber-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--amber-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--amber-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--amber-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--amber-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--amber-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--amber-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--amber-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--amber-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--amber-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--amber-1);         /* High-contrast text (-12) */
+  --line-light: var(--amber-12);                /* Light text */
+  --line-dark: var(--amber-1);                  /* Dark text */
 }
 
 :where(.is-amber) {

--- a/packages/theme/src/schemas/blue.css
+++ b/packages/theme/src/schemas/blue.css
@@ -1,33 +1,33 @@
 :where(.schema-blue) {
-  --background: var(--blue-1);            /* App background (-1) */
-  --subtle-background: var(--blue-2);     /* Subtle background (-2) */
-  --ui-background: var(--blue-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--blue-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--blue-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--blue-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--blue-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--blue-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--blue-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--blue-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--blue-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--blue-12);        /* High-contrast text (-12) */
-  --light: var(--blue-1);                 /* Light text */
-  --dark: var(--blue-12);                 /* Dark text */
+  --line-background: var(--blue-1);            /* App background (-1) */
+  --line-subtle-background: var(--blue-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--blue-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--blue-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--blue-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--blue-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--blue-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--blue-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--blue-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--blue-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--blue-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--blue-12);        /* High-contrast text (-12) */
+  --line-light: var(--blue-1);                 /* Light text */
+  --line-dark: var(--blue-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-blue)  {
-  --background: var(--blue-12);           /* App background (-1) */
-  --subtle-background: var(--blue-11);    /* Subtle background (-2) */
-  --ui-background: var(--blue-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--blue-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--blue-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--blue-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--blue-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--blue-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--blue-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--blue-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--blue-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--blue-1);         /* High-contrast text (-12) */
+  --line-background: var(--blue-12);           /* App background (-1) */
+  --line-subtle-background: var(--blue-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--blue-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--blue-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--blue-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--blue-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--blue-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--blue-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--blue-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--blue-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--blue-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--blue-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-blue) {

--- a/packages/theme/src/schemas/bronze.css
+++ b/packages/theme/src/schemas/bronze.css
@@ -1,33 +1,33 @@
 :where(.schema-bronze) {
-  --background: var(--bronze-1);            /* App background (-1) */
-  --subtle-background: var(--bronze-2);     /* Subtle background (-2) */
-  --ui-background: var(--bronze-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--bronze-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--bronze-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--bronze-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--bronze-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--bronze-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--bronze-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--bronze-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--bronze-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--bronze-12);        /* High-contrast text (-12) */
-  --light: var(--bronze-1);                 /* Light text */
-  --dark: var(--bronze-12);                 /* Dark text */
+  --line-background: var(--bronze-1);            /* App background (-1) */
+  --line-subtle-background: var(--bronze-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--bronze-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--bronze-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--bronze-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--bronze-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--bronze-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--bronze-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--bronze-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--bronze-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--bronze-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--bronze-12);        /* High-contrast text (-12) */
+  --line-light: var(--bronze-1);                 /* Light text */
+  --line-dark: var(--bronze-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-bronze)  {
-  --background: var(--bronze-12);           /* App background (-1) */
-  --subtle-background: var(--bronze-11);    /* Subtle background (-2) */
-  --ui-background: var(--bronze-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--bronze-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--bronze-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--bronze-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--bronze-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--bronze-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--bronze-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--bronze-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--bronze-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--bronze-1);         /* High-contrast text (-12) */
+  --line-background: var(--bronze-12);           /* App background (-1) */
+  --line-subtle-background: var(--bronze-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--bronze-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--bronze-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--bronze-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--bronze-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--bronze-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--bronze-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--bronze-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--bronze-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--bronze-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--bronze-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-bronze) {

--- a/packages/theme/src/schemas/brown.css
+++ b/packages/theme/src/schemas/brown.css
@@ -1,33 +1,33 @@
 :where(.schema-brown) {
-  --background: var(--brown-1);            /* App background (-1) */
-  --subtle-background: var(--brown-2);     /* Subtle background (-2) */
-  --ui-background: var(--brown-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--brown-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--brown-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--brown-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--brown-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--brown-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--brown-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--brown-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--brown-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--brown-12);        /* High-contrast text (-12) */
-  --light: var(--brown-1);                 /* Light text */
-  --dark: var(--brown-12);                 /* Dark text */
+  --line-background: var(--brown-1);            /* App background (-1) */
+  --line-subtle-background: var(--brown-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--brown-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--brown-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--brown-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--brown-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--brown-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--brown-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--brown-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--brown-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--brown-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--brown-12);        /* High-contrast text (-12) */
+  --line-light: var(--brown-1);                 /* Light text */
+  --line-dark: var(--brown-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-brown)  {
-  --background: var(--brown-12);           /* App background (-1) */
-  --subtle-background: var(--brown-11);    /* Subtle background (-2) */
-  --ui-background: var(--brown-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--brown-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--brown-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--brown-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--brown-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--brown-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--brown-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--brown-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--brown-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--brown-1);         /* High-contrast text (-12) */
+  --line-background: var(--brown-12);           /* App background (-1) */
+  --line-subtle-background: var(--brown-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--brown-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--brown-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--brown-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--brown-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--brown-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--brown-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--brown-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--brown-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--brown-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--brown-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-brown) {

--- a/packages/theme/src/schemas/crimson.css
+++ b/packages/theme/src/schemas/crimson.css
@@ -1,33 +1,33 @@
 :where(.schema-crimson) {
-  --background: var(--crimson-1);            /* App background (-1) */
-  --subtle-background: var(--crimson-2);     /* Subtle background (-2) */
-  --ui-background: var(--crimson-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--crimson-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--crimson-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--crimson-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--crimson-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--crimson-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--crimson-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--crimson-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--crimson-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--crimson-12);        /* High-contrast text (-12) */
-  --light: var(--crimson-1);                 /* Light text */
-  --dark: var(--crimson-12);                 /* Dark text */
+  --line-background: var(--crimson-1);            /* App background (-1) */
+  --line-subtle-background: var(--crimson-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--crimson-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--crimson-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--crimson-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--crimson-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--crimson-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--crimson-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--crimson-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--crimson-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--crimson-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--crimson-12);        /* High-contrast text (-12) */
+  --line-light: var(--crimson-1);                 /* Light text */
+  --line-dark: var(--crimson-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-crimson)  {
-  --background: var(--crimson-12);           /* App background (-1) */
-  --subtle-background: var(--crimson-11);    /* Subtle background (-2) */
-  --ui-background: var(--crimson-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--crimson-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--crimson-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--crimson-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--crimson-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--crimson-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--crimson-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--crimson-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--crimson-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--crimson-1);         /* High-contrast text (-12) */
+  --line-background: var(--crimson-12);           /* App background (-1) */
+  --line-subtle-background: var(--crimson-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--crimson-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--crimson-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--crimson-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--crimson-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--crimson-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--crimson-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--crimson-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--crimson-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--crimson-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--crimson-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-crimson) {

--- a/packages/theme/src/schemas/cyan.css
+++ b/packages/theme/src/schemas/cyan.css
@@ -1,33 +1,33 @@
 :where(.schema-cyan) {
-  --background: var(--cyan-1);            /* App background (-1) */
-  --subtle-background: var(--cyan-2);     /* Subtle background (-2) */
-  --ui-background: var(--cyan-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--cyan-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--cyan-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--cyan-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--cyan-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--cyan-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--cyan-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--cyan-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--cyan-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--cyan-12);        /* High-contrast text (-12) */
-  --light: var(--cyan-1);                 /* Light text */
-  --dark: var(--cyan-12);                 /* Dark text */
+  --line-background: var(--cyan-1);            /* App background (-1) */
+  --line-subtle-background: var(--cyan-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--cyan-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--cyan-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--cyan-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--cyan-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--cyan-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--cyan-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--cyan-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--cyan-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--cyan-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--cyan-12);        /* High-contrast text (-12) */
+  --line-light: var(--cyan-1);                 /* Light text */
+  --line-dark: var(--cyan-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-cyan)  {
-  --background: var(--cyan-12);           /* App background (-1) */
-  --subtle-background: var(--cyan-11);    /* Subtle background (-2) */
-  --ui-background: var(--cyan-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--cyan-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--cyan-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--cyan-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--cyan-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--cyan-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--cyan-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--cyan-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--cyan-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--cyan-1);         /* High-contrast text (-12) */
+  --line-background: var(--cyan-12);           /* App background (-1) */
+  --line-subtle-background: var(--cyan-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--cyan-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--cyan-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--cyan-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--cyan-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--cyan-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--cyan-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--cyan-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--cyan-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--cyan-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--cyan-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-cyan) {

--- a/packages/theme/src/schemas/gold.css
+++ b/packages/theme/src/schemas/gold.css
@@ -1,33 +1,33 @@
 :where(.schema-gold) {
-  --background: var(--gold-1);            /* App background (-1) */
-  --subtle-background: var(--gold-2);     /* Subtle background (-2) */
-  --ui-background: var(--gold-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--gold-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--gold-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--gold-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--gold-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--gold-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--gold-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--gold-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--gold-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--gold-12);        /* High-contrast text (-12) */
-  --light: var(--gold-1);                 /* Light text */
-  --dark: var(--gold-12);                 /* Dark text */
+  --line-background: var(--gold-1);            /* App background (-1) */
+  --line-subtle-background: var(--gold-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--gold-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--gold-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--gold-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--gold-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--gold-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--gold-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--gold-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--gold-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--gold-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--gold-12);        /* High-contrast text (-12) */
+  --line-light: var(--gold-1);                 /* Light text */
+  --line-dark: var(--gold-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-gold)  {
-  --background: var(--gold-12);           /* App background (-1) */
-  --subtle-background: var(--gold-11);    /* Subtle background (-2) */
-  --ui-background: var(--gold-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--gold-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--gold-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--gold-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--gold-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--gold-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--gold-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--gold-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--gold-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--gold-1);         /* High-contrast text (-12) */
+  --line-background: var(--gold-12);           /* App background (-1) */
+  --line-subtle-background: var(--gold-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--gold-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--gold-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--gold-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--gold-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--gold-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--gold-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--gold-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--gold-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--gold-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--gold-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-gold) {

--- a/packages/theme/src/schemas/grass.css
+++ b/packages/theme/src/schemas/grass.css
@@ -1,33 +1,33 @@
 :where(.schema-grass) {
-  --background: var(--grass-1);            /* App background (-1) */
-  --subtle-background: var(--grass-2);     /* Subtle background (-2) */
-  --ui-background: var(--grass-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--grass-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--grass-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--grass-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--grass-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--grass-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--grass-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--grass-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--grass-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--grass-12);        /* High-contrast text (-12) */
-  --light: var(--grass-1);                 /* Light text */
-  --dark: var(--grass-12);                 /* Dark text */
+  --line-background: var(--grass-1);            /* App background (-1) */
+  --line-subtle-background: var(--grass-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--grass-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--grass-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--grass-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--grass-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--grass-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--grass-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--grass-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--grass-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--grass-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--grass-12);        /* High-contrast text (-12) */
+  --line-light: var(--grass-1);                 /* Light text */
+  --line-dark: var(--grass-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-grass)  {
-  --background: var(--grass-12);           /* App background (-1) */
-  --subtle-background: var(--grass-11);    /* Subtle background (-2) */
-  --ui-background: var(--grass-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--grass-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--grass-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--grass-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--grass-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--grass-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--grass-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--grass-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--grass-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--grass-1);         /* High-contrast text (-12) */
+  --line-background: var(--grass-12);           /* App background (-1) */
+  --line-subtle-background: var(--grass-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--grass-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--grass-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--grass-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--grass-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--grass-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--grass-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--grass-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--grass-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--grass-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--grass-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-grass) {

--- a/packages/theme/src/schemas/gray.css
+++ b/packages/theme/src/schemas/gray.css
@@ -1,33 +1,33 @@
 :where(.schema-gray) {
-  --background: var(--gray-1);            /* App background (-1) */
-  --subtle-background: var(--gray-2);     /* Subtle background (-2) */
-  --ui-background: var(--gray-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--gray-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--gray-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--gray-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--gray-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--gray-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--gray-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--gray-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--gray-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--gray-12);        /* High-contrast text (-12) */
-  --light: var(--gray-1);                 /* Light text */
-  --dark: var(--gray-12);                 /* Dark text */
+  --line-background: var(--gray-1);            /* App background (-1) */
+  --line-subtle-background: var(--gray-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--gray-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--gray-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--gray-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--gray-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--gray-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--gray-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--gray-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--gray-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--gray-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--gray-12);        /* High-contrast text (-12) */
+  --line-light: var(--gray-1);                 /* Light text */
+  --line-dark: var(--gray-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-gray)  {
-  --background: var(--gray-12);           /* App background (-1) */
-  --subtle-background: var(--gray-11);    /* Subtle background (-2) */
-  --ui-background: var(--gray-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--gray-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--gray-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--gray-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--gray-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--gray-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--gray-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--gray-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--gray-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--gray-1);         /* High-contrast text (-12) */
+  --line-background: var(--gray-12);           /* App background (-1) */
+  --line-subtle-background: var(--gray-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--gray-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--gray-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--gray-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--gray-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--gray-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--gray-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--gray-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--gray-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--gray-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--gray-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-gray) {

--- a/packages/theme/src/schemas/green.css
+++ b/packages/theme/src/schemas/green.css
@@ -1,33 +1,33 @@
 :where(.schema-green) {
-  --background: var(--green-1);            /* App background (-1) */
-  --subtle-background: var(--green-2);     /* Subtle background (-2) */
-  --ui-background: var(--green-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--green-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--green-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--green-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--green-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--green-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--green-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--green-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--green-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--green-12);        /* High-contrast text (-12) */
-  --light: var(--green-1);                 /* Light text */
-  --dark: var(--green-12);                 /* Dark text */
+  --line-background: var(--green-1);            /* App background (-1) */
+  --line-subtle-background: var(--green-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--green-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--green-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--green-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--green-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--green-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--green-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--green-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--green-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--green-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--green-12);        /* High-contrast text (-12) */
+  --line-light: var(--green-1);                 /* Light text */
+  --line-dark: var(--green-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-green)  {
-  --background: var(--green-12);           /* App background (-1) */
-  --subtle-background: var(--green-11);    /* Subtle background (-2) */
-  --ui-background: var(--green-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--green-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--green-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--green-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--green-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--green-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--green-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--green-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--green-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--green-1);         /* High-contrast text (-12) */
+  --line-background: var(--green-12);           /* App background (-1) */
+  --line-subtle-background: var(--green-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--green-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--green-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--green-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--green-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--green-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--green-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--green-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--green-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--green-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--green-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-green) {

--- a/packages/theme/src/schemas/indigo.css
+++ b/packages/theme/src/schemas/indigo.css
@@ -1,33 +1,33 @@
 :where(.schema-indigo) {
-  --background: var(--indigo-1);            /* App background (-1) */
-  --subtle-background: var(--indigo-2);     /* Subtle background (-2) */
-  --ui-background: var(--indigo-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--indigo-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--indigo-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--indigo-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--indigo-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--indigo-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--indigo-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--indigo-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--indigo-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--indigo-12);        /* High-contrast text (-12) */
-  --light: var(--indigo-1);                 /* Light text */
-  --dark: var(--indigo-12);                 /* Dark text */
+  --line-background: var(--indigo-1);            /* App background (-1) */
+  --line-subtle-background: var(--indigo-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--indigo-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--indigo-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--indigo-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--indigo-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--indigo-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--indigo-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--indigo-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--indigo-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--indigo-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--indigo-12);        /* High-contrast text (-12) */
+  --line-light: var(--indigo-1);                 /* Light text */
+  --line-dark: var(--indigo-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-indigo)  {
-  --background: var(--indigo-12);           /* App background (-1) */
-  --subtle-background: var(--indigo-11);    /* Subtle background (-2) */
-  --ui-background: var(--indigo-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--indigo-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--indigo-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--indigo-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--indigo-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--indigo-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--indigo-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--indigo-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--indigo-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--indigo-1);         /* High-contrast text (-12) */
+  --line-background: var(--indigo-12);           /* App background (-1) */
+  --line-subtle-background: var(--indigo-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--indigo-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--indigo-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--indigo-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--indigo-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--indigo-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--indigo-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--indigo-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--indigo-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--indigo-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--indigo-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-indigo) {

--- a/packages/theme/src/schemas/lime.css
+++ b/packages/theme/src/schemas/lime.css
@@ -1,33 +1,33 @@
 :where(.schema-lime) {
-  --background: var(--lime-1);            /* App background (-1) */
-  --subtle-background: var(--lime-2);     /* Subtle background (-2) */
-  --ui-background: var(--lime-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--lime-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--lime-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--lime-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--lime-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--lime-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--lime-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--lime-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--lime-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--lime-12);        /* High-contrast text (-12) */
-  --light: var(--lime-1);                 /* Light text */
-  --dark: var(--lime-12);                 /* Dark text */
+  --line-background: var(--lime-1);            /* App background (-1) */
+  --line-subtle-background: var(--lime-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--lime-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--lime-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--lime-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--lime-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--lime-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--lime-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--lime-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--lime-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--lime-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--lime-12);        /* High-contrast text (-12) */
+  --line-light: var(--lime-1);                 /* Light text */
+  --line-dark: var(--lime-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-lime)  {
-  --background: var(--lime-12);           /* App background (-1) */
-  --subtle-background: var(--lime-11);    /* Subtle background (-2) */
-  --ui-background: var(--lime-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--lime-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--lime-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--lime-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--lime-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--lime-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--lime-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--lime-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--lime-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--lime-1);         /* High-contrast text (-12) */
+  --line-background: var(--lime-12);           /* App background (-1) */
+  --line-subtle-background: var(--lime-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--lime-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--lime-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--lime-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--lime-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--lime-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--lime-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--lime-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--lime-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--lime-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--lime-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-lime) {

--- a/packages/theme/src/schemas/mauve.css
+++ b/packages/theme/src/schemas/mauve.css
@@ -1,33 +1,33 @@
 :where(.schema-mauve) {
-  --background: var(--mauve-1);            /* App background (-1) */
-  --subtle-background: var(--mauve-2);     /* Subtle background (-2) */
-  --ui-background: var(--mauve-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--mauve-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--mauve-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--mauve-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--mauve-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--mauve-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--mauve-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--mauve-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--mauve-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--mauve-12);        /* High-contrast text (-12) */
-  --light: var(--mauve-1);                 /* Light text */
-  --dark: var(--mauve-12);                 /* Dark text */
+  --line-background: var(--mauve-1);            /* App background (-1) */
+  --line-subtle-background: var(--mauve-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--mauve-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--mauve-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--mauve-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--mauve-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--mauve-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--mauve-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--mauve-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--mauve-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--mauve-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--mauve-12);        /* High-contrast text (-12) */
+  --line-light: var(--mauve-1);                 /* Light text */
+  --line-dark: var(--mauve-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-mauve)  {
-  --background: var(--mauve-12);           /* App background (-1) */
-  --subtle-background: var(--mauve-11);    /* Subtle background (-2) */
-  --ui-background: var(--mauve-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--mauve-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--mauve-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--mauve-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--mauve-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--mauve-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--mauve-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--mauve-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--mauve-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--mauve-1);         /* High-contrast text (-12) */
+  --line-background: var(--mauve-12);           /* App background (-1) */
+  --line-subtle-background: var(--mauve-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--mauve-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--mauve-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--mauve-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--mauve-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--mauve-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--mauve-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--mauve-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--mauve-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--mauve-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--mauve-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-mauve) {

--- a/packages/theme/src/schemas/mint.css
+++ b/packages/theme/src/schemas/mint.css
@@ -1,35 +1,35 @@
 :where(.schema-mint) {
-  --background: var(--mint-1);            /* App background (-1) */
-  --subtle-background: var(--mint-2);     /* Subtle background (-2) */
-  --ui-background: var(--mint-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--mint-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--mint-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--mint-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--mint-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--mint-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--mint-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--mint-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--mint-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--mint-12);        /* High-contrast text (-12) */
-  --light: var(--mint-1);                 /* Light text */
-  --white: var(--mint-1);                 /* White text */
-  --black: var(--mint-12);                /* Black text */
-  --dark: var(--mint-12);                 /* Dark text */
+  --line-background: var(--mint-1);            /* App background (-1) */
+  --line-subtle-background: var(--mint-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--mint-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--mint-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--mint-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--mint-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--mint-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--mint-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--mint-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--mint-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--mint-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--mint-12);        /* High-contrast text (-12) */
+  --line-light: var(--mint-1);                 /* Light text */
+  --line-white: var(--mint-1);                 /* White text */
+  --line-black: var(--mint-12);                /* Black text */
+  --line-dark: var(--mint-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-mint)  {
-  --background: var(--mint-12);           /* App background (-1) */
-  --subtle-background: var(--mint-11);    /* Subtle background (-2) */
-  --ui-background: var(--mint-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--mint-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--mint-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--mint-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--mint-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--mint-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--mint-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--mint-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--mint-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--mint-1);         /* High-contrast text (-12) */
+  --line-background: var(--mint-12);           /* App background (-1) */
+  --line-subtle-background: var(--mint-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--mint-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--mint-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--mint-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--mint-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--mint-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--mint-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--mint-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--mint-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--mint-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--mint-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-mint) {

--- a/packages/theme/src/schemas/olive.css
+++ b/packages/theme/src/schemas/olive.css
@@ -1,35 +1,35 @@
 :where(.schema-olive) {
-  --background: var(--olive-1);            /* App background (-1) */
-  --subtle-background: var(--olive-2);     /* Subtle background (-2) */
-  --ui-background: var(--olive-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--olive-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--olive-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--olive-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--olive-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--olive-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--olive-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--olive-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--olive-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--olive-12);        /* High-contrast text (-12) */
-  --light: var(--olive-1);                 /* Light text */
-  --white: var(--olive-1);                 /* White text */
-  --black: var(--olive-12);                /* Black text */
-  --dark: var(--olive-12);                 /* Dark text */
+  --line-background: var(--olive-1);            /* App background (-1) */
+  --line-subtle-background: var(--olive-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--olive-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--olive-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--olive-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--olive-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--olive-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--olive-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--olive-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--olive-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--olive-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--olive-12);        /* High-contrast text (-12) */
+  --line-light: var(--olive-1);                 /* Light text */
+  --line-white: var(--olive-1);                 /* White text */
+  --line-black: var(--olive-12);                /* Black text */
+  --line-dark: var(--olive-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-olive)  {
-  --background: var(--olive-12);           /* App background (-1) */
-  --subtle-background: var(--olive-11);    /* Subtle background (-2) */
-  --ui-background: var(--olive-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--olive-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--olive-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--olive-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--olive-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--olive-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--olive-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--olive-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--olive-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--olive-1);         /* High-contrast text (-12) */
+  --line-background: var(--olive-12);           /* App background (-1) */
+  --line-subtle-background: var(--olive-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--olive-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--olive-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--olive-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--olive-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--olive-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--olive-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--olive-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--olive-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--olive-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--olive-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-olive) {

--- a/packages/theme/src/schemas/orange.css
+++ b/packages/theme/src/schemas/orange.css
@@ -1,35 +1,35 @@
 :where(.schema-orange) {
-  --background: var(--orange-1);            /* App background (-1) */
-  --subtle-background: var(--orange-2);     /* Subtle background (-2) */
-  --ui-background: var(--orange-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--orange-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--orange-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--orange-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--orange-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--orange-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--orange-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--orange-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--orange-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--orange-12);        /* High-contrast text (-12) */
-  --light: var(--orange-1);                 /* Light text */
-  --white: var(--orange-1);                 /* White text */
-  --black: var(--orange-12);                /* Black text */
-  --dark: var(--orange-12);                 /* Dark text */
+  --line-background: var(--orange-1);            /* App background (-1) */
+  --line-subtle-background: var(--orange-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--orange-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--orange-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--orange-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--orange-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--orange-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--orange-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--orange-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--orange-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--orange-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--orange-12);        /* High-contrast text (-12) */
+  --line-light: var(--orange-1);                 /* Light text */
+  --line-white: var(--orange-1);                 /* White text */
+  --line-black: var(--orange-12);                /* Black text */
+  --line-dark: var(--orange-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-orange)  {
-  --background: var(--orange-12);           /* App background (-1) */
-  --subtle-background: var(--orange-11);    /* Subtle background (-2) */
-  --ui-background: var(--orange-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--orange-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--orange-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--orange-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--orange-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--orange-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--orange-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--orange-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--orange-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--orange-1);         /* High-contrast text (-12) */
+  --line-background: var(--orange-12);           /* App background (-1) */
+  --line-subtle-background: var(--orange-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--orange-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--orange-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--orange-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--orange-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--orange-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--orange-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--orange-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--orange-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--orange-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--orange-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-orange) {

--- a/packages/theme/src/schemas/pink.css
+++ b/packages/theme/src/schemas/pink.css
@@ -1,35 +1,35 @@
 :where(.schema-pink) {
-  --background: var(--pink-1);            /* App background (-1) */
-  --subtle-background: var(--pink-2);     /* Subtle background (-2) */
-  --ui-background: var(--pink-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--pink-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--pink-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--pink-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--pink-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--pink-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--pink-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--pink-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--pink-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--pink-12);        /* High-contrast text (-12) */
-  --light: var(--pink-1);                 /* Light text */
-  --white: var(--pink-1);                 /* White text */
-  --black: var(--pink-12);                /* Black text */
-  --dark: var(--pink-12);                 /* Dark text */
+  --line-background: var(--pink-1);            /* App background (-1) */
+  --line-subtle-background: var(--pink-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--pink-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--pink-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--pink-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--pink-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--pink-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--pink-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--pink-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--pink-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--pink-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--pink-12);        /* High-contrast text (-12) */
+  --line-light: var(--pink-1);                 /* Light text */
+  --line-white: var(--pink-1);                 /* White text */
+  --line-black: var(--pink-12);                /* Black text */
+  --line-dark: var(--pink-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-pink)  {
-  --background: var(--pink-12);           /* App background (-1) */
-  --subtle-background: var(--pink-11);    /* Subtle background (-2) */
-  --ui-background: var(--pink-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--pink-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--pink-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--pink-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--pink-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--pink-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--pink-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--pink-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--pink-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--pink-1);         /* High-contrast text (-12) */
+  --line-background: var(--pink-12);           /* App background (-1) */
+  --line-subtle-background: var(--pink-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--pink-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--pink-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--pink-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--pink-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--pink-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--pink-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--pink-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--pink-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--pink-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--pink-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-pink) {

--- a/packages/theme/src/schemas/plum.css
+++ b/packages/theme/src/schemas/plum.css
@@ -1,35 +1,35 @@
 :where(.schema-plum) {
-  --background: var(--plum-1);            /* App background (-1) */
-  --subtle-background: var(--plum-2);     /* Subtle background (-2) */
-  --ui-background: var(--plum-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--plum-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--plum-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--plum-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--plum-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--plum-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--plum-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--plum-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--plum-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--plum-12);        /* High-contrast text (-12) */
-  --light: var(--plum-1);                 /* Light text */
-  --white: var(--plum-1);                 /* White text */
-  --black: var(--plum-12);                /* Black text */
-  --dark: var(--plum-12);                 /* Dark text */
+  --line-background: var(--plum-1);            /* App background (-1) */
+  --line-subtle-background: var(--plum-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--plum-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--plum-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--plum-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--plum-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--plum-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--plum-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--plum-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--plum-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--plum-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--plum-12);        /* High-contrast text (-12) */
+  --line-light: var(--plum-1);                 /* Light text */
+  --line-white: var(--plum-1);                 /* White text */
+  --line-black: var(--plum-12);                /* Black text */
+  --line-dark: var(--plum-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-plum)  {
-  --background: var(--plum-12);           /* App background (-1) */
-  --subtle-background: var(--plum-11);    /* Subtle background (-2) */
-  --ui-background: var(--plum-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--plum-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--plum-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--plum-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--plum-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--plum-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--plum-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--plum-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--plum-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--plum-1);         /* High-contrast text (-12) */
+  --line-background: var(--plum-12);           /* App background (-1) */
+  --line-subtle-background: var(--plum-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--plum-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--plum-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--plum-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--plum-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--plum-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--plum-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--plum-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--plum-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--plum-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--plum-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-plum) {

--- a/packages/theme/src/schemas/purple.css
+++ b/packages/theme/src/schemas/purple.css
@@ -1,35 +1,35 @@
 :where(.schema-purple) {
-  --background: var(--purple-1);            /* App background (-1) */
-  --subtle-background: var(--purple-2);     /* Subtle background (-2) */
-  --ui-background: var(--purple-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--purple-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--purple-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--purple-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--purple-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--purple-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--purple-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--purple-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--purple-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--purple-12);        /* High-contrast text (-12) */
-  --light: var(--purple-1);                 /* Light text */
-  --white: var(--purple-1);                 /* White text */
-  --black: var(--purple-12);                /* Black text */
-  --dark: var(--purple-12);                 /* Dark text */
+  --line-background: var(--purple-1);            /* App background (-1) */
+  --line-subtle-background: var(--purple-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--purple-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--purple-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--purple-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--purple-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--purple-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--purple-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--purple-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--purple-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--purple-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--purple-12);        /* High-contrast text (-12) */
+  --line-light: var(--purple-1);                 /* Light text */
+  --line-white: var(--purple-1);                 /* White text */
+  --line-black: var(--purple-12);                /* Black text */
+  --line-dark: var(--purple-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-purple)  {
-  --background: var(--purple-12);           /* App background (-1) */
-  --subtle-background: var(--purple-11);    /* Subtle background (-2) */
-  --ui-background: var(--purple-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--purple-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--purple-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--purple-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--purple-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--purple-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--purple-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--purple-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--purple-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--purple-1);         /* High-contrast text (-12) */
+  --line-background: var(--purple-12);           /* App background (-1) */
+  --line-subtle-background: var(--purple-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--purple-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--purple-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--purple-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--purple-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--purple-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--purple-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--purple-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--purple-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--purple-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--purple-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-purple) {

--- a/packages/theme/src/schemas/red.css
+++ b/packages/theme/src/schemas/red.css
@@ -1,35 +1,35 @@
 :where(.schema-red) {
-  --background: var(--red-1);            /* App background (-1) */
-  --subtle-background: var(--red-2);     /* Subtle background (-2) */
-  --ui-background: var(--red-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--red-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--red-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--red-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--red-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--red-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--red-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--red-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--red-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--red-12);        /* High-contrast text (-12) */
-  --light: var(--red-1);                 /* Light text */
-  --white: var(--red-1);                 /* White text */
-  --black: var(--red-12);                /* Black text */
-  --dark: var(--red-12);                 /* Dark text */
+  --line-background: var(--red-1);            /* App background (-1) */
+  --line-subtle-background: var(--red-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--red-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--red-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--red-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--red-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--red-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--red-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--red-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--red-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--red-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--red-12);        /* High-contrast text (-12) */
+  --line-light: var(--red-1);                 /* Light text */
+  --line-white: var(--red-1);                 /* White text */
+  --line-black: var(--red-12);                /* Black text */
+  --line-dark: var(--red-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-red)  {
-  --background: var(--red-12);           /* App background (-1) */
-  --subtle-background: var(--red-11);    /* Subtle background (-2) */
-  --ui-background: var(--red-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--red-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--red-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--red-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--red-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--red-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--red-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--red-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--red-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--red-1);         /* High-contrast text (-12) */
+  --line-background: var(--red-12);           /* App background (-1) */
+  --line-subtle-background: var(--red-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--red-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--red-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--red-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--red-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--red-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--red-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--red-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--red-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--red-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--red-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-red) {

--- a/packages/theme/src/schemas/sage.css
+++ b/packages/theme/src/schemas/sage.css
@@ -1,35 +1,35 @@
 :where(.schema-sage) {
-  --background: var(--sage-1);            /* App background (-1) */
-  --subtle-background: var(--sage-2);     /* Subtle background (-2) */
-  --ui-background: var(--sage-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--sage-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--sage-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--sage-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--sage-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--sage-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--sage-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--sage-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--sage-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--sage-12);        /* High-contrast text (-12) */
-  --light: var(--sage-1);                 /* Light text */
-  --white: var(--sage-1);                 /* White text */
-  --black: var(--sage-12);                /* Black text */
-  --dark: var(--sage-12);                 /* Dark text */
+  --line-background: var(--sage-1);            /* App background (-1) */
+  --line-subtle-background: var(--sage-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--sage-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--sage-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--sage-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--sage-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--sage-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--sage-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--sage-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--sage-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--sage-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--sage-12);        /* High-contrast text (-12) */
+  --line-light: var(--sage-1);                 /* Light text */
+  --line-white: var(--sage-1);                 /* White text */
+  --line-black: var(--sage-12);                /* Black text */
+  --line-dark: var(--sage-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-sage)  {
-  --background: var(--sage-12);           /* App background (-1) */
-  --subtle-background: var(--sage-11);    /* Subtle background (-2) */
-  --ui-background: var(--sage-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--sage-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--sage-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--sage-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--sage-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--sage-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--sage-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--sage-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--sage-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--sage-1);         /* High-contrast text (-12) */
+  --line-background: var(--sage-12);           /* App background (-1) */
+  --line-subtle-background: var(--sage-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--sage-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--sage-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--sage-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--sage-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--sage-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--sage-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--sage-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--sage-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--sage-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--sage-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-sage) {

--- a/packages/theme/src/schemas/sand.css
+++ b/packages/theme/src/schemas/sand.css
@@ -1,35 +1,35 @@
 :where(.schema-sand) {
-  --background: var(--sand-1);            /* App background (-1) */
-  --subtle-background: var(--sand-2);     /* Subtle background (-2) */
-  --ui-background: var(--sand-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--sand-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--sand-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--sand-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--sand-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--sand-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--sand-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--sand-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--sand-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--sand-12);        /* High-contrast text (-12) */
-  --light: var(--sand-1);                 /* Light text */
-  --white: var(--sand-1);                 /* White text */
-  --black: var(--sand-12);                /* Black text */
-  --dark: var(--sand-12);                 /* Dark text */
+  --line-background: var(--sand-1);            /* App background (-1) */
+  --line-subtle-background: var(--sand-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--sand-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--sand-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--sand-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--sand-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--sand-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--sand-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--sand-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--sand-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--sand-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--sand-12);        /* High-contrast text (-12) */
+  --line-light: var(--sand-1);                 /* Light text */
+  --line-white: var(--sand-1);                 /* White text */
+  --line-black: var(--sand-12);                /* Black text */
+  --line-dark: var(--sand-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-sand)  {
-  --background: var(--sand-12);           /* App background (-1) */
-  --subtle-background: var(--sand-11);    /* Subtle background (-2) */
-  --ui-background: var(--sand-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--sand-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--sand-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--sand-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--sand-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--sand-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--sand-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--sand-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--sand-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--sand-1);         /* High-contrast text (-12) */
+  --line-background: var(--sand-12);           /* App background (-1) */
+  --line-subtle-background: var(--sand-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--sand-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--sand-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--sand-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--sand-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--sand-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--sand-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--sand-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--sand-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--sand-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--sand-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-sand) {

--- a/packages/theme/src/schemas/sky.css
+++ b/packages/theme/src/schemas/sky.css
@@ -1,35 +1,35 @@
 :where(.schema-sky) {
-  --background: var(--sky-1);            /* App background (-1) */
-  --subtle-background: var(--sky-2);     /* Subtle background (-2) */
-  --ui-background: var(--sky-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--sky-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--sky-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--sky-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--sky-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--sky-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--sky-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--sky-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--sky-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--sky-12);        /* High-contrast text (-12) */
-  --light: var(--sky-1);                 /* Light text */
-  --white: var(--sky-1);                 /* White text */
-  --black: var(--sky-12);                /* Black text */
-  --dark: var(--sky-12);                 /* Dark text */
+  --line-background: var(--sky-1);            /* App background (-1) */
+  --line-subtle-background: var(--sky-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--sky-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--sky-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--sky-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--sky-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--sky-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--sky-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--sky-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--sky-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--sky-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--sky-12);        /* High-contrast text (-12) */
+  --line-light: var(--sky-1);                 /* Light text */
+  --line-white: var(--sky-1);                 /* White text */
+  --line-black: var(--sky-12);                /* Black text */
+  --line-dark: var(--sky-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-sky)  {
-  --background: var(--sky-12);           /* App background (-1) */
-  --subtle-background: var(--sky-11);    /* Subtle background (-2) */
-  --ui-background: var(--sky-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--sky-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--sky-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--sky-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--sky-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--sky-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--sky-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--sky-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--sky-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--sky-1);         /* High-contrast text (-12) */
+  --line-background: var(--sky-12);           /* App background (-1) */
+  --line-subtle-background: var(--sky-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--sky-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--sky-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--sky-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--sky-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--sky-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--sky-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--sky-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--sky-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--sky-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--sky-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-sky) {

--- a/packages/theme/src/schemas/slate.css
+++ b/packages/theme/src/schemas/slate.css
@@ -1,35 +1,35 @@
 :where(.schema-slate) {
-  --background: var(--slate-1);            /* App background (-1) */
-  --subtle-background: var(--slate-2);     /* Subtle background (-2) */
-  --ui-background: var(--slate-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--slate-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--slate-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--slate-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--slate-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--slate-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--slate-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--slate-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--slate-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--slate-12);        /* High-contrast text (-12) */
-  --light: var(--slate-1);                 /* Light text */
-  --white: var(--slate-1);                 /* White text */
-  --black: var(--slate-12);                /* Black text */
-  --dark: var(--slate-12);                 /* Dark text */
+  --line-background: var(--slate-1);            /* App background (-1) */
+  --line-subtle-background: var(--slate-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--slate-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--slate-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--slate-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--slate-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--slate-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--slate-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--slate-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--slate-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--slate-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--slate-12);        /* High-contrast text (-12) */
+  --line-light: var(--slate-1);                 /* Light text */
+  --line-white: var(--slate-1);                 /* White text */
+  --line-black: var(--slate-12);                /* Black text */
+  --line-dark: var(--slate-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-slate)  {
-  --background: var(--slate-12);           /* App background (-1) */
-  --subtle-background: var(--slate-11);    /* Subtle background (-2) */
-  --ui-background: var(--slate-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--slate-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--slate-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--slate-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--slate-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--slate-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--slate-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--slate-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--slate-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--slate-1);         /* High-contrast text (-12) */
+  --line-background: var(--slate-12);           /* App background (-1) */
+  --line-subtle-background: var(--slate-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--slate-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--slate-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--slate-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--slate-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--slate-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--slate-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--slate-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--slate-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--slate-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--slate-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-slate) {

--- a/packages/theme/src/schemas/teal.css
+++ b/packages/theme/src/schemas/teal.css
@@ -1,35 +1,35 @@
 :where(.schema-teal) {
-  --background: var(--teal-1);            /* App background (-1) */
-  --subtle-background: var(--teal-2);     /* Subtle background (-2) */
-  --ui-background: var(--teal-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--teal-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--teal-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--teal-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--teal-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--teal-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--teal-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--teal-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--teal-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--teal-12);        /* High-contrast text (-12) */
-  --light: var(--teal-1);                 /* Light text */
-  --white: var(--teal-1);                 /* White text */
-  --black: var(--teal-12);                /* Black text */
-  --dark: var(--teal-12);                 /* Dark text */
+  --line-background: var(--teal-1);            /* App background (-1) */
+  --line-subtle-background: var(--teal-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--teal-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--teal-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--teal-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--teal-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--teal-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--teal-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--teal-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--teal-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--teal-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--teal-12);        /* High-contrast text (-12) */
+  --line-light: var(--teal-1);                 /* Light text */
+  --line-white: var(--teal-1);                 /* White text */
+  --line-black: var(--teal-12);                /* Black text */
+  --line-dark: var(--teal-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-teal)  {
-  --background: var(--teal-12);           /* App background (-1) */
-  --subtle-background: var(--teal-11);    /* Subtle background (-2) */
-  --ui-background: var(--teal-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--teal-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--teal-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--teal-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--teal-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--teal-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--teal-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--teal-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--teal-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--teal-1);         /* High-contrast text (-12) */
+  --line-background: var(--teal-12);           /* App background (-1) */
+  --line-subtle-background: var(--teal-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--teal-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--teal-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--teal-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--teal-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--teal-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--teal-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--teal-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--teal-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--teal-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--teal-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-teal) {

--- a/packages/theme/src/schemas/tomato.css
+++ b/packages/theme/src/schemas/tomato.css
@@ -1,35 +1,35 @@
 :where(.schema-tomato) {
-  --background: var(--tomato-1);            /* App background (-1) */
-  --subtle-background: var(--tomato-2);     /* Subtle background (-2) */
-  --ui-background: var(--tomato-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--tomato-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--tomato-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--tomato-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--tomato-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--tomato-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--tomato-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--tomato-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--tomato-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--tomato-12);        /* High-contrast text (-12) */
-  --light: var(--tomato-1);                 /* Light text */
-  --white: var(--tomato-1);                 /* White text */
-  --black: var(--tomato-12);                /* Black text */
-  --dark: var(--tomato-12);                 /* Dark text */
+  --line-background: var(--tomato-1);            /* App background (-1) */
+  --line-subtle-background: var(--tomato-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--tomato-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--tomato-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--tomato-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--tomato-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--tomato-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--tomato-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--tomato-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--tomato-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--tomato-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--tomato-12);        /* High-contrast text (-12) */
+  --line-light: var(--tomato-1);                 /* Light text */
+  --line-white: var(--tomato-1);                 /* White text */
+  --line-black: var(--tomato-12);                /* Black text */
+  --line-dark: var(--tomato-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-tomato)  {
-  --background: var(--tomato-12);           /* App background (-1) */
-  --subtle-background: var(--tomato-11);    /* Subtle background (-2) */
-  --ui-background: var(--tomato-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--tomato-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--tomato-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--tomato-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--tomato-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--tomato-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--tomato-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--tomato-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--tomato-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--tomato-1);         /* High-contrast text (-12) */
+  --line-background: var(--tomato-12);           /* App background (-1) */
+  --line-subtle-background: var(--tomato-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--tomato-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--tomato-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--tomato-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--tomato-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--tomato-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--tomato-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--tomato-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--tomato-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--tomato-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--tomato-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-tomato) {

--- a/packages/theme/src/schemas/violet.css
+++ b/packages/theme/src/schemas/violet.css
@@ -1,35 +1,35 @@
 :where(.schema-violet) {
-  --background: var(--violet-1);            /* App background (-1) */
-  --subtle-background: var(--violet-2);     /* Subtle background (-2) */
-  --ui-background: var(--violet-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--violet-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--violet-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--violet-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--violet-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--violet-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--violet-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--violet-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--violet-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--violet-12);        /* High-contrast text (-12) */
-  --light: var(--violet-1);                 /* Light text */
-  --white: var(--violet-1);                 /* White text */
-  --black: var(--violet-12);                /* Black text */
-  --dark: var(--violet-12);                 /* Dark text */
+  --line-background: var(--violet-1);            /* App background (-1) */
+  --line-subtle-background: var(--violet-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--violet-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--violet-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--violet-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--violet-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--violet-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--violet-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--violet-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--violet-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--violet-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--violet-12);        /* High-contrast text (-12) */
+  --line-light: var(--violet-1);                 /* Light text */
+  --line-white: var(--violet-1);                 /* White text */
+  --line-black: var(--violet-12);                /* Black text */
+  --line-dark: var(--violet-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-violet)  {
-  --background: var(--violet-12);           /* App background (-1) */
-  --subtle-background: var(--violet-11);    /* Subtle background (-2) */
-  --ui-background: var(--violet-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--violet-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--violet-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--violet-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--violet-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--violet-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--violet-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--violet-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--violet-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--violet-1);         /* High-contrast text (-12) */
+  --line-background: var(--violet-12);           /* App background (-1) */
+  --line-subtle-background: var(--violet-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--violet-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--violet-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--violet-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--violet-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--violet-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--violet-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--violet-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--violet-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--violet-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--violet-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-violet) {

--- a/packages/theme/src/schemas/yellow.css
+++ b/packages/theme/src/schemas/yellow.css
@@ -1,35 +1,35 @@
 :where(.schema-yellow) {
-  --background: var(--yellow-1);            /* App background (-1) */
-  --subtle-background: var(--yellow-2);     /* Subtle background (-2) */
-  --ui-background: var(--yellow-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--yellow-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--yellow-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--yellow-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--yellow-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--yellow-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--yellow-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--yellow-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--yellow-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--yellow-12);        /* High-contrast text (-12) */
-  --light: var(--yellow-1);                 /* Light text */
-  --white: var(--yellow-1);                 /* White text */
-  --black: var(--yellow-12);                /* Black text */
-  --dark: var(--yellow-12);                 /* Dark text */
+  --line-background: var(--yellow-1);            /* App background (-1) */
+  --line-subtle-background: var(--yellow-2);     /* Subtle background (-2) */
+  --line-ui-background: var(--yellow-3);         /* UI element background (-3) */
+  --line-ui-hover-background: var(--yellow-4);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--yellow-5);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--yellow-6);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--yellow-7);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--yellow-8);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--yellow-9);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--yellow-10);          /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--yellow-11);         /* Low-contrast text (-11) */
+  --line-high-contrast: var(--yellow-12);        /* High-contrast text (-12) */
+  --line-light: var(--yellow-1);                 /* Light text */
+  --line-white: var(--yellow-1);                 /* White text */
+  --line-black: var(--yellow-12);                /* Black text */
+  --line-dark: var(--yellow-12);                 /* Dark text */
 }
 
 :is(.dark) :where(.schema-yellow)  {
-  --background: var(--yellow-12);           /* App background (-1) */
-  --subtle-background: var(--yellow-11);    /* Subtle background (-2) */
-  --ui-background: var(--yellow-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--yellow-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--yellow-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--yellow-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--yellow-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--yellow-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--yellow-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--yellow-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--yellow-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--yellow-1);         /* High-contrast text (-12) */
+  --line-background: var(--yellow-12);           /* App background (-1) */
+  --line-subtle-background: var(--yellow-11);    /* Subtle background (-2) */
+  --line-ui-background: var(--yellow-10);        /* UI element background (-3) */
+  --line-ui-hover-background: var(--yellow-9);   /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--yellow-8);  /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--yellow-7);         /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--yellow-6);             /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--yellow-5);       /* Hovered UI element border (-8) */
+  --line-solid-background: var(--yellow-4);      /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--yellow-3);           /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--yellow-2);          /* Low-contrast text (-11) */
+  --line-high-contrast: var(--yellow-1);         /* High-contrast text (-12) */
 }
 
 :where(.is-yellow) {

--- a/packages/theme/src/style.css
+++ b/packages/theme/src/style.css
@@ -61,8 +61,8 @@
 @import './custom/orange-custom.css';
 
 body {
-  color: var(--low-contrast);
-  background-color: var(--background);
+  color: var(--line-low-contrast);
+  background-color: var(--line-background);
 }
 
 .page-title {
@@ -99,7 +99,7 @@ body {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  border-color: var(--ui-border);
+  border-color: var(--line-ui-border);
   border-bottom-width: 1px;
 
   &-title {
@@ -147,13 +147,13 @@ body {
 }
 
 .ui-theme-button {
-  color: var(--high-contrast);
-  border-color: var(--ui-border);
-  outline-color: var(--ui-border);
+  color: var(--line-high-contrast);
+  border-color: var(--line-ui-border);
+  outline-color: var(--line-ui-border);
 
   &:hover {
-    border-color: var(--ui-border-hover);
-    outline-color: var(--ui-border-hover);
+    border-color: var(--line-ui-border-hover);
+    outline-color: var(--line-ui-border-hover);
   }
 }
 
@@ -167,27 +167,27 @@ body {
 
   div {
     height: var(--size-7);
-    outline-color: var(--ui-border);
+    outline-color: var(--line-ui-border);
     outline-style: solid;
     outline-width: 1px;
-    color: var(--low-contrast);
+    color: var(--line-low-contrast);
   }
 }
 
 .ui-light {
-  background-color: var(--light);
+  background-color: var(--line-light);
 }
 
 .ui-dark {
-  background-color: var(--dark);
+  background-color: var(--line-dark);
 }
 
 .ui-white {
-  background-color: var(--white);
+  background-color: var(--line-white);
 }
 
 .ui-black {
-  background-color: var(--black);
+  background-color: var(--line-black);
 }
 
 

--- a/packages/theme/src/utils/general.css
+++ b/packages/theme/src/utils/general.css
@@ -1,83 +1,83 @@
 ::-moz-selection { /* Code for Firefox */
   transition: all ease-in-out delay-150;
-  color: var(--low-contrast);
-  background-color: var(--ui-active-background);
+  color: var(--line-low-contrast);
+  background-color: var(--line-ui-active-background);
 }
 
 ::selection {
   transition: all ease-in-out delay-150;
-  color: var(--low-contrast);
-  background-color: var(--ui-active-background);
+  color: var(--line-low-contrast);
+  background-color: var(--line-ui-active-background);
 }
 
 .is-background {
-  background-color: var(--background);
+  background-color: var(--line-background);
 }
 
 .is-subtle-background {
-  background-color: var(--subtle-background);
+  background-color: var(--line-subtle-background);
 }
 
 .is-ui-background {
   transition: colors ease-in-out delay-150;
-  background-color: var(--ui-background);
+  background-color: var(--line-ui-background);
 }
 
 .is-hover-background {
-  background-color: var(--ui-hover-background);
+  background-color: var(--line-ui-hover-background);
 }
 
 .is-active-background {
-  background-color: var(--ui-active-background);
+  background-color: var(--line-ui-active-background);
 }
 
 .is-subtle-border {
-  border-color: var(--subtle-border);
-  outline-color: var(--subtle-border);
+  border-color: var(--line-subtle-border);
+  outline-color: var(--line-subtle-border);
 }
 
 .is-ui-border {
   transition: colors ease-in-out delay-150;
-  border-color: var(--ui-border);
-  outline-color: var(--ui-border);
+  border-color: var(--line-ui-border);
+  outline-color: var(--line-ui-border);
 }
 
 .is-ui-hover {
-  border-color: var(--ui-border-hover);
-  outline-color: var(--ui-border-hover);
+  border-color: var(--line-ui-border-hover);
+  outline-color: var(--line-ui-border-hover);
 }
 
 .is-solid-background {
   transition:colors ease-in-out delay-150;
-  background-color: var(--solid-background);
+  background-color: var(--line-solid-background);
 }
 
 .is-hover-solid {
-  background-color: var(--solid-hover);
+  background-color: var(--line-solid-hover);
 }
 
 .is-low-contrast {
-  color: var(--low-contrast);
+  color: var(--line-low-contrast);
 }
 
 .is-high-contrast {
-  color: var(--high-contrast);
+  color: var(--line-high-contrast);
 }
 
 .is-light {
-  color: var(--light);
+  color: var(--line-light);
 }
 
 .is-dark {
-  color: var(--dark);
+  color: var(--line-dark);
 }
 
 .is-white {
-  color: var(--white);
+  color: var(--line-white);
 }
 
 .is-black {
-  color: var(--black);
+  color: var(--line-black);
 }
 
 .carousel {

--- a/packages/theme/src/utils/rules.css
+++ b/packages/theme/src/utils/rules.css
@@ -1,38 +1,38 @@
 @media (prefers-color-scheme: light) {
   :root {
-    --background: hsl(0, 0%, 99.0%);            /* App background (-1) */
-    --subtle-background: hsl(0, 0%, 97.5%);     /* Subtle background (-2) */
-    --ui-background: hsl(0, 0%, 94.6%);         /* UI element background (-3) */
-    --ui-hover-background: hsl(0, 0%, 92.0%);   /* Hovered UI element background  (-4)*/
-    --ui-active-background: hsl(0, 0%, 89.5%);  /* Active / Selected UI element background (-5) */
-    --subtle-border: hsl(0, 0%, 86.8%);         /* Subtle borders and separators (-6) */
-    --ui-border: hsl(0, 0%, 83.0%);             /* UI element border and focus rings (-7) */
-    --ui-border-hover: hsl(0, 0%, 73.2%);       /* Hovered UI element border (-8) */
-    --solid-background: hsl(0, 0%, 55.2%);      /* Solid backgrounds (-9) */
-    --solid-hover: hsl(0, 0%, 50.3%);           /* Hovered solid backgrounds (-10) */
-    --low-contrast: hsl(0, 0%, 39.3%);          /* Low-contrast text (-11) */
-    --high-contrast: hsl(0, 0%, 12.5%);         /* High-contrast text (-12) */
-    --white: #f1f1f1;                           /* White text */
-    --black: #030303;                           /* Black text */
+    --line-background: hsl(0, 0%, 99.0%);            /* App background (-1) */
+    --line-subtle-background: hsl(0, 0%, 97.5%);     /* Subtle background (-2) */
+    --line-ui-background: hsl(0, 0%, 94.6%);         /* UI element background (-3) */
+    --line-ui-hover-background: hsl(0, 0%, 92.0%);   /* Hovered UI element background  (-4)*/
+    --line-ui-active-background: hsl(0, 0%, 89.5%);  /* Active / Selected UI element background (-5) */
+    --line-subtle-border: hsl(0, 0%, 86.8%);         /* Subtle borders and separators (-6) */
+    --line-ui-border: hsl(0, 0%, 83.0%);             /* UI element border and focus rings (-7) */
+    --line-ui-border-hover: hsl(0, 0%, 73.2%);       /* Hovered UI element border (-8) */
+    --line-solid-background: hsl(0, 0%, 55.2%);      /* Solid backgrounds (-9) */
+    --line-solid-hover: hsl(0, 0%, 50.3%);           /* Hovered solid backgrounds (-10) */
+    --line-low-contrast: hsl(0, 0%, 39.3%);          /* Low-contrast text (-11) */
+    --line-high-contrast: hsl(0, 0%, 12.5%);         /* High-contrast text (-12) */
+    --line-white: #f1f1f1;                           /* White text */
+    --line-black: #030303;                           /* Black text */
   }
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: hsl(0, 0%, 9.5%);             /* App background (-1) */
-    --subtle-background: hsl(0, 0%, 10.5%);     /* Subtle background (-2) */
-    --ui-background: hsl(0, 0%, 15.8%);         /* UI element background (-3) */
-    --ui-hover-background: hsl(0, 0%, 18.9%);   /* Hovered UI element background  (-4)*/
-    --ui-active-background: hsl(0, 0%, 21.7%);  /* Active / Selected UI element background (-5) */
-    --subtle-border: hsl(0, 0%, 24.7%);         /* Subtle borders and separators (-6) */
-    --ui-border: hsl(0, 0%, 29.1%);             /* UI element border and focus rings (-7) */
-    --ui-border-hover: hsl(0, 0%, 37.5%);       /* Hovered UI element border (-8) */
-    --solid-background: hsl(0, 0%, 43.0%);      /* Solid backgrounds (-9) */
-    --solid-hover: hsl(0, 0%, 50.7%);           /* Hovered solid backgrounds (-10) */
-    --low-contrast: hsl(0, 0%, 69.5%);          /* Low-contrast text (-11) */
-    --high-contrast: hsl(0, 0%, 93.5%);         /* High-contrast text (-12) */
-    --white: #f1f1f1;                           /* White text */
-    --black: #030303;                           /* Black text */
+    --line-background: hsl(0, 0%, 9.5%);             /* App background (-1) */
+    --line-subtle-background: hsl(0, 0%, 10.5%);     /* Subtle background (-2) */
+    --line-ui-background: hsl(0, 0%, 15.8%);         /* UI element background (-3) */
+    --line-ui-hover-background: hsl(0, 0%, 18.9%);   /* Hovered UI element background  (-4)*/
+    --line-ui-active-background: hsl(0, 0%, 21.7%);  /* Active / Selected UI element background (-5) */
+    --line-subtle-border: hsl(0, 0%, 24.7%);         /* Subtle borders and separators (-6) */
+    --line-ui-border: hsl(0, 0%, 29.1%);             /* UI element border and focus rings (-7) */
+    --line-ui-border-hover: hsl(0, 0%, 37.5%);       /* Hovered UI element border (-8) */
+    --line-solid-background: hsl(0, 0%, 43.0%);      /* Solid backgrounds (-9) */
+    --line-solid-hover: hsl(0, 0%, 50.7%);           /* Hovered solid backgrounds (-10) */
+    --line-low-contrast: hsl(0, 0%, 69.5%);          /* Low-contrast text (-11) */
+    --line-high-contrast: hsl(0, 0%, 93.5%);         /* High-contrast text (-12) */
+    --line-white: #f1f1f1;                           /* White text */
+    --line-black: #030303;                           /* Black text */
   }
 }
 


### PR DESCRIPTION
Rename 16 unprefixed semantic variables (--background, --subtle-background, --ui-background, --ui-hover-background, --ui-active-background, --subtle-border, --ui-border, --ui-border-hover, --solid-background, --solid-hover, --low-contrast, --high-contrast, --light, --dark, --white, --black) to use the --line-* prefix per PRD 9.14 branding convention across all 28 schema files, rules.css, general.css, and style.css (~825 occurrences).