### PR TITLE
refactor: prefix all CSS classes with line- namespace

### DIFF
--- a/packages/theme/index.html
+++ b/packages/theme/index.html
@@ -6,120 +6,120 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + TS</title>
   </head>
-  <body class="schema-gray">
+  <body class="line-schema-gray">
     <nav class="ui-nav">
       <h1 class="ui-nav-title">sublime://vitamin</h1>
       <div class="ui-nav-colors">
-        <button data-theme="schema-gray" class="ui-nav-button ui-nav-button-active is-gray-border">
-          <span class="ui-nav-color is-gray">G</span>
+        <button data-theme="line-schema-gray" class="ui-nav-button ui-nav-button-active line-is-gray-border">
+          <span class="ui-nav-color line-is-gray">G</span>
         </button>
 
-        <button data-theme="schema-mauve" class="ui-nav-button is-mauve-border">
-          <span class="ui-nav-color is-mauve">M</span>
+        <button data-theme="line-schema-mauve" class="ui-nav-button line-is-mauve-border">
+          <span class="ui-nav-color line-is-mauve">M</span>
         </button>
 
-        <button data-theme="schema-slate" class="ui-nav-button is-slate-border">
-          <span class="ui-nav-color is-slate">S</span>
+        <button data-theme="line-schema-slate" class="ui-nav-button line-is-slate-border">
+          <span class="ui-nav-color line-is-slate">S</span>
         </button>
 
-        <button data-theme="schema-sage" class="ui-nav-button is-sage-border">
-          <span class="ui-nav-color is-sage">S</span>
+        <button data-theme="line-schema-sage" class="ui-nav-button line-is-sage-border">
+          <span class="ui-nav-color line-is-sage">S</span>
         </button>
 
-        <button data-theme="schema-olive" class="ui-nav-button is-olive-border">
-          <span class="ui-nav-color is-olive">O</span>
+        <button data-theme="line-schema-olive" class="ui-nav-button line-is-olive-border">
+          <span class="ui-nav-color line-is-olive">O</span>
         </button>
 
-        <button data-theme="schema-sand" class="ui-nav-button is-sand-border">
-          <span class="ui-nav-color is-sand">S</span>
+        <button data-theme="line-schema-sand" class="ui-nav-button line-is-sand-border">
+          <span class="ui-nav-color line-is-sand">S</span>
         </button>
 
-        <button data-theme="schema-tomato" class="ui-nav-button is-tomato-border">
-          <span class="ui-nav-color is-tomato">T</span>
+        <button data-theme="line-schema-tomato" class="ui-nav-button line-is-tomato-border">
+          <span class="ui-nav-color line-is-tomato">T</span>
         </button>
 
-        <button data-theme="schema-red" class="ui-nav-button is-red-border">
-          <span class="ui-nav-color is-red">R</span>
+        <button data-theme="line-schema-red" class="ui-nav-button line-is-red-border">
+          <span class="ui-nav-color line-is-red">R</span>
         </button>
 
-        <button data-theme="schema-crimson" class="ui-nav-button is-crimson-border">
-          <span class="ui-nav-color is-crimson">C</span>
+        <button data-theme="line-schema-crimson" class="ui-nav-button line-is-crimson-border">
+          <span class="ui-nav-color line-is-crimson">C</span>
         </button>
 
-        <button data-theme="schema-pink" class="ui-nav-button is-pink-border">
-          <span class="ui-nav-color is-pink">P</span>
+        <button data-theme="line-schema-pink" class="ui-nav-button line-is-pink-border">
+          <span class="ui-nav-color line-is-pink">P</span>
         </button>
 
-        <button data-theme="schema-plum" class="ui-nav-button is-plum-border">
-          <span class="ui-nav-color is-plum">P</span>
+        <button data-theme="line-schema-plum" class="ui-nav-button line-is-plum-border">
+          <span class="ui-nav-color line-is-plum">P</span>
         </button>
 
-        <button data-theme="schema-purple" class="ui-nav-button is-purple-border">
-          <span class="ui-nav-color is-purple">P</span>
+        <button data-theme="line-schema-purple" class="ui-nav-button line-is-purple-border">
+          <span class="ui-nav-color line-is-purple">P</span>
         </button>
 
-        <button data-theme="schema-violet" class="ui-nav-button is-violet-border">
-          <span class="ui-nav-color is-violet">V</span>
+        <button data-theme="line-schema-violet" class="ui-nav-button line-is-violet-border">
+          <span class="ui-nav-color line-is-violet">V</span>
         </button>
 
-        <button data-theme="schema-indigo" class="ui-nav-button is-indigo-border">
-          <span class="ui-nav-color is-indigo">I</span>
+        <button data-theme="line-schema-indigo" class="ui-nav-button line-is-indigo-border">
+          <span class="ui-nav-color line-is-indigo">I</span>
         </button>
 
-        <button data-theme="schema-blue" class="ui-nav-button is-blue-border">
-          <span class="ui-nav-color is-blue">B</span>
+        <button data-theme="line-schema-blue" class="ui-nav-button line-is-blue-border">
+          <span class="ui-nav-color line-is-blue">B</span>
         </button>
 
-        <button data-theme="schema-cyan" class="ui-nav-button is-cyan-border">
-          <span class="ui-nav-color is-cyan">C</span>
+        <button data-theme="line-schema-cyan" class="ui-nav-button line-is-cyan-border">
+          <span class="ui-nav-color line-is-cyan">C</span>
         </button>
 
-        <button data-theme="schema-teal" class="ui-nav-button is-teal-border">
-          <span class="ui-nav-color is-teal">T</span>
+        <button data-theme="line-schema-teal" class="ui-nav-button line-is-teal-border">
+          <span class="ui-nav-color line-is-teal">T</span>
         </button>
 
-        <button data-theme="schema-green" class="ui-nav-button is-green-border">
-          <span class="ui-nav-color is-green">G</span>
+        <button data-theme="line-schema-green" class="ui-nav-button line-is-green-border">
+          <span class="ui-nav-color line-is-green">G</span>
         </button>
 
-        <button data-theme="schema-grass" class="ui-nav-button is-grass-border">
-          <span class="ui-nav-color is-grass">G</span>
+        <button data-theme="line-schema-grass" class="ui-nav-button line-is-grass-border">
+          <span class="ui-nav-color line-is-grass">G</span>
         </button>
 
-        <button data-theme="schema-brown" class="ui-nav-button is-brown-border">
-          <span class="ui-nav-color is-brown">B</span>
+        <button data-theme="line-schema-brown" class="ui-nav-button line-is-brown-border">
+          <span class="ui-nav-color line-is-brown">B</span>
         </button>
 
-        <button data-theme="schema-bronze" class="ui-nav-button is-bronze-border">
-          <span class="ui-nav-color is-bronze">B</span>
+        <button data-theme="line-schema-bronze" class="ui-nav-button line-is-bronze-border">
+          <span class="ui-nav-color line-is-bronze">B</span>
         </button>
 
-        <button data-theme="schema-gold" class="ui-nav-button is-gold-border">
-          <span class="ui-nav-color is-gold">G</span>
+        <button data-theme="line-schema-gold" class="ui-nav-button line-is-gold-border">
+          <span class="ui-nav-color line-is-gold">G</span>
         </button>
 
-        <button data-theme="schema-sky" class="ui-nav-button is-sky-border">
-          <span class="ui-nav-color is-sky">S</span>
+        <button data-theme="line-schema-sky" class="ui-nav-button line-is-sky-border">
+          <span class="ui-nav-color line-is-sky">S</span>
         </button>
 
-        <button data-theme="schema-mint" class="ui-nav-button is-mint-border">
-          <span class="ui-nav-color is-mint">M</span>
+        <button data-theme="line-schema-mint" class="ui-nav-button line-is-mint-border">
+          <span class="ui-nav-color line-is-mint">M</span>
         </button>
 
-        <button data-theme="schema-lime" class="ui-nav-button is-lime-border">
-          <span class="ui-nav-color is-lime">L</span>
+        <button data-theme="line-schema-lime" class="ui-nav-button line-is-lime-border">
+          <span class="ui-nav-color line-is-lime">L</span>
         </button>
 
-        <button data-theme="schema-yellow" class="ui-nav-button is-yellow-border">
-          <span class="ui-nav-color is-yellow">Y</span>
+        <button data-theme="line-schema-yellow" class="ui-nav-button line-is-yellow-border">
+          <span class="ui-nav-color line-is-yellow">Y</span>
         </button>
 
-        <button data-theme="schema-amber" class="ui-nav-button is-amber-border">
-          <span class="ui-nav-color is-amber">A</span>
+        <button data-theme="line-schema-amber" class="ui-nav-button line-is-amber-border">
+          <span class="ui-nav-color line-is-amber">A</span>
         </button>
 
-        <button data-theme="schema-orange" class="ui-nav-button is-orange-border">
-          <span class="ui-nav-color is-orange">O</span>
+        <button data-theme="line-schema-orange" class="ui-nav-button line-is-orange-border">
+          <span class="ui-nav-color line-is-orange">O</span>
         </button>
       </div>
       <div class="ui-nav-theme">
@@ -594,53 +594,53 @@
       <h1>Css Tokens</h1>
 
       <div class="ui-scale-container ui-tokens">
-        <div class="is-amber is-amber-border">.is-amber</div>
-        <div class="is-blue is-blue-border">.is-blue</div>
-        <div class="is-bronze is-bronze-border">.is-bronze</div>
-        <div class="is-brown is-brown-border">.is-brown</div>
-        <div class="is-crimson is-crimson-border">.is-crimson</div>
-        <div class="is-cyan is-cyan-border">.is-cyan</div>
-        <div class="is-gold is-gold-border">.is-gold</div>
-        <div class="is-grass is-grass-border">.is-grass</div>
-        <div class="is-gray is-gray-border">.is-gray</div>
-        <div class="is-green is-green-border">.is-green</div>
-        <div class="is-indigo is-indigo-border">.is-indigo</div>
-        <div class="is-lime is-lime-border">.is-lime</div>
-        <div class="is-mauve is-mauve-border">.is-mauve</div>
-        <div class="is-mint is-mint-border">.is-mint</div>
-        <div class="is-olive is-olive-border">.is-olive</div>
-        <div class="is-orange is-orange-border">.is-orange</div>
-        <div class="is-pink is-pink-border">.is-pink</div>
-        <div class="is-plum is-plum-border">.is-plum</div>
-        <div class="is-purple is-purple-border">.is-purple</div>
-        <div class="is-red is-red-border">.is-red</div>
-        <div class="is-sage is-sage-border">.is-sage</div>
-        <div class="is-sand is-sand-border">.is-sand</div>
-        <div class="is-sky is-sky-border">.is-sky</div>
-        <div class="is-slate is-slate-border">.is-slate</div>
-        <div class="is-teal is-teal-border">.is-teal</div>
-        <div class="is-tomato is-tomato-border">.is-tomato</div>
-        <div class="is-violet is-violet-border">.is-violet</div>
-        <div class="is-yellow is-yellow-border">.is-yellow</div>
+        <div class="line-is-amber line-is-amber-border">.line-is-amber</div>
+        <div class="line-is-blue line-is-blue-border">.line-is-blue</div>
+        <div class="line-is-bronze line-is-bronze-border">.line-is-bronze</div>
+        <div class="line-is-brown line-is-brown-border">.line-is-brown</div>
+        <div class="line-is-crimson line-is-crimson-border">.line-is-crimson</div>
+        <div class="line-is-cyan line-is-cyan-border">.line-is-cyan</div>
+        <div class="line-is-gold line-is-gold-border">.line-is-gold</div>
+        <div class="line-is-grass line-is-grass-border">.line-is-grass</div>
+        <div class="line-is-gray line-is-gray-border">.line-is-gray</div>
+        <div class="line-is-green line-is-green-border">.line-is-green</div>
+        <div class="line-is-indigo line-is-indigo-border">.line-is-indigo</div>
+        <div class="line-is-lime line-is-lime-border">.line-is-lime</div>
+        <div class="line-is-mauve line-is-mauve-border">.line-is-mauve</div>
+        <div class="line-is-mint line-is-mint-border">.line-is-mint</div>
+        <div class="line-is-olive line-is-olive-border">.line-is-olive</div>
+        <div class="line-is-orange line-is-orange-border">.line-is-orange</div>
+        <div class="line-is-pink line-is-pink-border">.line-is-pink</div>
+        <div class="line-is-plum line-is-plum-border">.line-is-plum</div>
+        <div class="line-is-purple line-is-purple-border">.line-is-purple</div>
+        <div class="line-is-red line-is-red-border">.line-is-red</div>
+        <div class="line-is-sage line-is-sage-border">.line-is-sage</div>
+        <div class="line-is-sand line-is-sand-border">.line-is-sand</div>
+        <div class="line-is-sky line-is-sky-border">.line-is-sky</div>
+        <div class="line-is-slate line-is-slate-border">.line-is-slate</div>
+        <div class="line-is-teal line-is-teal-border">.line-is-teal</div>
+        <div class="line-is-tomato line-is-tomato-border">.line-is-tomato</div>
+        <div class="line-is-violet line-is-violet-border">.line-is-violet</div>
+        <div class="line-is-yellow line-is-yellow-border">.line-is-yellow</div>
       </div>
 
       <div class="ui-scale-container ui-tokens">
-        <div class="is-background">.is-background</div>
-        <div class="is-subtle-background">.is-subtle-background</div>
-        <div class="is-ui-background">.is-ui-background</div>
-        <div class="is-hover-background">.is-hover-background</div>
-        <div class="is-active-background">.is-active-background</div>
-        <div class="is-subtle-border">.is-subtle-border</div>
-        <div class="is-ui-border">.is-ui-border</div>
-        <div class="is-ui-hover">.is-ui-hover</div>
-        <div class="is-solid-background">.is-solid-background</div>
-        <div class="is-hover-solid">.is-hover-solid</div>
-        <div class="is-low-contrast">.is-low-contrast</div>
-        <div class="is-high-contrast">.is-high-contrast</div>
-        <div class="is-light">.is-light</div>
-        <div class="is-dark">.is-dark</div>
-        <div class="is-white">.is-white</div>
-        <div class="is-black">.is-black</div>
+        <div class="line-is-background">.line-is-background</div>
+        <div class="line-is-subtle-background">.line-is-subtle-background</div>
+        <div class="line-is-ui-background">.line-is-ui-background</div>
+        <div class="line-is-hover-background">.line-is-hover-background</div>
+        <div class="line-is-active-background">.line-is-active-background</div>
+        <div class="line-is-subtle-border">.line-is-subtle-border</div>
+        <div class="line-is-ui-border">.line-is-ui-border</div>
+        <div class="line-is-ui-hover">.line-is-ui-hover</div>
+        <div class="line-is-solid-background">.line-is-solid-background</div>
+        <div class="line-is-hover-solid">.line-is-hover-solid</div>
+        <div class="line-is-low-contrast">.line-is-low-contrast</div>
+        <div class="line-is-high-contrast">.line-is-high-contrast</div>
+        <div class="line-is-light">.line-is-light</div>
+        <div class="line-is-dark">.line-is-dark</div>
+        <div class="line-is-white">.line-is-white</div>
+        <div class="line-is-black">.line-is-black</div>
       </div>
     </section>
 

--- a/packages/theme/src/schemas/amber.css
+++ b/packages/theme/src/schemas/amber.css
@@ -1,4 +1,4 @@
-:where(.schema-amber) {
+:where(.line-schema-amber) {
   --background: var(--amber-1);            /* App background (-1) */
   --subtle-background: var(--amber-2);     /* Subtle background (-2) */
   --ui-background: var(--amber-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--amber-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-amber)   {
+:is(.dark) :where(.line-schema-amber)   {
   --background: var(--amber-12);           /* App background (-1) */
   --subtle-background: var(--amber-11);    /* Subtle background (-2) */
   --ui-background: var(--amber-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --dark: var(--amber-1);                  /* Dark text */
 }
 
-:where(.is-amber) {
+:where(.line-is-amber) {
   color: var(--amber-12);
   background-color: var(--amber-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-amber) {
+:is(.dark) :where(.line-is-amber) {
   color: var(--amber-12);
   background-color: var(--amber-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-amber-color) {
+:where(.line-is-amber-color) {
   color: var(--amber-12);
 }
 
-:is(:dark) :where(.is-amber-color) {
+:is(:dark) :where(.line-is-amber-color) {
   color: var(--amber-1);
 }
 
-:where(.is-amber-low-contrast) {
+:where(.line-is-amber-low-contrast) {
   color: var(--amber-11);
 }
 
-:is(.dark) :where(.is-amber-low-contrast) {
+:is(.dark) :where(.line-is-amber-low-contrast) {
   color: var(--amber-2);
 }
 
-:where(.is-amber-high-contrast) {
+:where(.line-is-amber-high-contrast) {
   color: var(--amber-12);
 }
 
-:is(.dark) :where(.is-amber-high-contrast) {
+:is(.dark) :where(.line-is-amber-high-contrast) {
   color: var(--amber-1);
 }
 
-:where(.is-amber-background) {
+:where(.line-is-amber-background) {
   background-color: var(--amber-1);
 }
 
-:is(.dark) :where(.is-amber-background) {
+:is(.dark) :where(.line-is-amber-background) {
   background-color: var(--amber-12);
 }
 
-:where(.is-amber-subtle-background) {
+:where(.line-is-amber-subtle-background) {
   background-color: var(--amber-2);
 }
 
-:is(.dark) :where(.is-amber-subtle-background) {
+:is(.dark) :where(.line-is-amber-subtle-background) {
   background-color: var(--amber-11);
 }
 
-:where(.is-amber-ui-background) {
+:where(.line-is-amber-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--amber-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-amber-ui-background) {
+:is(.dark) :where(.line-is-amber-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--amber-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-amber-ui-hover-background) {
+:where(.line-is-amber-ui-hover-background) {
   background-color: var(--amber-4);
 }
 
-:is(.dark) :where(.is-amber-ui-hover-background) {
+:is(.dark) :where(.line-is-amber-ui-hover-background) {
   background-color: var(--amber-9);
 }
 
-:where(.is-amber-ui-active-background) {
+:where(.line-is-amber-ui-active-background) {
   background-color: var(--amber-5);
 }
 
-:is(.dark) :where(.is-amber-ui-active-background) {
+:is(.dark) :where(.line-is-amber-ui-active-background) {
   background-color: var(--amber-8);
 }
 
-:where(.is-amber-subtle-element-background) {
+:where(.line-is-amber-subtle-element-background) {
   background-color: var(--amber-6);
 }
 
-:is(.dark) :where(.is-amber-subtle-element-background) {
+:is(.dark) :where(.line-is-amber-subtle-element-background) {
   background-color: var(--amber-7);
 }
 
-:where(.is-amber-ui-element-background) {
+:where(.line-is-amber-ui-element-background) {
   background-color: var(--amber-7);
 }
 
-:is(.dark) :where(.is-amber-ui-element-background) {
+:is(.dark) :where(.line-is-amber-ui-element-background) {
   background-color: var(--amber-6);
 }
 
-:where(.is-amber-ui-hover-background) {
+:where(.line-is-amber-ui-hover-background) {
   background-color: var(--amber-8);
 }
 
-:is(.dark) :where(.is-amber-ui-hover-background) {
+:is(.dark) :where(.line-is-amber-ui-hover-background) {
   background-color: var(--amber-5);
 }
 
-:where(.is-amber-solid-background) {
+:where(.line-is-amber-solid-background) {
   background-color: var(--amber-9);
 }
 
-:is(.dark) :where(.is-amber-solid-background) {
+:is(.dark) :where(.line-is-amber-solid-background) {
   background-color: var(--amber-4);
 }
 
-:where(.is-amber-hover-solid-background) {
+:where(.line-is-amber-hover-solid-background) {
   background-color: var(--amber-10);
 }
 
-:is(.dark) :where(.is-amber-hover-solid-background) {
+:is(.dark) :where(.line-is-amber-hover-solid-background) {
   background-color: var(--amber-3);
 }
 
-:where(.is-amber-low-contrast-background) {
+:where(.line-is-amber-low-contrast-background) {
   background-color: var(--amber-11);
 }
 
-:is(.dark) :where(.is-amber-low-contrast-background) {
+:is(.dark) :where(.line-is-amber-low-contrast-background) {
   background-color: var(--amber-2);
 }
 
-:where(.is-amber-high-contrast-background) {
+:where(.line-is-amber-high-contrast-background) {
   background-color: var(--amber-12);
 }
 
-:is(.dark) :where(.is-amber-high-contrast-background) {
+:is(.dark) :where(.line-is-amber-high-contrast-background) {
   background-color: var(--amber-1);
 }
 
-:where(.is-amber-border) {
+:where(.line-is-amber-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--amber-7);
   border-color: var(--amber-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-amber-border) {
+:is(.dark) :where(.line-is-amber-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--amber-6);
   border-color: var(--amber-6);

--- a/packages/theme/src/schemas/blue.css
+++ b/packages/theme/src/schemas/blue.css
@@ -1,4 +1,4 @@
-:where(.schema-blue) {
+:where(.line-schema-blue) {
   --background: var(--blue-1);            /* App background (-1) */
   --subtle-background: var(--blue-2);     /* Subtle background (-2) */
   --ui-background: var(--blue-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--blue-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-blue)  {
+:is(.dark) :where(.line-schema-blue)  {
   --background: var(--blue-12);           /* App background (-1) */
   --subtle-background: var(--blue-11);    /* Subtle background (-2) */
   --ui-background: var(--blue-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--blue-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-blue) {
+:where(.line-is-blue) {
   color: var(--blue-1);
   background-color: var(--blue-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-blue) {
+:is(.dark) :where(.line-is-blue) {
   color: var(--blue-1);
   background-color: var(--blue-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-blue-color) {
+:where(.line-is-blue-color) {
   color: var(--blue-12);
 }
 
-:is(:dark) :where(.is-blue-color) {
+:is(:dark) :where(.line-is-blue-color) {
   color: var(--blue-1);
 }
 
-:where(.is-blue-low-contrast) {
+:where(.line-is-blue-low-contrast) {
   color: var(--blue-11);
 }
 
-:is(.dark) :where(.is-blue-low-contrast) {
+:is(.dark) :where(.line-is-blue-low-contrast) {
   color: var(--blue-2);
 }
 
-:where(.is-blue-high-contrast) {
+:where(.line-is-blue-high-contrast) {
   color: var(--blue-12);
 }
 
-:is(.dark) :where(.is-blue-high-contrast) {
+:is(.dark) :where(.line-is-blue-high-contrast) {
   color: var(--blue-1);
 }
 
-:where(.is-blue-background) {
+:where(.line-is-blue-background) {
   background-color: var(--blue-1);
 }
 
-:is(.dark) :where(.is-blue-background) {
+:is(.dark) :where(.line-is-blue-background) {
   background-color: var(--blue-12);
 }
 
-:where(.is-blue-subtle-background) {
+:where(.line-is-blue-subtle-background) {
   background-color: var(--blue-2);
 }
 
-:is(.dark) :where(.is-blue-subtle-background) {
+:is(.dark) :where(.line-is-blue-subtle-background) {
   background-color: var(--blue-11);
 }
 
-:where(.is-blue-ui-background) {
+:where(.line-is-blue-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--blue-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-blue-ui-background) {
+:is(.dark) :where(.line-is-blue-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--blue-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-blue-ui-hover-background) {
+:where(.line-is-blue-ui-hover-background) {
   background-color: var(--blue-4);
 }
 
-:is(.dark) :where(.is-blue-ui-hover-background) {
+:is(.dark) :where(.line-is-blue-ui-hover-background) {
   background-color: var(--blue-9);
 }
 
-:where(.is-blue-ui-active-background) {
+:where(.line-is-blue-ui-active-background) {
   background-color: var(--blue-5);
 }
 
-:is(.dark) :where(.is-blue-ui-active-background) {
+:is(.dark) :where(.line-is-blue-ui-active-background) {
   background-color: var(--blue-8);
 }
 
-:where(.is-blue-subtle-element-background) {
+:where(.line-is-blue-subtle-element-background) {
   background-color: var(--blue-6);
 }
 
-:is(.dark) :where(.is-blue-subtle-element-background) {
+:is(.dark) :where(.line-is-blue-subtle-element-background) {
   background-color: var(--blue-7);
 }
 
-:where(.is-blue-ui-element-background) {
+:where(.line-is-blue-ui-element-background) {
   background-color: var(--blue-7);
 }
 
-:is(.dark) :where(.is-blue-ui-element-background) {
+:is(.dark) :where(.line-is-blue-ui-element-background) {
   background-color: var(--blue-6);
 }
 
-:where(.is-blue-ui-hover-background) {
+:where(.line-is-blue-ui-hover-background) {
   background-color: var(--blue-8);
 }
 
-:is(.dark) :where(.is-blue-ui-hover-background) {
+:is(.dark) :where(.line-is-blue-ui-hover-background) {
   background-color: var(--blue-5);
 }
 
-:where(.is-blue-solid-background) {
+:where(.line-is-blue-solid-background) {
   background-color: var(--blue-9);
 }
 
-:is(.dark) :where(.is-blue-solid-background) {
+:is(.dark) :where(.line-is-blue-solid-background) {
   background-color: var(--blue-4);
 }
 
-:where(.is-blue-hover-solid-background) {
+:where(.line-is-blue-hover-solid-background) {
   background-color: var(--blue-10);
 }
 
-:is(.dark) :where(.is-blue-hover-solid-background) {
+:is(.dark) :where(.line-is-blue-hover-solid-background) {
   background-color: var(--blue-3);
 }
 
-:where(.is-blue-low-contrast-background) {
+:where(.line-is-blue-low-contrast-background) {
   background-color: var(--blue-11);
 }
 
-:is(.dark) :where(.is-blue-low-contrast-background) {
+:is(.dark) :where(.line-is-blue-low-contrast-background) {
   background-color: var(--blue-2);
 }
 
-:where(.is-blue-high-contrast-background) {
+:where(.line-is-blue-high-contrast-background) {
   background-color: var(--blue-12);
 }
 
-:is(.dark) :where(.is-blue-high-contrast-background) {
+:is(.dark) :where(.line-is-blue-high-contrast-background) {
   background-color: var(--blue-1);
 }
 
-:where(.is-blue-border) {
+:where(.line-is-blue-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--blue-7);
   border-color: var(--blue-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-blue-border) {
+:is(.dark) :where(.line-is-blue-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--blue-6);
   border-color: var(--blue-6);

--- a/packages/theme/src/schemas/bronze.css
+++ b/packages/theme/src/schemas/bronze.css
@@ -1,4 +1,4 @@
-:where(.schema-bronze) {
+:where(.line-schema-bronze) {
   --background: var(--bronze-1);            /* App background (-1) */
   --subtle-background: var(--bronze-2);     /* Subtle background (-2) */
   --ui-background: var(--bronze-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--bronze-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-bronze)  {
+:is(.dark) :where(.line-schema-bronze)  {
   --background: var(--bronze-12);           /* App background (-1) */
   --subtle-background: var(--bronze-11);    /* Subtle background (-2) */
   --ui-background: var(--bronze-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--bronze-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-bronze) {
+:where(.line-is-bronze) {
   color: var(--bronze-1);
   background-color: var(--bronze-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-bronze) {
+:is(.dark) :where(.line-is-bronze) {
   color: var(--bronze-1);
   background-color: var(--bronze-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-bronze-color) {
+:where(.line-is-bronze-color) {
   color: var(--bronze-12);
 }
 
-:is(:dark) :where(.is-bronze-color) {
+:is(:dark) :where(.line-is-bronze-color) {
   color: var(--bronze-1);
 }
 
-:where(.is-bronze-low-contrast) {
+:where(.line-is-bronze-low-contrast) {
   color: var(--bronze-11);
 }
 
-:is(.dark) :where(.is-bronze-low-contrast) {
+:is(.dark) :where(.line-is-bronze-low-contrast) {
   color: var(--bronze-2);
 }
 
-:where(.is-bronze-high-contrast) {
+:where(.line-is-bronze-high-contrast) {
   color: var(--bronze-12);
 }
 
-:is(.dark) :where(.is-bronze-high-contrast) {
+:is(.dark) :where(.line-is-bronze-high-contrast) {
   color: var(--bronze-1);
 }
 
-:where(.is-bronze-background) {
+:where(.line-is-bronze-background) {
   background-color: var(--bronze-1);
 }
 
-:is(.dark) :where(.is-bronze-background) {
+:is(.dark) :where(.line-is-bronze-background) {
   background-color: var(--bronze-12);
 }
 
-:where(.is-bronze-subtle-background) {
+:where(.line-is-bronze-subtle-background) {
   background-color: var(--bronze-2);
 }
 
-:is(.dark) :where(.is-bronze-subtle-background) {
+:is(.dark) :where(.line-is-bronze-subtle-background) {
   background-color: var(--bronze-11);
 }
 
-:where(.is-bronze-ui-background) {
+:where(.line-is-bronze-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--bronze-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-bronze-ui-background) {
+:is(.dark) :where(.line-is-bronze-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--bronze-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-bronze-ui-hover-background) {
+:where(.line-is-bronze-ui-hover-background) {
   background-color: var(--bronze-4);
 }
 
-:is(.dark) :where(.is-bronze-ui-hover-background) {
+:is(.dark) :where(.line-is-bronze-ui-hover-background) {
   background-color: var(--bronze-9);
 }
 
-:where(.is-bronze-ui-active-background) {
+:where(.line-is-bronze-ui-active-background) {
   background-color: var(--bronze-5);
 }
 
-:is(.dark) :where(.is-bronze-ui-active-background) {
+:is(.dark) :where(.line-is-bronze-ui-active-background) {
   background-color: var(--bronze-8);
 }
 
-:where(.is-bronze-subtle-element-background) {
+:where(.line-is-bronze-subtle-element-background) {
   background-color: var(--bronze-6);
 }
 
-:is(.dark) :where(.is-bronze-subtle-element-background) {
+:is(.dark) :where(.line-is-bronze-subtle-element-background) {
   background-color: var(--bronze-7);
 }
 
-:where(.is-bronze-ui-element-background) {
+:where(.line-is-bronze-ui-element-background) {
   background-color: var(--bronze-7);
 }
 
-:is(.dark) :where(.is-bronze-ui-element-background) {
+:is(.dark) :where(.line-is-bronze-ui-element-background) {
   background-color: var(--bronze-6);
 }
 
-:where(.is-bronze-ui-hover-background) {
+:where(.line-is-bronze-ui-hover-background) {
   background-color: var(--bronze-8);
 }
 
-:is(.dark) :where(.is-bronze-ui-hover-background) {
+:is(.dark) :where(.line-is-bronze-ui-hover-background) {
   background-color: var(--bronze-5);
 }
 
-:where(.is-bronze-solid-background) {
+:where(.line-is-bronze-solid-background) {
   background-color: var(--bronze-9);
 }
 
-:is(.dark) :where(.is-bronze-solid-background) {
+:is(.dark) :where(.line-is-bronze-solid-background) {
   background-color: var(--bronze-4);
 }
 
-:where(.is-bronze-hover-solid-background) {
+:where(.line-is-bronze-hover-solid-background) {
   background-color: var(--bronze-10);
 }
 
-:is(.dark) :where(.is-bronze-hover-solid-background) {
+:is(.dark) :where(.line-is-bronze-hover-solid-background) {
   background-color: var(--bronze-3);
 }
 
-:where(.is-bronze-low-contrast-background) {
+:where(.line-is-bronze-low-contrast-background) {
   background-color: var(--bronze-11);
 }
 
-:is(.dark) :where(.is-bronze-low-contrast-background) {
+:is(.dark) :where(.line-is-bronze-low-contrast-background) {
   background-color: var(--bronze-2);
 }
 
-:where(.is-bronze-high-contrast-background) {
+:where(.line-is-bronze-high-contrast-background) {
   background-color: var(--bronze-12);
 }
 
-:is(.dark) :where(.is-bronze-high-contrast-background) {
+:is(.dark) :where(.line-is-bronze-high-contrast-background) {
   background-color: var(--bronze-1);
 }
 
-:where(.is-bronze-border) {
+:where(.line-is-bronze-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--bronze-7);
   border-color: var(--bronze-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-bronze-border) {
+:is(.dark) :where(.line-is-bronze-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--bronze-6);
   border-color: var(--bronze-6);

--- a/packages/theme/src/schemas/brown.css
+++ b/packages/theme/src/schemas/brown.css
@@ -1,4 +1,4 @@
-:where(.schema-brown) {
+:where(.line-schema-brown) {
   --background: var(--brown-1);            /* App background (-1) */
   --subtle-background: var(--brown-2);     /* Subtle background (-2) */
   --ui-background: var(--brown-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--brown-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-brown)  {
+:is(.dark) :where(.line-schema-brown)  {
   --background: var(--brown-12);           /* App background (-1) */
   --subtle-background: var(--brown-11);    /* Subtle background (-2) */
   --ui-background: var(--brown-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--brown-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-brown) {
+:where(.line-is-brown) {
   color: var(--brown-1);
   background-color: var(--brown-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-brown) {
+:is(.dark) :where(.line-is-brown) {
   color: var(--brown-1);
   background-color: var(--brown-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-brown-color) {
+:where(.line-is-brown-color) {
   color: var(--brown-12);
 }
 
-:is(:dark) :where(.is-brown-color) {
+:is(:dark) :where(.line-is-brown-color) {
   color: var(--brown-1);
 }
 
-:where(.is-brown-low-contrast) {
+:where(.line-is-brown-low-contrast) {
   color: var(--brown-11);
 }
 
-:is(.dark) :where(.is-brown-low-contrast) {
+:is(.dark) :where(.line-is-brown-low-contrast) {
   color: var(--brown-2);
 }
 
-:where(.is-brown-high-contrast) {
+:where(.line-is-brown-high-contrast) {
   color: var(--brown-12);
 }
 
-:is(.dark) :where(.is-brown-high-contrast) {
+:is(.dark) :where(.line-is-brown-high-contrast) {
   color: var(--brown-1);
 }
 
-:where(.is-brown-background) {
+:where(.line-is-brown-background) {
   background-color: var(--brown-1);
 }
 
-:is(.dark) :where(.is-brown-background) {
+:is(.dark) :where(.line-is-brown-background) {
   background-color: var(--brown-12);
 }
 
-:where(.is-brown-subtle-background) {
+:where(.line-is-brown-subtle-background) {
   background-color: var(--brown-2);
 }
 
-:is(.dark) :where(.is-brown-subtle-background) {
+:is(.dark) :where(.line-is-brown-subtle-background) {
   background-color: var(--brown-11);
 }
 
-:where(.is-brown-ui-background) {
+:where(.line-is-brown-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--brown-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-brown-ui-background) {
+:is(.dark) :where(.line-is-brown-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--brown-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-brown-ui-hover-background) {
+:where(.line-is-brown-ui-hover-background) {
   background-color: var(--brown-4);
 }
 
-:is(.dark) :where(.is-brown-ui-hover-background) {
+:is(.dark) :where(.line-is-brown-ui-hover-background) {
   background-color: var(--brown-9);
 }
 
-:where(.is-brown-ui-active-background) {
+:where(.line-is-brown-ui-active-background) {
   background-color: var(--brown-5);
 }
 
-:is(.dark) :where(.is-brown-ui-active-background) {
+:is(.dark) :where(.line-is-brown-ui-active-background) {
   background-color: var(--brown-8);
 }
 
-:where(.is-brown-subtle-element-background) {
+:where(.line-is-brown-subtle-element-background) {
   background-color: var(--brown-6);
 }
 
-:is(.dark) :where(.is-brown-subtle-element-background) {
+:is(.dark) :where(.line-is-brown-subtle-element-background) {
   background-color: var(--brown-7);
 }
 
-:where(.is-brown-ui-element-background) {
+:where(.line-is-brown-ui-element-background) {
   background-color: var(--brown-7);
 }
 
-:is(.dark) :where(.is-brown-ui-element-background) {
+:is(.dark) :where(.line-is-brown-ui-element-background) {
   background-color: var(--brown-6);
 }
 
-:where(.is-brown-ui-hover-background) {
+:where(.line-is-brown-ui-hover-background) {
   background-color: var(--brown-8);
 }
 
-:is(.dark) :where(.is-brown-ui-hover-background) {
+:is(.dark) :where(.line-is-brown-ui-hover-background) {
   background-color: var(--brown-5);
 }
 
-:where(.is-brown-solid-background) {
+:where(.line-is-brown-solid-background) {
   background-color: var(--brown-9);
 }
 
-:is(.dark) :where(.is-brown-solid-background) {
+:is(.dark) :where(.line-is-brown-solid-background) {
   background-color: var(--brown-4);
 }
 
-:where(.is-brown-hover-solid-background) {
+:where(.line-is-brown-hover-solid-background) {
   background-color: var(--brown-10);
 }
 
-:is(.dark) :where(.is-brown-hover-solid-background) {
+:is(.dark) :where(.line-is-brown-hover-solid-background) {
   background-color: var(--brown-3);
 }
 
-:where(.is-brown-low-contrast-background) {
+:where(.line-is-brown-low-contrast-background) {
   background-color: var(--brown-11);
 }
 
-:is(.dark) :where(.is-brown-low-contrast-background) {
+:is(.dark) :where(.line-is-brown-low-contrast-background) {
   background-color: var(--brown-2);
 }
 
-:where(.is-brown-high-contrast-background) {
+:where(.line-is-brown-high-contrast-background) {
   background-color: var(--brown-12);
 }
 
-:is(.dark) :where(.is-brown-high-contrast-background) {
+:is(.dark) :where(.line-is-brown-high-contrast-background) {
   background-color: var(--brown-1);
 }
 
-:where(.is-brown-border) {
+:where(.line-is-brown-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--brown-7);
   border-color: var(--brown-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-brown-border) {
+:is(.dark) :where(.line-is-brown-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--brown-6);
   border-color: var(--brown-6);

--- a/packages/theme/src/schemas/crimson.css
+++ b/packages/theme/src/schemas/crimson.css
@@ -1,4 +1,4 @@
-:where(.schema-crimson) {
+:where(.line-schema-crimson) {
   --background: var(--crimson-1);            /* App background (-1) */
   --subtle-background: var(--crimson-2);     /* Subtle background (-2) */
   --ui-background: var(--crimson-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--crimson-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-crimson)  {
+:is(.dark) :where(.line-schema-crimson)  {
   --background: var(--crimson-12);           /* App background (-1) */
   --subtle-background: var(--crimson-11);    /* Subtle background (-2) */
   --ui-background: var(--crimson-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--crimson-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-crimson) {
+:where(.line-is-crimson) {
   color: var(--crimson-1);
   background-color: var(--crimson-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-crimson) {
+:is(.dark) :where(.line-is-crimson) {
   color: var(--crimson-1);
   background-color: var(--crimson-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-crimson-color) {
+:where(.line-is-crimson-color) {
   color: var(--crimson-12);
 }
 
-:is(:dark) :where(.is-crimson-color) {
+:is(:dark) :where(.line-is-crimson-color) {
   color: var(--crimson-1);
 }
 
-:where(.is-crimson-low-contrast) {
+:where(.line-is-crimson-low-contrast) {
   color: var(--crimson-11);
 }
 
-:is(.dark) :where(.is-crimson-low-contrast) {
+:is(.dark) :where(.line-is-crimson-low-contrast) {
   color: var(--crimson-2);
 }
 
-:where(.is-crimson-high-contrast) {
+:where(.line-is-crimson-high-contrast) {
   color: var(--crimson-12);
 }
 
-:is(.dark) :where(.is-crimson-high-contrast) {
+:is(.dark) :where(.line-is-crimson-high-contrast) {
   color: var(--crimson-1);
 }
 
-:where(.is-crimson-background) {
+:where(.line-is-crimson-background) {
   background-color: var(--crimson-1);
 }
 
-:is(.dark) :where(.is-crimson-background) {
+:is(.dark) :where(.line-is-crimson-background) {
   background-color: var(--crimson-12);
 }
 
-:where(.is-crimson-subtle-background) {
+:where(.line-is-crimson-subtle-background) {
   background-color: var(--crimson-2);
 }
 
-:is(.dark) :where(.is-crimson-subtle-background) {
+:is(.dark) :where(.line-is-crimson-subtle-background) {
   background-color: var(--crimson-11);
 }
 
-:where(.is-crimson-ui-background) {
+:where(.line-is-crimson-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--crimson-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-crimson-ui-background) {
+:is(.dark) :where(.line-is-crimson-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--crimson-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-crimson-ui-hover-background) {
+:where(.line-is-crimson-ui-hover-background) {
   background-color: var(--crimson-4);
 }
 
-:is(.dark) :where(.is-crimson-ui-hover-background) {
+:is(.dark) :where(.line-is-crimson-ui-hover-background) {
   background-color: var(--crimson-9);
 }
 
-:where(.is-crimson-ui-active-background) {
+:where(.line-is-crimson-ui-active-background) {
   background-color: var(--crimson-5);
 }
 
-:is(.dark) :where(.is-crimson-ui-active-background) {
+:is(.dark) :where(.line-is-crimson-ui-active-background) {
   background-color: var(--crimson-8);
 }
 
-:where(.is-crimson-subtle-element-background) {
+:where(.line-is-crimson-subtle-element-background) {
   background-color: var(--crimson-6);
 }
 
-:is(.dark) :where(.is-crimson-subtle-element-background) {
+:is(.dark) :where(.line-is-crimson-subtle-element-background) {
   background-color: var(--crimson-7);
 }
 
-:where(.is-crimson-ui-element-background) {
+:where(.line-is-crimson-ui-element-background) {
   background-color: var(--crimson-7);
 }
 
-:is(.dark) :where(.is-crimson-ui-element-background) {
+:is(.dark) :where(.line-is-crimson-ui-element-background) {
   background-color: var(--crimson-6);
 }
 
-:where(.is-crimson-ui-hover-background) {
+:where(.line-is-crimson-ui-hover-background) {
   background-color: var(--crimson-8);
 }
 
-:is(.dark) :where(.is-crimson-ui-hover-background) {
+:is(.dark) :where(.line-is-crimson-ui-hover-background) {
   background-color: var(--crimson-5);
 }
 
-:where(.is-crimson-solid-background) {
+:where(.line-is-crimson-solid-background) {
   background-color: var(--crimson-9);
 }
 
-:is(.dark) :where(.is-crimson-solid-background) {
+:is(.dark) :where(.line-is-crimson-solid-background) {
   background-color: var(--crimson-4);
 }
 
-:where(.is-crimson-hover-solid-background) {
+:where(.line-is-crimson-hover-solid-background) {
   background-color: var(--crimson-10);
 }
 
-:is(.dark) :where(.is-crimson-hover-solid-background) {
+:is(.dark) :where(.line-is-crimson-hover-solid-background) {
   background-color: var(--crimson-3);
 }
 
-:where(.is-crimson-low-contrast-background) {
+:where(.line-is-crimson-low-contrast-background) {
   background-color: var(--crimson-11);
 }
 
-:is(.dark) :where(.is-crimson-low-contrast-background) {
+:is(.dark) :where(.line-is-crimson-low-contrast-background) {
   background-color: var(--crimson-2);
 }
 
-:where(.is-crimson-high-contrast-background) {
+:where(.line-is-crimson-high-contrast-background) {
   background-color: var(--crimson-12);
 }
 
-:is(.dark) :where(.is-crimson-high-contrast-background) {
+:is(.dark) :where(.line-is-crimson-high-contrast-background) {
   background-color: var(--crimson-1);
 }
 
-:where(.is-crimson-border) {
+:where(.line-is-crimson-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--crimson-7);
   border-color: var(--crimson-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-crimson-border) {
+:is(.dark) :where(.line-is-crimson-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--crimson-6);
   border-color: var(--crimson-6);

--- a/packages/theme/src/schemas/cyan.css
+++ b/packages/theme/src/schemas/cyan.css
@@ -1,4 +1,4 @@
-:where(.schema-cyan) {
+:where(.line-schema-cyan) {
   --background: var(--cyan-1);            /* App background (-1) */
   --subtle-background: var(--cyan-2);     /* Subtle background (-2) */
   --ui-background: var(--cyan-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--cyan-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-cyan)  {
+:is(.dark) :where(.line-schema-cyan)  {
   --background: var(--cyan-12);           /* App background (-1) */
   --subtle-background: var(--cyan-11);    /* Subtle background (-2) */
   --ui-background: var(--cyan-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--cyan-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-cyan) {
+:where(.line-is-cyan) {
   color: var(--cyan-1);
   background-color: var(--cyan-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-cyan) {
+:is(.dark) :where(.line-is-cyan) {
   color: var(--cyan-1);
   background-color: var(--cyan-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-cyan-color) {
+:where(.line-is-cyan-color) {
   color: var(--cyan-12);
 }
 
-:is(:dark) :where(.is-cyan-color) {
+:is(:dark) :where(.line-is-cyan-color) {
   color: var(--cyan-1);
 }
 
-:where(.is-cyan-low-contrast) {
+:where(.line-is-cyan-low-contrast) {
   color: var(--cyan-11);
 }
 
-:is(.dark) :where(.is-cyan-low-contrast) {
+:is(.dark) :where(.line-is-cyan-low-contrast) {
   color: var(--cyan-2);
 }
 
-:where(.is-cyan-high-contrast) {
+:where(.line-is-cyan-high-contrast) {
   color: var(--cyan-12);
 }
 
-:is(.dark) :where(.is-cyan-high-contrast) {
+:is(.dark) :where(.line-is-cyan-high-contrast) {
   color: var(--cyan-1);
 }
 
-:where(.is-cyan-background) {
+:where(.line-is-cyan-background) {
   background-color: var(--cyan-1);
 }
 
-:is(.dark) :where(.is-cyan-background) {
+:is(.dark) :where(.line-is-cyan-background) {
   background-color: var(--cyan-12);
 }
 
-:where(.is-cyan-subtle-background) {
+:where(.line-is-cyan-subtle-background) {
   background-color: var(--cyan-2);
 }
 
-:is(.dark) :where(.is-cyan-subtle-background) {
+:is(.dark) :where(.line-is-cyan-subtle-background) {
   background-color: var(--cyan-11);
 }
 
-:where(.is-cyan-ui-background) {
+:where(.line-is-cyan-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--cyan-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-cyan-ui-background) {
+:is(.dark) :where(.line-is-cyan-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--cyan-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-cyan-ui-hover-background) {
+:where(.line-is-cyan-ui-hover-background) {
   background-color: var(--cyan-4);
 }
 
-:is(.dark) :where(.is-cyan-ui-hover-background) {
+:is(.dark) :where(.line-is-cyan-ui-hover-background) {
   background-color: var(--cyan-9);
 }
 
-:where(.is-cyan-ui-active-background) {
+:where(.line-is-cyan-ui-active-background) {
   background-color: var(--cyan-5);
 }
 
-:is(.dark) :where(.is-cyan-ui-active-background) {
+:is(.dark) :where(.line-is-cyan-ui-active-background) {
   background-color: var(--cyan-8);
 }
 
-:where(.is-cyan-subtle-element-background) {
+:where(.line-is-cyan-subtle-element-background) {
   background-color: var(--cyan-6);
 }
 
-:is(.dark) :where(.is-cyan-subtle-element-background) {
+:is(.dark) :where(.line-is-cyan-subtle-element-background) {
   background-color: var(--cyan-7);
 }
 
-:where(.is-cyan-ui-element-background) {
+:where(.line-is-cyan-ui-element-background) {
   background-color: var(--cyan-7);
 }
 
-:is(.dark) :where(.is-cyan-ui-element-background) {
+:is(.dark) :where(.line-is-cyan-ui-element-background) {
   background-color: var(--cyan-6);
 }
 
-:where(.is-cyan-ui-hover-background) {
+:where(.line-is-cyan-ui-hover-background) {
   background-color: var(--cyan-8);
 }
 
-:is(.dark) :where(.is-cyan-ui-hover-background) {
+:is(.dark) :where(.line-is-cyan-ui-hover-background) {
   background-color: var(--cyan-5);
 }
 
-:where(.is-cyan-solid-background) {
+:where(.line-is-cyan-solid-background) {
   background-color: var(--cyan-9);
 }
 
-:is(.dark) :where(.is-cyan-solid-background) {
+:is(.dark) :where(.line-is-cyan-solid-background) {
   background-color: var(--cyan-4);
 }
 
-:where(.is-cyan-hover-solid-background) {
+:where(.line-is-cyan-hover-solid-background) {
   background-color: var(--cyan-10);
 }
 
-:is(.dark) :where(.is-cyan-hover-solid-background) {
+:is(.dark) :where(.line-is-cyan-hover-solid-background) {
   background-color: var(--cyan-3);
 }
 
-:where(.is-cyan-low-contrast-background) {
+:where(.line-is-cyan-low-contrast-background) {
   background-color: var(--cyan-11);
 }
 
-:is(.dark) :where(.is-cyan-low-contrast-background) {
+:is(.dark) :where(.line-is-cyan-low-contrast-background) {
   background-color: var(--cyan-2);
 }
 
-:where(.is-cyan-high-contrast-background) {
+:where(.line-is-cyan-high-contrast-background) {
   background-color: var(--cyan-12);
 }
 
-:is(.dark) :where(.is-cyan-high-contrast-background) {
+:is(.dark) :where(.line-is-cyan-high-contrast-background) {
   background-color: var(--cyan-1);
 }
 
-:where(.is-cyan-border) {
+:where(.line-is-cyan-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--cyan-7);
   border-color: var(--cyan-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-cyan-border) {
+:is(.dark) :where(.line-is-cyan-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--cyan-6);
   border-color: var(--cyan-6);

--- a/packages/theme/src/schemas/gold.css
+++ b/packages/theme/src/schemas/gold.css
@@ -1,4 +1,4 @@
-:where(.schema-gold) {
+:where(.line-schema-gold) {
   --background: var(--gold-1);            /* App background (-1) */
   --subtle-background: var(--gold-2);     /* Subtle background (-2) */
   --ui-background: var(--gold-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--gold-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-gold)  {
+:is(.dark) :where(.line-schema-gold)  {
   --background: var(--gold-12);           /* App background (-1) */
   --subtle-background: var(--gold-11);    /* Subtle background (-2) */
   --ui-background: var(--gold-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--gold-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-gold) {
+:where(.line-is-gold) {
   color: var(--gold-1);
   background-color: var(--gold-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-gold) {
+:is(.dark) :where(.line-is-gold) {
   color: var(--gold-1);
   background-color: var(--gold-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-gold-color) {
+:where(.line-is-gold-color) {
   color: var(--gold-12);
 }
 
-:is(:dark) :where(.is-gold-color) {
+:is(:dark) :where(.line-is-gold-color) {
   color: var(--gold-1);
 }
 
-:where(.is-gold-low-contrast) {
+:where(.line-is-gold-low-contrast) {
   color: var(--gold-11);
 }
 
-:is(.dark) :where(.is-gold-low-contrast) {
+:is(.dark) :where(.line-is-gold-low-contrast) {
   color: var(--gold-2);
 }
 
-:where(.is-gold-high-contrast) {
+:where(.line-is-gold-high-contrast) {
   color: var(--gold-12);
 }
 
-:is(.dark) :where(.is-gold-high-contrast) {
+:is(.dark) :where(.line-is-gold-high-contrast) {
   color: var(--gold-1);
 }
 
-:where(.is-gold-background) {
+:where(.line-is-gold-background) {
   background-color: var(--gold-1);
 }
 
-:is(.dark) :where(.is-gold-background) {
+:is(.dark) :where(.line-is-gold-background) {
   background-color: var(--gold-12);
 }
 
-:where(.is-gold-subtle-background) {
+:where(.line-is-gold-subtle-background) {
   background-color: var(--gold-2);
 }
 
-:is(.dark) :where(.is-gold-subtle-background) {
+:is(.dark) :where(.line-is-gold-subtle-background) {
   background-color: var(--gold-11);
 }
 
-:where(.is-gold-ui-background) {
+:where(.line-is-gold-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--gold-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-gold-ui-background) {
+:is(.dark) :where(.line-is-gold-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--gold-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-gold-ui-hover-background) {
+:where(.line-is-gold-ui-hover-background) {
   background-color: var(--gold-4);
 }
 
-:is(.dark) :where(.is-gold-ui-hover-background) {
+:is(.dark) :where(.line-is-gold-ui-hover-background) {
   background-color: var(--gold-9);
 }
 
-:where(.is-gold-ui-active-background) {
+:where(.line-is-gold-ui-active-background) {
   background-color: var(--gold-5);
 }
 
-:is(.dark) :where(.is-gold-ui-active-background) {
+:is(.dark) :where(.line-is-gold-ui-active-background) {
   background-color: var(--gold-8);
 }
 
-:where(.is-gold-subtle-element-background) {
+:where(.line-is-gold-subtle-element-background) {
   background-color: var(--gold-6);
 }
 
-:is(.dark) :where(.is-gold-subtle-element-background) {
+:is(.dark) :where(.line-is-gold-subtle-element-background) {
   background-color: var(--gold-7);
 }
 
-:where(.is-gold-ui-element-background) {
+:where(.line-is-gold-ui-element-background) {
   background-color: var(--gold-7);
 }
 
-:is(.dark) :where(.is-gold-ui-element-background) {
+:is(.dark) :where(.line-is-gold-ui-element-background) {
   background-color: var(--gold-6);
 }
 
-:where(.is-gold-ui-hover-background) {
+:where(.line-is-gold-ui-hover-background) {
   background-color: var(--gold-8);
 }
 
-:is(.dark) :where(.is-gold-ui-hover-background) {
+:is(.dark) :where(.line-is-gold-ui-hover-background) {
   background-color: var(--gold-5);
 }
 
-:where(.is-gold-solid-background) {
+:where(.line-is-gold-solid-background) {
   background-color: var(--gold-9);
 }
 
-:is(.dark) :where(.is-gold-solid-background) {
+:is(.dark) :where(.line-is-gold-solid-background) {
   background-color: var(--gold-4);
 }
 
-:where(.is-gold-hover-solid-background) {
+:where(.line-is-gold-hover-solid-background) {
   background-color: var(--gold-10);
 }
 
-:is(.dark) :where(.is-gold-hover-solid-background) {
+:is(.dark) :where(.line-is-gold-hover-solid-background) {
   background-color: var(--gold-3);
 }
 
-:where(.is-gold-low-contrast-background) {
+:where(.line-is-gold-low-contrast-background) {
   background-color: var(--gold-11);
 }
 
-:is(.dark) :where(.is-gold-low-contrast-background) {
+:is(.dark) :where(.line-is-gold-low-contrast-background) {
   background-color: var(--gold-2);
 }
 
-:where(.is-gold-high-contrast-background) {
+:where(.line-is-gold-high-contrast-background) {
   background-color: var(--gold-12);
 }
 
-:is(.dark) :where(.is-gold-high-contrast-background) {
+:is(.dark) :where(.line-is-gold-high-contrast-background) {
   background-color: var(--gold-1);
 }
 
-:where(.is-gold-border) {
+:where(.line-is-gold-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--gold-7);
   border-color: var(--gold-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-gold-border) {
+:is(.dark) :where(.line-is-gold-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--gold-6);
   border-color: var(--gold-6);

--- a/packages/theme/src/schemas/grass.css
+++ b/packages/theme/src/schemas/grass.css
@@ -1,4 +1,4 @@
-:where(.schema-grass) {
+:where(.line-schema-grass) {
   --background: var(--grass-1);            /* App background (-1) */
   --subtle-background: var(--grass-2);     /* Subtle background (-2) */
   --ui-background: var(--grass-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--grass-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-grass)  {
+:is(.dark) :where(.line-schema-grass)  {
   --background: var(--grass-12);           /* App background (-1) */
   --subtle-background: var(--grass-11);    /* Subtle background (-2) */
   --ui-background: var(--grass-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--grass-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-grass) {
+:where(.line-is-grass) {
   color: var(--grass-1);
   background-color: var(--grass-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-grass) {
+:is(.dark) :where(.line-is-grass) {
   color: var(--grass-1);
   background-color: var(--grass-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-grass-color) {
+:where(.line-is-grass-color) {
   color: var(--grass-12);
 }
 
-:is(:dark) :where(.is-grass-color) {
+:is(:dark) :where(.line-is-grass-color) {
   color: var(--grass-1);
 }
 
-:where(.is-grass-low-contrast) {
+:where(.line-is-grass-low-contrast) {
   color: var(--grass-11);
 }
 
-:is(.dark) :where(.is-grass-low-contrast) {
+:is(.dark) :where(.line-is-grass-low-contrast) {
   color: var(--grass-2);
 }
 
-:where(.is-grass-high-contrast) {
+:where(.line-is-grass-high-contrast) {
   color: var(--grass-12);
 }
 
-:is(.dark) :where(.is-grass-high-contrast) {
+:is(.dark) :where(.line-is-grass-high-contrast) {
   color: var(--grass-1);
 }
 
-:where(.is-grass-background) {
+:where(.line-is-grass-background) {
   background-color: var(--grass-1);
 }
 
-:is(.dark) :where(.is-grass-background) {
+:is(.dark) :where(.line-is-grass-background) {
   background-color: var(--grass-12);
 }
 
-:where(.is-grass-subtle-background) {
+:where(.line-is-grass-subtle-background) {
   background-color: var(--grass-2);
 }
 
-:is(.dark) :where(.is-grass-subtle-background) {
+:is(.dark) :where(.line-is-grass-subtle-background) {
   background-color: var(--grass-11);
 }
 
-:where(.is-grass-ui-background) {
+:where(.line-is-grass-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--grass-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-grass-ui-background) {
+:is(.dark) :where(.line-is-grass-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--grass-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-grass-ui-hover-background) {
+:where(.line-is-grass-ui-hover-background) {
   background-color: var(--grass-4);
 }
 
-:is(.dark) :where(.is-grass-ui-hover-background) {
+:is(.dark) :where(.line-is-grass-ui-hover-background) {
   background-color: var(--grass-9);
 }
 
-:where(.is-grass-ui-active-background) {
+:where(.line-is-grass-ui-active-background) {
   background-color: var(--grass-5);
 }
 
-:is(.dark) :where(.is-grass-ui-active-background) {
+:is(.dark) :where(.line-is-grass-ui-active-background) {
   background-color: var(--grass-8);
 }
 
-:where(.is-grass-subtle-element-background) {
+:where(.line-is-grass-subtle-element-background) {
   background-color: var(--grass-6);
 }
 
-:is(.dark) :where(.is-grass-subtle-element-background) {
+:is(.dark) :where(.line-is-grass-subtle-element-background) {
   background-color: var(--grass-7);
 }
 
-:where(.is-grass-ui-element-background) {
+:where(.line-is-grass-ui-element-background) {
   background-color: var(--grass-7);
 }
 
-:is(.dark) :where(.is-grass-ui-element-background) {
+:is(.dark) :where(.line-is-grass-ui-element-background) {
   background-color: var(--grass-6);
 }
 
-:where(.is-grass-ui-hover-background) {
+:where(.line-is-grass-ui-hover-background) {
   background-color: var(--grass-8);
 }
 
-:is(.dark) :where(.is-grass-ui-hover-background) {
+:is(.dark) :where(.line-is-grass-ui-hover-background) {
   background-color: var(--grass-5);
 }
 
-:where(.is-grass-solid-background) {
+:where(.line-is-grass-solid-background) {
   background-color: var(--grass-9);
 }
 
-:is(.dark) :where(.is-grass-solid-background) {
+:is(.dark) :where(.line-is-grass-solid-background) {
   background-color: var(--grass-4);
 }
 
-:where(.is-grass-hover-solid-background) {
+:where(.line-is-grass-hover-solid-background) {
   background-color: var(--grass-10);
 }
 
-:is(.dark) :where(.is-grass-hover-solid-background) {
+:is(.dark) :where(.line-is-grass-hover-solid-background) {
   background-color: var(--grass-3);
 }
 
-:where(.is-grass-low-contrast-background) {
+:where(.line-is-grass-low-contrast-background) {
   background-color: var(--grass-11);
 }
 
-:is(.dark) :where(.is-grass-low-contrast-background) {
+:is(.dark) :where(.line-is-grass-low-contrast-background) {
   background-color: var(--grass-2);
 }
 
-:where(.is-grass-high-contrast-background) {
+:where(.line-is-grass-high-contrast-background) {
   background-color: var(--grass-12);
 }
 
-:is(.dark) :where(.is-grass-high-contrast-background) {
+:is(.dark) :where(.line-is-grass-high-contrast-background) {
   background-color: var(--grass-1);
 }
 
-:where(.is-grass-border) {
+:where(.line-is-grass-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--grass-7);
   border-color: var(--grass-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-grass-border) {
+:is(.dark) :where(.line-is-grass-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--grass-6);
   border-color: var(--grass-6);

--- a/packages/theme/src/schemas/gray.css
+++ b/packages/theme/src/schemas/gray.css
@@ -1,4 +1,4 @@
-:where(.schema-gray) {
+:where(.line-schema-gray) {
   --background: var(--gray-1);            /* App background (-1) */
   --subtle-background: var(--gray-2);     /* Subtle background (-2) */
   --ui-background: var(--gray-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--gray-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-gray)  {
+:is(.dark) :where(.line-schema-gray)  {
   --background: var(--gray-12);           /* App background (-1) */
   --subtle-background: var(--gray-11);    /* Subtle background (-2) */
   --ui-background: var(--gray-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--gray-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-gray) {
+:where(.line-is-gray) {
   color: var(--gray-1);
   background-color: var(--gray-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-gray) {
+:is(.dark) :where(.line-is-gray) {
   color: var(--gray-1);
   background-color: var(--gray-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-gray-color) {
+:where(.line-is-gray-color) {
   color: var(--gray-12);
 }
 
-:is(.dark) :where(.is-gray-color) {
+:is(.dark) :where(.line-is-gray-color) {
   color: var(--gray-1);
 }
 
-:where(.is-gray-low-contrast) {
+:where(.line-is-gray-low-contrast) {
   color: var(--gray-11);
 }
 
-:is(.dark) :where(.is-gray-low-contrast) {
+:is(.dark) :where(.line-is-gray-low-contrast) {
   color: var(--gray-2);
 }
 
-:where(.is-gray-high-contrast) {
+:where(.line-is-gray-high-contrast) {
   color: var(--gray-12);
 }
 
-:is(.dark) :where(.is-gray-high-contrast) {
+:is(.dark) :where(.line-is-gray-high-contrast) {
   color: var(--gray-1);
 }
 
-:where(.is-gray-background) {
+:where(.line-is-gray-background) {
   background-color: var(--gray-1);
 }
 
-:is(.dark) :where(.is-gray-background) {
+:is(.dark) :where(.line-is-gray-background) {
   background-color: var(--gray-12);
 }
 
-:where(.is-gray-subtle-background) {
+:where(.line-is-gray-subtle-background) {
   background-color: var(--gray-2);
 }
 
-:is(.dark) :where(.is-gray-subtle-background) {
+:is(.dark) :where(.line-is-gray-subtle-background) {
   background-color: var(--gray-11);
 }
 
-:where(.is-gray-ui-background) {
+:where(.line-is-gray-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--gray-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-gray-ui-background) {
+:is(.dark) :where(.line-is-gray-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--gray-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-gray-ui-hover-background) {
+:where(.line-is-gray-ui-hover-background) {
   background-color: var(--gray-4);
 }
 
-:is(.dark) :where(.is-gray-ui-hover-background) {
+:is(.dark) :where(.line-is-gray-ui-hover-background) {
   background-color: var(--gray-9);
 }
 
-:where(.is-gray-ui-active-background) {
+:where(.line-is-gray-ui-active-background) {
   background-color: var(--gray-5);
 }
 
-:is(.dark) :where(.is-gray-ui-active-background) {
+:is(.dark) :where(.line-is-gray-ui-active-background) {
   background-color: var(--gray-8);
 }
 
-:where(.is-gray-subtle-element-background) {
+:where(.line-is-gray-subtle-element-background) {
   background-color: var(--gray-6);
 }
 
-:is(.dark) :where(.is-gray-subtle-element-background) {
+:is(.dark) :where(.line-is-gray-subtle-element-background) {
   background-color: var(--gray-7);
 }
 
-:where(.is-gray-ui-element-background) {
+:where(.line-is-gray-ui-element-background) {
   background-color: var(--gray-7);
 }
 
-:is(.dark) :where(.is-gray-ui-element-background) {
+:is(.dark) :where(.line-is-gray-ui-element-background) {
   background-color: var(--gray-6);
 }
 
-:where(.is-gray-ui-hover-background) {
+:where(.line-is-gray-ui-hover-background) {
   background-color: var(--gray-8);
 }
 
-:is(.dark) :where(.is-gray-ui-hover-background) {
+:is(.dark) :where(.line-is-gray-ui-hover-background) {
   background-color: var(--gray-5);
 }
 
-:where(.is-gray-solid-background) {
+:where(.line-is-gray-solid-background) {
   background-color: var(--gray-9);
 }
 
-:is(.dark) :where(.is-gray-solid-background) {
+:is(.dark) :where(.line-is-gray-solid-background) {
   background-color: var(--gray-4);
 }
 
-:where(.is-gray-hover-solid-background) {
+:where(.line-is-gray-hover-solid-background) {
   background-color: var(--gray-10);
 }
 
-:is(.dark) :where(.is-gray-hover-solid-background) {
+:is(.dark) :where(.line-is-gray-hover-solid-background) {
   background-color: var(--gray-3);
 }
 
-:where(.is-gray-low-contrast-background) {
+:where(.line-is-gray-low-contrast-background) {
   background-color: var(--gray-11);
 }
 
-:is(.dark) :where(.is-gray-low-contrast-background) {
+:is(.dark) :where(.line-is-gray-low-contrast-background) {
   background-color: var(--gray-2);
 }
 
-:where(.is-gray-high-contrast-background) {
+:where(.line-is-gray-high-contrast-background) {
   background-color: var(--gray-12);
 }
 
-:is(.dark) :where(.is-gray-high-contrast-background) {
+:is(.dark) :where(.line-is-gray-high-contrast-background) {
   background-color: var(--gray-1);
 }
 
-:where(.is-gray-border) {
+:where(.line-is-gray-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--gray-7);
   border-color: var(--gray-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-gray-border) {
+:is(.dark) :where(.line-is-gray-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--gray-6);
   border-color: var(--gray-6);

--- a/packages/theme/src/schemas/green.css
+++ b/packages/theme/src/schemas/green.css
@@ -1,4 +1,4 @@
-:where(.schema-green) {
+:where(.line-schema-green) {
   --background: var(--green-1);            /* App background (-1) */
   --subtle-background: var(--green-2);     /* Subtle background (-2) */
   --ui-background: var(--green-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--green-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-green)  {
+:is(.dark) :where(.line-schema-green)  {
   --background: var(--green-12);           /* App background (-1) */
   --subtle-background: var(--green-11);    /* Subtle background (-2) */
   --ui-background: var(--green-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--green-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-green) {
+:where(.line-is-green) {
   color: var(--green-1);
   background-color: var(--green-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-green) {
+:is(.dark) :where(.line-is-green) {
   color: var(--green-1);
   background-color: var(--green-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-green-color) {
+:where(.line-is-green-color) {
   color: var(--green-12);
 }
 
-:is(:dark) :where(.is-green-color) {
+:is(:dark) :where(.line-is-green-color) {
   color: var(--green-1);
 }
 
-:where(.is-green-low-contrast) {
+:where(.line-is-green-low-contrast) {
   color: var(--green-11);
 }
 
-:is(.dark) :where(.is-green-low-contrast) {
+:is(.dark) :where(.line-is-green-low-contrast) {
   color: var(--green-2);
 }
 
-:where(.is-green-high-contrast) {
+:where(.line-is-green-high-contrast) {
   color: var(--green-12);
 }
 
-:is(.dark) :where(.is-green-high-contrast) {
+:is(.dark) :where(.line-is-green-high-contrast) {
   color: var(--green-1);
 }
 
-:where(.is-green-background) {
+:where(.line-is-green-background) {
   background-color: var(--green-1);
 }
 
-:is(.dark) :where(.is-green-background) {
+:is(.dark) :where(.line-is-green-background) {
   background-color: var(--green-12);
 }
 
-:where(.is-green-subtle-background) {
+:where(.line-is-green-subtle-background) {
   background-color: var(--green-2);
 }
 
-:is(.dark) :where(.is-green-subtle-background) {
+:is(.dark) :where(.line-is-green-subtle-background) {
   background-color: var(--green-11);
 }
 
-:where(.is-green-ui-background) {
+:where(.line-is-green-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--green-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-green-ui-background) {
+:is(.dark) :where(.line-is-green-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--green-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-green-ui-hover-background) {
+:where(.line-is-green-ui-hover-background) {
   background-color: var(--green-4);
 }
 
-:is(.dark) :where(.is-green-ui-hover-background) {
+:is(.dark) :where(.line-is-green-ui-hover-background) {
   background-color: var(--green-9);
 }
 
-:where(.is-green-ui-active-background) {
+:where(.line-is-green-ui-active-background) {
   background-color: var(--green-5);
 }
 
-:is(.dark) :where(.is-green-ui-active-background) {
+:is(.dark) :where(.line-is-green-ui-active-background) {
   background-color: var(--green-8);
 }
 
-:where(.is-green-subtle-element-background) {
+:where(.line-is-green-subtle-element-background) {
   background-color: var(--green-6);
 }
 
-:is(.dark) :where(.is-green-subtle-element-background) {
+:is(.dark) :where(.line-is-green-subtle-element-background) {
   background-color: var(--green-7);
 }
 
-:where(.is-green-ui-element-background) {
+:where(.line-is-green-ui-element-background) {
   background-color: var(--green-7);
 }
 
-:is(.dark) :where(.is-green-ui-element-background) {
+:is(.dark) :where(.line-is-green-ui-element-background) {
   background-color: var(--green-6);
 }
 
-:where(.is-green-ui-hover-background) {
+:where(.line-is-green-ui-hover-background) {
   background-color: var(--green-8);
 }
 
-:is(.dark) :where(.is-green-ui-hover-background) {
+:is(.dark) :where(.line-is-green-ui-hover-background) {
   background-color: var(--green-5);
 }
 
-:where(.is-green-solid-background) {
+:where(.line-is-green-solid-background) {
   background-color: var(--green-9);
 }
 
-:is(.dark) :where(.is-green-solid-background) {
+:is(.dark) :where(.line-is-green-solid-background) {
   background-color: var(--green-4);
 }
 
-:where(.is-green-hover-solid-background) {
+:where(.line-is-green-hover-solid-background) {
   background-color: var(--green-10);
 }
 
-:is(.dark) :where(.is-green-hover-solid-background) {
+:is(.dark) :where(.line-is-green-hover-solid-background) {
   background-color: var(--green-3);
 }
 
-:where(.is-green-low-contrast-background) {
+:where(.line-is-green-low-contrast-background) {
   background-color: var(--green-11);
 }
 
-:is(.dark) :where(.is-green-low-contrast-background) {
+:is(.dark) :where(.line-is-green-low-contrast-background) {
   background-color: var(--green-2);
 }
 
-:where(.is-green-high-contrast-background) {
+:where(.line-is-green-high-contrast-background) {
   background-color: var(--green-12);
 }
 
-:is(.dark) :where(.is-green-high-contrast-background) {
+:is(.dark) :where(.line-is-green-high-contrast-background) {
   background-color: var(--green-1);
 }
 
-:where(.is-green-border) {
+:where(.line-is-green-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--green-7);
   border-color: var(--green-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-green-border) {
+:is(.dark) :where(.line-is-green-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--green-6);
   border-color: var(--green-6);

--- a/packages/theme/src/schemas/indigo.css
+++ b/packages/theme/src/schemas/indigo.css
@@ -1,4 +1,4 @@
-:where(.schema-indigo) {
+:where(.line-schema-indigo) {
   --background: var(--indigo-1);            /* App background (-1) */
   --subtle-background: var(--indigo-2);     /* Subtle background (-2) */
   --ui-background: var(--indigo-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--indigo-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-indigo)  {
+:is(.dark) :where(.line-schema-indigo)  {
   --background: var(--indigo-12);           /* App background (-1) */
   --subtle-background: var(--indigo-11);    /* Subtle background (-2) */
   --ui-background: var(--indigo-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--indigo-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-indigo) {
+:where(.line-is-indigo) {
   color: var(--indigo-1);
   background-color: var(--indigo-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-indigo) {
+:is(.dark) :where(.line-is-indigo) {
   color: var(--indigo-1);
   background-color: var(--indigo-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-indigo-color) {
+:where(.line-is-indigo-color) {
   color: var(--indigo-12);
 }
 
-:is(:dark) :where(.is-indigo-color) {
+:is(:dark) :where(.line-is-indigo-color) {
   color: var(--indigo-1);
 }
 
-:where(.is-indigo-low-contrast) {
+:where(.line-is-indigo-low-contrast) {
   color: var(--indigo-11);
 }
 
-:is(.dark) :where(.is-indigo-low-contrast) {
+:is(.dark) :where(.line-is-indigo-low-contrast) {
   color: var(--indigo-2);
 }
 
-:where(.is-indigo-high-contrast) {
+:where(.line-is-indigo-high-contrast) {
   color: var(--indigo-12);
 }
 
-:is(.dark) :where(.is-indigo-high-contrast) {
+:is(.dark) :where(.line-is-indigo-high-contrast) {
   color: var(--indigo-1);
 }
 
-:where(.is-indigo-background) {
+:where(.line-is-indigo-background) {
   background-color: var(--indigo-1);
 }
 
-:is(.dark) :where(.is-indigo-background) {
+:is(.dark) :where(.line-is-indigo-background) {
   background-color: var(--indigo-12);
 }
 
-:where(.is-indigo-subtle-background) {
+:where(.line-is-indigo-subtle-background) {
   background-color: var(--indigo-2);
 }
 
-:is(.dark) :where(.is-indigo-subtle-background) {
+:is(.dark) :where(.line-is-indigo-subtle-background) {
   background-color: var(--indigo-11);
 }
 
-:where(.is-indigo-ui-background) {
+:where(.line-is-indigo-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--indigo-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-indigo-ui-background) {
+:is(.dark) :where(.line-is-indigo-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--indigo-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-indigo-ui-hover-background) {
+:where(.line-is-indigo-ui-hover-background) {
   background-color: var(--indigo-4);
 }
 
-:is(.dark) :where(.is-indigo-ui-hover-background) {
+:is(.dark) :where(.line-is-indigo-ui-hover-background) {
   background-color: var(--indigo-9);
 }
 
-:where(.is-indigo-ui-active-background) {
+:where(.line-is-indigo-ui-active-background) {
   background-color: var(--indigo-5);
 }
 
-:is(.dark) :where(.is-indigo-ui-active-background) {
+:is(.dark) :where(.line-is-indigo-ui-active-background) {
   background-color: var(--indigo-8);
 }
 
-:where(.is-indigo-subtle-element-background) {
+:where(.line-is-indigo-subtle-element-background) {
   background-color: var(--indigo-6);
 }
 
-:is(.dark) :where(.is-indigo-subtle-element-background) {
+:is(.dark) :where(.line-is-indigo-subtle-element-background) {
   background-color: var(--indigo-7);
 }
 
-:where(.is-indigo-ui-element-background) {
+:where(.line-is-indigo-ui-element-background) {
   background-color: var(--indigo-7);
 }
 
-:is(.dark) :where(.is-indigo-ui-element-background) {
+:is(.dark) :where(.line-is-indigo-ui-element-background) {
   background-color: var(--indigo-6);
 }
 
-:where(.is-indigo-ui-hover-background) {
+:where(.line-is-indigo-ui-hover-background) {
   background-color: var(--indigo-8);
 }
 
-:is(.dark) :where(.is-indigo-ui-hover-background) {
+:is(.dark) :where(.line-is-indigo-ui-hover-background) {
   background-color: var(--indigo-5);
 }
 
-:where(.is-indigo-solid-background) {
+:where(.line-is-indigo-solid-background) {
   background-color: var(--indigo-9);
 }
 
-:is(.dark) :where(.is-indigo-solid-background) {
+:is(.dark) :where(.line-is-indigo-solid-background) {
   background-color: var(--indigo-4);
 }
 
-:where(.is-indigo-hover-solid-background) {
+:where(.line-is-indigo-hover-solid-background) {
   background-color: var(--indigo-10);
 }
 
-:is(.dark) :where(.is-indigo-hover-solid-background) {
+:is(.dark) :where(.line-is-indigo-hover-solid-background) {
   background-color: var(--indigo-3);
 }
 
-:where(.is-indigo-low-contrast-background) {
+:where(.line-is-indigo-low-contrast-background) {
   background-color: var(--indigo-11);
 }
 
-:is(.dark) :where(.is-indigo-low-contrast-background) {
+:is(.dark) :where(.line-is-indigo-low-contrast-background) {
   background-color: var(--indigo-2);
 }
 
-:where(.is-indigo-high-contrast-background) {
+:where(.line-is-indigo-high-contrast-background) {
   background-color: var(--indigo-12);
 }
 
-:is(.dark) :where(.is-indigo-high-contrast-background) {
+:is(.dark) :where(.line-is-indigo-high-contrast-background) {
   background-color: var(--indigo-1);
 }
 
-:where(.is-indigo-border) {
+:where(.line-is-indigo-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--indigo-7);
   border-color: var(--indigo-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-indigo-border) {
+:is(.dark) :where(.line-is-indigo-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--indigo-6);
   border-color: var(--indigo-6);

--- a/packages/theme/src/schemas/lime.css
+++ b/packages/theme/src/schemas/lime.css
@@ -1,4 +1,4 @@
-:where(.schema-lime) {
+:where(.line-schema-lime) {
   --background: var(--lime-1);            /* App background (-1) */
   --subtle-background: var(--lime-2);     /* Subtle background (-2) */
   --ui-background: var(--lime-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--lime-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-lime)  {
+:is(.dark) :where(.line-schema-lime)  {
   --background: var(--lime-12);           /* App background (-1) */
   --subtle-background: var(--lime-11);    /* Subtle background (-2) */
   --ui-background: var(--lime-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--lime-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-lime) {
+:where(.line-is-lime) {
   color: var(--lime-12);
   background-color: var(--lime-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-lime) {
+:is(.dark) :where(.line-is-lime) {
   color: var(--lime-12);
   background-color: var(--lime-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-lime-color) {
+:where(.line-is-lime-color) {
   color: var(--lime-12);
 }
 
-:is(:dark) :where(.is-lime-color) {
+:is(:dark) :where(.line-is-lime-color) {
   color: var(--lime-1);
 }
 
-:where(.is-lime-low-contrast) {
+:where(.line-is-lime-low-contrast) {
   color: var(--lime-11);
 }
 
-:is(.dark) :where(.is-lime-low-contrast) {
+:is(.dark) :where(.line-is-lime-low-contrast) {
   color: var(--lime-2);
 }
 
-:where(.is-lime-high-contrast) {
+:where(.line-is-lime-high-contrast) {
   color: var(--lime-12);
 }
 
-:is(.dark) :where(.is-lime-high-contrast) {
+:is(.dark) :where(.line-is-lime-high-contrast) {
   color: var(--lime-1);
 }
 
-:where(.is-lime-background) {
+:where(.line-is-lime-background) {
   background-color: var(--lime-1);
 }
 
-:is(.dark) :where(.is-lime-background) {
+:is(.dark) :where(.line-is-lime-background) {
   background-color: var(--lime-12);
 }
 
-:where(.is-lime-subtle-background) {
+:where(.line-is-lime-subtle-background) {
   background-color: var(--lime-2);
 }
 
-:is(.dark) :where(.is-lime-subtle-background) {
+:is(.dark) :where(.line-is-lime-subtle-background) {
   background-color: var(--lime-11);
 }
 
-:where(.is-lime-ui-background) {
+:where(.line-is-lime-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--lime-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-lime-ui-background) {
+:is(.dark) :where(.line-is-lime-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--lime-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-lime-ui-hover-background) {
+:where(.line-is-lime-ui-hover-background) {
   background-color: var(--lime-4);
 }
 
-:is(.dark) :where(.is-lime-ui-hover-background) {
+:is(.dark) :where(.line-is-lime-ui-hover-background) {
   background-color: var(--lime-9);
 }
 
-:where(.is-lime-ui-active-background) {
+:where(.line-is-lime-ui-active-background) {
   background-color: var(--lime-5);
 }
 
-:is(.dark) :where(.is-lime-ui-active-background) {
+:is(.dark) :where(.line-is-lime-ui-active-background) {
   background-color: var(--lime-8);
 }
 
-:where(.is-lime-subtle-element-background) {
+:where(.line-is-lime-subtle-element-background) {
   background-color: var(--lime-6);
 }
 
-:is(.dark) :where(.is-lime-subtle-element-background) {
+:is(.dark) :where(.line-is-lime-subtle-element-background) {
   background-color: var(--lime-7);
 }
 
-:where(.is-lime-ui-element-background) {
+:where(.line-is-lime-ui-element-background) {
   background-color: var(--lime-7);
 }
 
-:is(.dark) :where(.is-lime-ui-element-background) {
+:is(.dark) :where(.line-is-lime-ui-element-background) {
   background-color: var(--lime-6);
 }
 
-:where(.is-lime-ui-hover-background) {
+:where(.line-is-lime-ui-hover-background) {
   background-color: var(--lime-8);
 }
 
-:is(.dark) :where(.is-lime-ui-hover-background) {
+:is(.dark) :where(.line-is-lime-ui-hover-background) {
   background-color: var(--lime-5);
 }
 
-:where(.is-lime-solid-background) {
+:where(.line-is-lime-solid-background) {
   background-color: var(--lime-9);
 }
 
-:is(.dark) :where(.is-lime-solid-background) {
+:is(.dark) :where(.line-is-lime-solid-background) {
   background-color: var(--lime-4);
 }
 
-:where(.is-lime-hover-solid-background) {
+:where(.line-is-lime-hover-solid-background) {
   background-color: var(--lime-10);
 }
 
-:is(.dark) :where(.is-lime-hover-solid-background) {
+:is(.dark) :where(.line-is-lime-hover-solid-background) {
   background-color: var(--lime-3);
 }
 
-:where(.is-lime-low-contrast-background) {
+:where(.line-is-lime-low-contrast-background) {
   background-color: var(--lime-11);
 }
 
-:is(.dark) :where(.is-lime-low-contrast-background) {
+:is(.dark) :where(.line-is-lime-low-contrast-background) {
   background-color: var(--lime-2);
 }
 
-:where(.is-lime-high-contrast-background) {
+:where(.line-is-lime-high-contrast-background) {
   background-color: var(--lime-12);
 }
 
-:is(.dark) :where(.is-lime-high-contrast-background) {
+:is(.dark) :where(.line-is-lime-high-contrast-background) {
   background-color: var(--lime-1);
 }
 
-:where(.is-lime-border) {
+:where(.line-is-lime-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--lime-7);
   border-color: var(--lime-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-lime-border) {
+:is(.dark) :where(.line-is-lime-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--lime-6);
   border-color: var(--lime-6);

--- a/packages/theme/src/schemas/mauve.css
+++ b/packages/theme/src/schemas/mauve.css
@@ -1,4 +1,4 @@
-:where(.schema-mauve) {
+:where(.line-schema-mauve) {
   --background: var(--mauve-1);            /* App background (-1) */
   --subtle-background: var(--mauve-2);     /* Subtle background (-2) */
   --ui-background: var(--mauve-3);         /* UI element background (-3) */
@@ -15,7 +15,7 @@
   --dark: var(--mauve-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-mauve)  {
+:is(.dark) :where(.line-schema-mauve)  {
   --background: var(--mauve-12);           /* App background (-1) */
   --subtle-background: var(--mauve-11);    /* Subtle background (-2) */
   --ui-background: var(--mauve-10);        /* UI element background (-3) */
@@ -30,7 +30,7 @@
   --high-contrast: var(--mauve-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-mauve) {
+:where(.line-is-mauve) {
   color: var(--mauve-1);
   background-color: var(--mauve-9);
   transition: all ease-in-out 150ms;
@@ -40,7 +40,7 @@
   }
 }
 
-:is(.dark) :where(.is-mauve) {
+:is(.dark) :where(.line-is-mauve) {
   color: var(--mauve-1);
   background-color: var(--mauve-4);
   transition: all ease-in-out 150ms;
@@ -50,47 +50,47 @@
   }
 }
 
-:where(.is-mauve-color) {
+:where(.line-is-mauve-color) {
   color: var(--mauve-12);
 }
 
-:is(:dark) :where(.is-mauve-color) {
+:is(:dark) :where(.line-is-mauve-color) {
   color: var(--mauve-1);
 }
 
-:where(.is-mauve-low-contrast) {
+:where(.line-is-mauve-low-contrast) {
   color: var(--mauve-11);
 }
 
-:is(.dark) :where(.is-mauve-low-contrast) {
+:is(.dark) :where(.line-is-mauve-low-contrast) {
   color: var(--mauve-2);
 }
 
-:where(.is-mauve-high-contrast) {
+:where(.line-is-mauve-high-contrast) {
   color: var(--mauve-12);
 }
 
-:is(.dark) :where(.is-mauve-high-contrast) {
+:is(.dark) :where(.line-is-mauve-high-contrast) {
   color: var(--mauve-1);
 }
 
-:where(.is-mauve-background) {
+:where(.line-is-mauve-background) {
   background-color: var(--mauve-1);
 }
 
-:is(.dark) :where(.is-mauve-background) {
+:is(.dark) :where(.line-is-mauve-background) {
   background-color: var(--mauve-12);
 }
 
-:where(.is-mauve-subtle-background) {
+:where(.line-is-mauve-subtle-background) {
   background-color: var(--mauve-2);
 }
 
-:is(.dark) :where(.is-mauve-subtle-background) {
+:is(.dark) :where(.line-is-mauve-subtle-background) {
   background-color: var(--mauve-11);
 }
 
-:where(.is-mauve-ui-background) {
+:where(.line-is-mauve-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--mauve-3);
 
@@ -99,7 +99,7 @@
   }
 }
 
-:is(.dark) :where(.is-mauve-ui-background) {
+:is(.dark) :where(.line-is-mauve-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--mauve-10);
 
@@ -108,79 +108,79 @@
   }
 }
 
-:where(.is-mauve-ui-hover-background) {
+:where(.line-is-mauve-ui-hover-background) {
   background-color: var(--mauve-4);
 }
 
-:is(.dark) :where(.is-mauve-ui-hover-background) {
+:is(.dark) :where(.line-is-mauve-ui-hover-background) {
   background-color: var(--mauve-9);
 }
 
-:where(.is-mauve-ui-active-background) {
+:where(.line-is-mauve-ui-active-background) {
   background-color: var(--mauve-5);
 }
 
-:is(.dark) :where(.is-mauve-ui-active-background) {
+:is(.dark) :where(.line-is-mauve-ui-active-background) {
   background-color: var(--mauve-8);
 }
 
-:where(.is-mauve-subtle-element-background) {
+:where(.line-is-mauve-subtle-element-background) {
   background-color: var(--mauve-6);
 }
 
-:is(.dark) :where(.is-mauve-subtle-element-background) {
+:is(.dark) :where(.line-is-mauve-subtle-element-background) {
   background-color: var(--mauve-7);
 }
 
-:where(.is-mauve-ui-element-background) {
+:where(.line-is-mauve-ui-element-background) {
   background-color: var(--mauve-7);
 }
 
-:is(.dark) :where(.is-mauve-ui-element-background) {
+:is(.dark) :where(.line-is-mauve-ui-element-background) {
   background-color: var(--mauve-6);
 }
 
-:where(.is-mauve-ui-hover-background) {
+:where(.line-is-mauve-ui-hover-background) {
   background-color: var(--mauve-8);
 }
 
-:is(.dark) :where(.is-mauve-ui-hover-background) {
+:is(.dark) :where(.line-is-mauve-ui-hover-background) {
   background-color: var(--mauve-5);
 }
 
-:where(.is-mauve-solid-background) {
+:where(.line-is-mauve-solid-background) {
   background-color: var(--mauve-9);
 }
 
-:is(.dark) :where(.is-mauve-solid-background) {
+:is(.dark) :where(.line-is-mauve-solid-background) {
   background-color: var(--mauve-4);
 }
 
-:where(.is-mauve-hover-solid-background) {
+:where(.line-is-mauve-hover-solid-background) {
   background-color: var(--mauve-10);
 }
 
-:is(.dark) :where(.is-mauve-hover-solid-background) {
+:is(.dark) :where(.line-is-mauve-hover-solid-background) {
   background-color: var(--mauve-3);
 }
 
-:where(.is-mauve-low-contrast-background) {
+:where(.line-is-mauve-low-contrast-background) {
   background-color: var(--mauve-11);
 }
 
-:is(.dark) :where(.is-mauve-low-contrast-background) {
+:is(.dark) :where(.line-is-mauve-low-contrast-background) {
   background-color: var(--mauve-2);
 }
 
-:where(.is-mauve-high-contrast-background) {
+:where(.line-is-mauve-high-contrast-background) {
   background-color: var(--mauve-12);
 }
 
-:is(.dark) :where(.is-mauve-high-contrast-background) {
+:is(.dark) :where(.line-is-mauve-high-contrast-background) {
   background-color: var(--mauve-1);
 }
 
-:where(.is-mauve-border) {
+:where(.line-is-mauve-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--mauve-7);
   border-color: var(--mauve-7);
@@ -191,7 +191,7 @@
   }
 }
 
-:is(.dark) :where(.is-mauve-border) {
+:is(.dark) :where(.line-is-mauve-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--mauve-6);
   border-color: var(--mauve-6);

--- a/packages/theme/src/schemas/mint.css
+++ b/packages/theme/src/schemas/mint.css
@@ -1,4 +1,4 @@
-:where(.schema-mint) {
+:where(.line-schema-mint) {
   --background: var(--mint-1);            /* App background (-1) */
   --subtle-background: var(--mint-2);     /* Subtle background (-2) */
   --ui-background: var(--mint-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--mint-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-mint)  {
+:is(.dark) :where(.line-schema-mint)  {
   --background: var(--mint-12);           /* App background (-1) */
   --subtle-background: var(--mint-11);    /* Subtle background (-2) */
   --ui-background: var(--mint-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--mint-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-mint) {
+:where(.line-is-mint) {
   color: var(--mint-12);
   background-color: var(--mint-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-mint) {
+:is(.dark) :where(.line-is-mint) {
   color: var(--mint-12);
   background-color: var(--mint-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-mint-color) {
+:where(.line-is-mint-color) {
   color: var(--mint-12);
 }
 
-:is(:dark) :where(.is-mint-color) {
+:is(:dark) :where(.line-is-mint-color) {
   color: var(--mint-1);
 }
 
-:where(.is-mint-low-contrast) {
+:where(.line-is-mint-low-contrast) {
   color: var(--mint-11);
 }
 
-:is(.dark) :where(.is-mint-low-contrast) {
+:is(.dark) :where(.line-is-mint-low-contrast) {
   color: var(--mint-2);
 }
 
-:where(.is-mint-high-contrast) {
+:where(.line-is-mint-high-contrast) {
   color: var(--mint-12);
 }
 
-:is(.dark) :where(.is-mint-high-contrast) {
+:is(.dark) :where(.line-is-mint-high-contrast) {
   color: var(--mint-1);
 }
 
-:where(.is-mint-background) {
+:where(.line-is-mint-background) {
   background-color: var(--mint-1);
 }
 
-:is(.dark) :where(.is-mint-background) {
+:is(.dark) :where(.line-is-mint-background) {
   background-color: var(--mint-12);
 }
 
-:where(.is-mint-subtle-background) {
+:where(.line-is-mint-subtle-background) {
   background-color: var(--mint-2);
 }
 
-:is(.dark) :where(.is-mint-subtle-background) {
+:is(.dark) :where(.line-is-mint-subtle-background) {
   background-color: var(--mint-11);
 }
 
-:where(.is-mint-ui-background) {
+:where(.line-is-mint-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--mint-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-mint-ui-background) {
+:is(.dark) :where(.line-is-mint-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--mint-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-mint-ui-hover-background) {
+:where(.line-is-mint-ui-hover-background) {
   background-color: var(--mint-4);
 }
 
-:is(.dark) :where(.is-mint-ui-hover-background) {
+:is(.dark) :where(.line-is-mint-ui-hover-background) {
   background-color: var(--mint-9);
 }
 
-:where(.is-mint-ui-active-background) {
+:where(.line-is-mint-ui-active-background) {
   background-color: var(--mint-5);
 }
 
-:is(.dark) :where(.is-mint-ui-active-background) {
+:is(.dark) :where(.line-is-mint-ui-active-background) {
   background-color: var(--mint-8);
 }
 
-:where(.is-mint-subtle-element-background) {
+:where(.line-is-mint-subtle-element-background) {
   background-color: var(--mint-6);
 }
 
-:is(.dark) :where(.is-mint-subtle-element-background) {
+:is(.dark) :where(.line-is-mint-subtle-element-background) {
   background-color: var(--mint-7);
 }
 
-:where(.is-mint-ui-element-background) {
+:where(.line-is-mint-ui-element-background) {
   background-color: var(--mint-7);
 }
 
-:is(.dark) :where(.is-mint-ui-element-background) {
+:is(.dark) :where(.line-is-mint-ui-element-background) {
   background-color: var(--mint-6);
 }
 
-:where(.is-mint-ui-hover-background) {
+:where(.line-is-mint-ui-hover-background) {
   background-color: var(--mint-8);
 }
 
-:is(.dark) :where(.is-mint-ui-hover-background) {
+:is(.dark) :where(.line-is-mint-ui-hover-background) {
   background-color: var(--mint-5);
 }
 
-:where(.is-mint-solid-background) {
+:where(.line-is-mint-solid-background) {
   background-color: var(--mint-9);
 }
 
-:is(.dark) :where(.is-mint-solid-background) {
+:is(.dark) :where(.line-is-mint-solid-background) {
   background-color: var(--mint-4);
 }
 
-:where(.is-mint-hover-solid-background) {
+:where(.line-is-mint-hover-solid-background) {
   background-color: var(--mint-10);
 }
 
-:is(.dark) :where(.is-mint-hover-solid-background) {
+:is(.dark) :where(.line-is-mint-hover-solid-background) {
   background-color: var(--mint-3);
 }
 
-:where(.is-mint-low-contrast-background) {
+:where(.line-is-mint-low-contrast-background) {
   background-color: var(--mint-11);
 }
 
-:is(.dark) :where(.is-mint-low-contrast-background) {
+:is(.dark) :where(.line-is-mint-low-contrast-background) {
   background-color: var(--mint-2);
 }
 
-:where(.is-mint-high-contrast-background) {
+:where(.line-is-mint-high-contrast-background) {
   background-color: var(--mint-12);
 }
 
-:is(.dark) :where(.is-mint-high-contrast-background) {
+:is(.dark) :where(.line-is-mint-high-contrast-background) {
   background-color: var(--mint-1);
 }
 
-:where(.is-mint-border) {
+:where(.line-is-mint-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--mint-7);
   border-color: var(--mint-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-mint-border) {
+:is(.dark) :where(.line-is-mint-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--mint-6);
   border-color: var(--mint-6);

--- a/packages/theme/src/schemas/olive.css
+++ b/packages/theme/src/schemas/olive.css
@@ -1,4 +1,4 @@
-:where(.schema-olive) {
+:where(.line-schema-olive) {
   --background: var(--olive-1);            /* App background (-1) */
   --subtle-background: var(--olive-2);     /* Subtle background (-2) */
   --ui-background: var(--olive-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--olive-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-olive)  {
+:is(.dark) :where(.line-schema-olive)  {
   --background: var(--olive-12);           /* App background (-1) */
   --subtle-background: var(--olive-11);    /* Subtle background (-2) */
   --ui-background: var(--olive-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--olive-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-olive) {
+:where(.line-is-olive) {
   color: var(--olive-1);
   background-color: var(--olive-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-olive) {
+:is(.dark) :where(.line-is-olive) {
   color: var(--olive-1);
   background-color: var(--olive-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-olive-color) {
+:where(.line-is-olive-color) {
   color: var(--olive-12);
 }
 
-:is(:dark) :where(.is-olive-color) {
+:is(:dark) :where(.line-is-olive-color) {
   color: var(--olive-1);
 }
 
-:where(.is-olive-low-contrast) {
+:where(.line-is-olive-low-contrast) {
   color: var(--olive-11);
 }
 
-:is(.dark) :where(.is-olive-low-contrast) {
+:is(.dark) :where(.line-is-olive-low-contrast) {
   color: var(--olive-2);
 }
 
-:where(.is-olive-high-contrast) {
+:where(.line-is-olive-high-contrast) {
   color: var(--olive-12);
 }
 
-:is(.dark) :where(.is-olive-high-contrast) {
+:is(.dark) :where(.line-is-olive-high-contrast) {
   color: var(--olive-1);
 }
 
-:where(.is-olive-background) {
+:where(.line-is-olive-background) {
   background-color: var(--olive-1);
 }
 
-:is(.dark) :where(.is-olive-background) {
+:is(.dark) :where(.line-is-olive-background) {
   background-color: var(--olive-12);
 }
 
-:where(.is-olive-subtle-background) {
+:where(.line-is-olive-subtle-background) {
   background-color: var(--olive-2);
 }
 
-:is(.dark) :where(.is-olive-subtle-background) {
+:is(.dark) :where(.line-is-olive-subtle-background) {
   background-color: var(--olive-11);
 }
 
-:where(.is-olive-ui-background) {
+:where(.line-is-olive-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--olive-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-olive-ui-background) {
+:is(.dark) :where(.line-is-olive-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--olive-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-olive-ui-hover-background) {
+:where(.line-is-olive-ui-hover-background) {
   background-color: var(--olive-4);
 }
 
-:is(.dark) :where(.is-olive-ui-hover-background) {
+:is(.dark) :where(.line-is-olive-ui-hover-background) {
   background-color: var(--olive-9);
 }
 
-:where(.is-olive-ui-active-background) {
+:where(.line-is-olive-ui-active-background) {
   background-color: var(--olive-5);
 }
 
-:is(.dark) :where(.is-olive-ui-active-background) {
+:is(.dark) :where(.line-is-olive-ui-active-background) {
   background-color: var(--olive-8);
 }
 
-:where(.is-olive-subtle-element-background) {
+:where(.line-is-olive-subtle-element-background) {
   background-color: var(--olive-6);
 }
 
-:is(.dark) :where(.is-olive-subtle-element-background) {
+:is(.dark) :where(.line-is-olive-subtle-element-background) {
   background-color: var(--olive-7);
 }
 
-:where(.is-olive-ui-element-background) {
+:where(.line-is-olive-ui-element-background) {
   background-color: var(--olive-7);
 }
 
-:is(.dark) :where(.is-olive-ui-element-background) {
+:is(.dark) :where(.line-is-olive-ui-element-background) {
   background-color: var(--olive-6);
 }
 
-:where(.is-olive-ui-hover-background) {
+:where(.line-is-olive-ui-hover-background) {
   background-color: var(--olive-8);
 }
 
-:is(.dark) :where(.is-olive-ui-hover-background) {
+:is(.dark) :where(.line-is-olive-ui-hover-background) {
   background-color: var(--olive-5);
 }
 
-:where(.is-olive-solid-background) {
+:where(.line-is-olive-solid-background) {
   background-color: var(--olive-9);
 }
 
-:is(.dark) :where(.is-olive-solid-background) {
+:is(.dark) :where(.line-is-olive-solid-background) {
   background-color: var(--olive-4);
 }
 
-:where(.is-olive-hover-solid-background) {
+:where(.line-is-olive-hover-solid-background) {
   background-color: var(--olive-10);
 }
 
-:is(.dark) :where(.is-olive-hover-solid-background) {
+:is(.dark) :where(.line-is-olive-hover-solid-background) {
   background-color: var(--olive-3);
 }
 
-:where(.is-olive-low-contrast-background) {
+:where(.line-is-olive-low-contrast-background) {
   background-color: var(--olive-11);
 }
 
-:is(.dark) :where(.is-olive-low-contrast-background) {
+:is(.dark) :where(.line-is-olive-low-contrast-background) {
   background-color: var(--olive-2);
 }
 
-:where(.is-olive-high-contrast-background) {
+:where(.line-is-olive-high-contrast-background) {
   background-color: var(--olive-12);
 }
 
-:is(.dark) :where(.is-olive-high-contrast-background) {
+:is(.dark) :where(.line-is-olive-high-contrast-background) {
   background-color: var(--olive-1);
 }
 
-:where(.is-olive-border) {
+:where(.line-is-olive-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--olive-7);
   border-color: var(--olive-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-olive-border) {
+:is(.dark) :where(.line-is-olive-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--olive-6);
   border-color: var(--olive-6);

--- a/packages/theme/src/schemas/orange.css
+++ b/packages/theme/src/schemas/orange.css
@@ -1,4 +1,4 @@
-:where(.schema-orange) {
+:where(.line-schema-orange) {
   --background: var(--orange-1);            /* App background (-1) */
   --subtle-background: var(--orange-2);     /* Subtle background (-2) */
   --ui-background: var(--orange-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--orange-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-orange)  {
+:is(.dark) :where(.line-schema-orange)  {
   --background: var(--orange-12);           /* App background (-1) */
   --subtle-background: var(--orange-11);    /* Subtle background (-2) */
   --ui-background: var(--orange-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--orange-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-orange) {
+:where(.line-is-orange) {
   color: var(--orange-1);
   background-color: var(--orange-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-orange) {
+:is(.dark) :where(.line-is-orange) {
   color: var(--orange-1);
   background-color: var(--orange-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-orange-color) {
+:where(.line-is-orange-color) {
   color: var(--orange-12);
 }
 
-:is(:dark) :where(.is-orange-color) {
+:is(:dark) :where(.line-is-orange-color) {
   color: var(--orange-1);
 }
 
-:where(.is-orange-low-contrast) {
+:where(.line-is-orange-low-contrast) {
   color: var(--orange-11);
 }
 
-:is(.dark) :where(.is-orange-low-contrast) {
+:is(.dark) :where(.line-is-orange-low-contrast) {
   color: var(--orange-2);
 }
 
-:where(.is-orange-high-contrast) {
+:where(.line-is-orange-high-contrast) {
   color: var(--orange-12);
 }
 
-:is(.dark) :where(.is-orange-high-contrast) {
+:is(.dark) :where(.line-is-orange-high-contrast) {
   color: var(--orange-1);
 }
 
-:where(.is-orange-background) {
+:where(.line-is-orange-background) {
   background-color: var(--orange-1);
 }
 
-:is(.dark) :where(.is-orange-background) {
+:is(.dark) :where(.line-is-orange-background) {
   background-color: var(--orange-12);
 }
 
-:where(.is-orange-subtle-background) {
+:where(.line-is-orange-subtle-background) {
   background-color: var(--orange-2);
 }
 
-:is(.dark) :where(.is-orange-subtle-background) {
+:is(.dark) :where(.line-is-orange-subtle-background) {
   background-color: var(--orange-11);
 }
 
-:where(.is-orange-ui-background) {
+:where(.line-is-orange-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--orange-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-orange-ui-background) {
+:is(.dark) :where(.line-is-orange-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--orange-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-orange-ui-hover-background) {
+:where(.line-is-orange-ui-hover-background) {
   background-color: var(--orange-4);
 }
 
-:is(.dark) :where(.is-orange-ui-hover-background) {
+:is(.dark) :where(.line-is-orange-ui-hover-background) {
   background-color: var(--orange-9);
 }
 
-:where(.is-orange-ui-active-background) {
+:where(.line-is-orange-ui-active-background) {
   background-color: var(--orange-5);
 }
 
-:is(.dark) :where(.is-orange-ui-active-background) {
+:is(.dark) :where(.line-is-orange-ui-active-background) {
   background-color: var(--orange-8);
 }
 
-:where(.is-orange-subtle-element-background) {
+:where(.line-is-orange-subtle-element-background) {
   background-color: var(--orange-6);
 }
 
-:is(.dark) :where(.is-orange-subtle-element-background) {
+:is(.dark) :where(.line-is-orange-subtle-element-background) {
   background-color: var(--orange-7);
 }
 
-:where(.is-orange-ui-element-background) {
+:where(.line-is-orange-ui-element-background) {
   background-color: var(--orange-7);
 }
 
-:is(.dark) :where(.is-orange-ui-element-background) {
+:is(.dark) :where(.line-is-orange-ui-element-background) {
   background-color: var(--orange-6);
 }
 
-:where(.is-orange-ui-hover-background) {
+:where(.line-is-orange-ui-hover-background) {
   background-color: var(--orange-8);
 }
 
-:is(.dark) :where(.is-orange-ui-hover-background) {
+:is(.dark) :where(.line-is-orange-ui-hover-background) {
   background-color: var(--orange-5);
 }
 
-:where(.is-orange-solid-background) {
+:where(.line-is-orange-solid-background) {
   background-color: var(--orange-9);
 }
 
-:is(.dark) :where(.is-orange-solid-background) {
+:is(.dark) :where(.line-is-orange-solid-background) {
   background-color: var(--orange-4);
 }
 
-:where(.is-orange-hover-solid-background) {
+:where(.line-is-orange-hover-solid-background) {
   background-color: var(--orange-10);
 }
 
-:is(.dark) :where(.is-orange-hover-solid-background) {
+:is(.dark) :where(.line-is-orange-hover-solid-background) {
   background-color: var(--orange-3);
 }
 
-:where(.is-orange-low-contrast-background) {
+:where(.line-is-orange-low-contrast-background) {
   background-color: var(--orange-11);
 }
 
-:is(.dark) :where(.is-orange-low-contrast-background) {
+:is(.dark) :where(.line-is-orange-low-contrast-background) {
   background-color: var(--orange-2);
 }
 
-:where(.is-orange-high-contrast-background) {
+:where(.line-is-orange-high-contrast-background) {
   background-color: var(--orange-12);
 }
 
-:is(.dark) :where(.is-orange-high-contrast-background) {
+:is(.dark) :where(.line-is-orange-high-contrast-background) {
   background-color: var(--orange-1);
 }
 
-:where(.is-orange-border) {
+:where(.line-is-orange-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--orange-7);
   border-color: var(--orange-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-orange-border) {
+:is(.dark) :where(.line-is-orange-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--orange-6);
   border-color: var(--orange-6);

--- a/packages/theme/src/schemas/pink.css
+++ b/packages/theme/src/schemas/pink.css
@@ -1,4 +1,4 @@
-:where(.schema-pink) {
+:where(.line-schema-pink) {
   --background: var(--pink-1);            /* App background (-1) */
   --subtle-background: var(--pink-2);     /* Subtle background (-2) */
   --ui-background: var(--pink-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--pink-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-pink)  {
+:is(.dark) :where(.line-schema-pink)  {
   --background: var(--pink-12);           /* App background (-1) */
   --subtle-background: var(--pink-11);    /* Subtle background (-2) */
   --ui-background: var(--pink-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--pink-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-pink) {
+:where(.line-is-pink) {
   color: var(--pink-1);
   background-color: var(--pink-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-pink) {
+:is(.dark) :where(.line-is-pink) {
   color: var(--pink-1);
   background-color: var(--pink-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-pink-color) {
+:where(.line-is-pink-color) {
   color: var(--pink-12);
 }
 
-:is(:dark) :where(.is-pink-color) {
+:is(:dark) :where(.line-is-pink-color) {
   color: var(--pink-1);
 }
 
-:where(.is-pink-low-contrast) {
+:where(.line-is-pink-low-contrast) {
   color: var(--pink-11);
 }
 
-:is(.dark) :where(.is-pink-low-contrast) {
+:is(.dark) :where(.line-is-pink-low-contrast) {
   color: var(--pink-2);
 }
 
-:where(.is-pink-high-contrast) {
+:where(.line-is-pink-high-contrast) {
   color: var(--pink-12);
 }
 
-:is(.dark) :where(.is-pink-high-contrast) {
+:is(.dark) :where(.line-is-pink-high-contrast) {
   color: var(--pink-1);
 }
 
-:where(.is-pink-background) {
+:where(.line-is-pink-background) {
   background-color: var(--pink-1);
 }
 
-:is(.dark) :where(.is-pink-background) {
+:is(.dark) :where(.line-is-pink-background) {
   background-color: var(--pink-12);
 }
 
-:where(.is-pink-subtle-background) {
+:where(.line-is-pink-subtle-background) {
   background-color: var(--pink-2);
 }
 
-:is(.dark) :where(.is-pink-subtle-background) {
+:is(.dark) :where(.line-is-pink-subtle-background) {
   background-color: var(--pink-11);
 }
 
-:where(.is-pink-ui-background) {
+:where(.line-is-pink-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--pink-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-pink-ui-background) {
+:is(.dark) :where(.line-is-pink-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--pink-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-pink-ui-hover-background) {
+:where(.line-is-pink-ui-hover-background) {
   background-color: var(--pink-4);
 }
 
-:is(.dark) :where(.is-pink-ui-hover-background) {
+:is(.dark) :where(.line-is-pink-ui-hover-background) {
   background-color: var(--pink-9);
 }
 
-:where(.is-pink-ui-active-background) {
+:where(.line-is-pink-ui-active-background) {
   background-color: var(--pink-5);
 }
 
-:is(.dark) :where(.is-pink-ui-active-background) {
+:is(.dark) :where(.line-is-pink-ui-active-background) {
   background-color: var(--pink-8);
 }
 
-:where(.is-pink-subtle-element-background) {
+:where(.line-is-pink-subtle-element-background) {
   background-color: var(--pink-6);
 }
 
-:is(.dark) :where(.is-pink-subtle-element-background) {
+:is(.dark) :where(.line-is-pink-subtle-element-background) {
   background-color: var(--pink-7);
 }
 
-:where(.is-pink-ui-element-background) {
+:where(.line-is-pink-ui-element-background) {
   background-color: var(--pink-7);
 }
 
-:is(.dark) :where(.is-pink-ui-element-background) {
+:is(.dark) :where(.line-is-pink-ui-element-background) {
   background-color: var(--pink-6);
 }
 
-:where(.is-pink-ui-hover-background) {
+:where(.line-is-pink-ui-hover-background) {
   background-color: var(--pink-8);
 }
 
-:is(.dark) :where(.is-pink-ui-hover-background) {
+:is(.dark) :where(.line-is-pink-ui-hover-background) {
   background-color: var(--pink-5);
 }
 
-:where(.is-pink-solid-background) {
+:where(.line-is-pink-solid-background) {
   background-color: var(--pink-9);
 }
 
-:is(.dark) :where(.is-pink-solid-background) {
+:is(.dark) :where(.line-is-pink-solid-background) {
   background-color: var(--pink-4);
 }
 
-:where(.is-pink-hover-solid-background) {
+:where(.line-is-pink-hover-solid-background) {
   background-color: var(--pink-10);
 }
 
-:is(.dark) :where(.is-pink-hover-solid-background) {
+:is(.dark) :where(.line-is-pink-hover-solid-background) {
   background-color: var(--pink-3);
 }
 
-:where(.is-pink-low-contrast-background) {
+:where(.line-is-pink-low-contrast-background) {
   background-color: var(--pink-11);
 }
 
-:is(.dark) :where(.is-pink-low-contrast-background) {
+:is(.dark) :where(.line-is-pink-low-contrast-background) {
   background-color: var(--pink-2);
 }
 
-:where(.is-pink-high-contrast-background) {
+:where(.line-is-pink-high-contrast-background) {
   background-color: var(--pink-12);
 }
 
-:is(.dark) :where(.is-pink-high-contrast-background) {
+:is(.dark) :where(.line-is-pink-high-contrast-background) {
   background-color: var(--pink-1);
 }
 
-:where(.is-pink-border) {
+:where(.line-is-pink-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--pink-7);
   border-color: var(--pink-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-pink-border) {
+:is(.dark) :where(.line-is-pink-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--pink-6);
   border-color: var(--pink-6);

--- a/packages/theme/src/schemas/plum.css
+++ b/packages/theme/src/schemas/plum.css
@@ -1,4 +1,4 @@
-:where(.schema-plum) {
+:where(.line-schema-plum) {
   --background: var(--plum-1);            /* App background (-1) */
   --subtle-background: var(--plum-2);     /* Subtle background (-2) */
   --ui-background: var(--plum-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--plum-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-plum)  {
+:is(.dark) :where(.line-schema-plum)  {
   --background: var(--plum-12);           /* App background (-1) */
   --subtle-background: var(--plum-11);    /* Subtle background (-2) */
   --ui-background: var(--plum-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--plum-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-plum) {
+:where(.line-is-plum) {
   color: var(--plum-1);
   background-color: var(--plum-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-plum) {
+:is(.dark) :where(.line-is-plum) {
   color: var(--plum-1);
   background-color: var(--plum-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-plum-color) {
+:where(.line-is-plum-color) {
   color: var(--plum-12);
 }
 
-:is(:dark) :where(.is-plum-color) {
+:is(:dark) :where(.line-is-plum-color) {
   color: var(--plum-1);
 }
 
-:where(.is-plum-low-contrast) {
+:where(.line-is-plum-low-contrast) {
   color: var(--plum-11);
 }
 
-:is(.dark) :where(.is-plum-low-contrast) {
+:is(.dark) :where(.line-is-plum-low-contrast) {
   color: var(--plum-2);
 }
 
-:where(.is-plum-high-contrast) {
+:where(.line-is-plum-high-contrast) {
   color: var(--plum-12);
 }
 
-:is(.dark) :where(.is-plum-high-contrast) {
+:is(.dark) :where(.line-is-plum-high-contrast) {
   color: var(--plum-1);
 }
 
-:where(.is-plum-background) {
+:where(.line-is-plum-background) {
   background-color: var(--plum-1);
 }
 
-:is(.dark) :where(.is-plum-background) {
+:is(.dark) :where(.line-is-plum-background) {
   background-color: var(--plum-12);
 }
 
-:where(.is-plum-subtle-background) {
+:where(.line-is-plum-subtle-background) {
   background-color: var(--plum-2);
 }
 
-:is(.dark) :where(.is-plum-subtle-background) {
+:is(.dark) :where(.line-is-plum-subtle-background) {
   background-color: var(--plum-11);
 }
 
-:where(.is-plum-ui-background) {
+:where(.line-is-plum-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--plum-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-plum-ui-background) {
+:is(.dark) :where(.line-is-plum-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--plum-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-plum-ui-hover-background) {
+:where(.line-is-plum-ui-hover-background) {
   background-color: var(--plum-4);
 }
 
-:is(.dark) :where(.is-plum-ui-hover-background) {
+:is(.dark) :where(.line-is-plum-ui-hover-background) {
   background-color: var(--plum-9);
 }
 
-:where(.is-plum-ui-active-background) {
+:where(.line-is-plum-ui-active-background) {
   background-color: var(--plum-5);
 }
 
-:is(.dark) :where(.is-plum-ui-active-background) {
+:is(.dark) :where(.line-is-plum-ui-active-background) {
   background-color: var(--plum-8);
 }
 
-:where(.is-plum-subtle-element-background) {
+:where(.line-is-plum-subtle-element-background) {
   background-color: var(--plum-6);
 }
 
-:is(.dark) :where(.is-plum-subtle-element-background) {
+:is(.dark) :where(.line-is-plum-subtle-element-background) {
   background-color: var(--plum-7);
 }
 
-:where(.is-plum-ui-element-background) {
+:where(.line-is-plum-ui-element-background) {
   background-color: var(--plum-7);
 }
 
-:is(.dark) :where(.is-plum-ui-element-background) {
+:is(.dark) :where(.line-is-plum-ui-element-background) {
   background-color: var(--plum-6);
 }
 
-:where(.is-plum-ui-hover-background) {
+:where(.line-is-plum-ui-hover-background) {
   background-color: var(--plum-8);
 }
 
-:is(.dark) :where(.is-plum-ui-hover-background) {
+:is(.dark) :where(.line-is-plum-ui-hover-background) {
   background-color: var(--plum-5);
 }
 
-:where(.is-plum-solid-background) {
+:where(.line-is-plum-solid-background) {
   background-color: var(--plum-9);
 }
 
-:is(.dark) :where(.is-plum-solid-background) {
+:is(.dark) :where(.line-is-plum-solid-background) {
   background-color: var(--plum-4);
 }
 
-:where(.is-plum-hover-solid-background) {
+:where(.line-is-plum-hover-solid-background) {
   background-color: var(--plum-10);
 }
 
-:is(.dark) :where(.is-plum-hover-solid-background) {
+:is(.dark) :where(.line-is-plum-hover-solid-background) {
   background-color: var(--plum-3);
 }
 
-:where(.is-plum-low-contrast-background) {
+:where(.line-is-plum-low-contrast-background) {
   background-color: var(--plum-11);
 }
 
-:is(.dark) :where(.is-plum-low-contrast-background) {
+:is(.dark) :where(.line-is-plum-low-contrast-background) {
   background-color: var(--plum-2);
 }
 
-:where(.is-plum-high-contrast-background) {
+:where(.line-is-plum-high-contrast-background) {
   background-color: var(--plum-12);
 }
 
-:is(.dark) :where(.is-plum-high-contrast-background) {
+:is(.dark) :where(.line-is-plum-high-contrast-background) {
   background-color: var(--plum-1);
 }
 
-:where(.is-plum-border) {
+:where(.line-is-plum-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--plum-7);
   border-color: var(--plum-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-plum-border) {
+:is(.dark) :where(.line-is-plum-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--plum-6);
   border-color: var(--plum-6);

--- a/packages/theme/src/schemas/purple.css
+++ b/packages/theme/src/schemas/purple.css
@@ -1,4 +1,4 @@
-:where(.schema-purple) {
+:where(.line-schema-purple) {
   --background: var(--purple-1);            /* App background (-1) */
   --subtle-background: var(--purple-2);     /* Subtle background (-2) */
   --ui-background: var(--purple-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--purple-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-purple)  {
+:is(.dark) :where(.line-schema-purple)  {
   --background: var(--purple-12);           /* App background (-1) */
   --subtle-background: var(--purple-11);    /* Subtle background (-2) */
   --ui-background: var(--purple-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--purple-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-purple) {
+:where(.line-is-purple) {
   color: var(--purple-1);
   background-color: var(--purple-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-purple) {
+:is(.dark) :where(.line-is-purple) {
   color: var(--purple-1);
   background-color: var(--purple-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-purple-color) {
+:where(.line-is-purple-color) {
   color: var(--purple-12);
 }
 
-:is(:dark) :where(.is-purple-color) {
+:is(:dark) :where(.line-is-purple-color) {
   color: var(--purple-1);
 }
 
-:where(.is-purple-low-contrast) {
+:where(.line-is-purple-low-contrast) {
   color: var(--purple-11);
 }
 
-:is(.dark) :where(.is-purple-low-contrast) {
+:is(.dark) :where(.line-is-purple-low-contrast) {
   color: var(--purple-2);
 }
 
-:where(.is-purple-high-contrast) {
+:where(.line-is-purple-high-contrast) {
   color: var(--purple-12);
 }
 
-:is(.dark) :where(.is-purple-high-contrast) {
+:is(.dark) :where(.line-is-purple-high-contrast) {
   color: var(--purple-1);
 }
 
-:where(.is-purple-background) {
+:where(.line-is-purple-background) {
   background-color: var(--purple-1);
 }
 
-:is(.dark) :where(.is-purple-background) {
+:is(.dark) :where(.line-is-purple-background) {
   background-color: var(--purple-12);
 }
 
-:where(.is-purple-subtle-background) {
+:where(.line-is-purple-subtle-background) {
   background-color: var(--purple-2);
 }
 
-:is(.dark) :where(.is-purple-subtle-background) {
+:is(.dark) :where(.line-is-purple-subtle-background) {
   background-color: var(--purple-11);
 }
 
-:where(.is-purple-ui-background) {
+:where(.line-is-purple-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--purple-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-purple-ui-background) {
+:is(.dark) :where(.line-is-purple-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--purple-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-purple-ui-hover-background) {
+:where(.line-is-purple-ui-hover-background) {
   background-color: var(--purple-4);
 }
 
-:is(.dark) :where(.is-purple-ui-hover-background) {
+:is(.dark) :where(.line-is-purple-ui-hover-background) {
   background-color: var(--purple-9);
 }
 
-:where(.is-purple-ui-active-background) {
+:where(.line-is-purple-ui-active-background) {
   background-color: var(--purple-5);
 }
 
-:is(.dark) :where(.is-purple-ui-active-background) {
+:is(.dark) :where(.line-is-purple-ui-active-background) {
   background-color: var(--purple-8);
 }
 
-:where(.is-purple-subtle-element-background) {
+:where(.line-is-purple-subtle-element-background) {
   background-color: var(--purple-6);
 }
 
-:is(.dark) :where(.is-purple-subtle-element-background) {
+:is(.dark) :where(.line-is-purple-subtle-element-background) {
   background-color: var(--purple-7);
 }
 
-:where(.is-purple-ui-element-background) {
+:where(.line-is-purple-ui-element-background) {
   background-color: var(--purple-7);
 }
 
-:is(.dark) :where(.is-purple-ui-element-background) {
+:is(.dark) :where(.line-is-purple-ui-element-background) {
   background-color: var(--purple-6);
 }
 
-:where(.is-purple-ui-hover-background) {
+:where(.line-is-purple-ui-hover-background) {
   background-color: var(--purple-8);
 }
 
-:is(.dark) :where(.is-purple-ui-hover-background) {
+:is(.dark) :where(.line-is-purple-ui-hover-background) {
   background-color: var(--purple-5);
 }
 
-:where(.is-purple-solid-background) {
+:where(.line-is-purple-solid-background) {
   background-color: var(--purple-9);
 }
 
-:is(.dark) :where(.is-purple-solid-background) {
+:is(.dark) :where(.line-is-purple-solid-background) {
   background-color: var(--purple-4);
 }
 
-:where(.is-purple-hover-solid-background) {
+:where(.line-is-purple-hover-solid-background) {
   background-color: var(--purple-10);
 }
 
-:is(.dark) :where(.is-purple-hover-solid-background) {
+:is(.dark) :where(.line-is-purple-hover-solid-background) {
   background-color: var(--purple-3);
 }
 
-:where(.is-purple-low-contrast-background) {
+:where(.line-is-purple-low-contrast-background) {
   background-color: var(--purple-11);
 }
 
-:is(.dark) :where(.is-purple-low-contrast-background) {
+:is(.dark) :where(.line-is-purple-low-contrast-background) {
   background-color: var(--purple-2);
 }
 
-:where(.is-purple-high-contrast-background) {
+:where(.line-is-purple-high-contrast-background) {
   background-color: var(--purple-12);
 }
 
-:is(.dark) :where(.is-purple-high-contrast-background) {
+:is(.dark) :where(.line-is-purple-high-contrast-background) {
   background-color: var(--purple-1);
 }
 
-:where(.is-purple-border) {
+:where(.line-is-purple-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--purple-7);
   border-color: var(--purple-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-purple-border) {
+:is(.dark) :where(.line-is-purple-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--purple-6);
   border-color: var(--purple-6);

--- a/packages/theme/src/schemas/red.css
+++ b/packages/theme/src/schemas/red.css
@@ -1,4 +1,4 @@
-:where(.schema-red) {
+:where(.line-schema-red) {
   --background: var(--red-1);            /* App background (-1) */
   --subtle-background: var(--red-2);     /* Subtle background (-2) */
   --ui-background: var(--red-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--red-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-red)  {
+:is(.dark) :where(.line-schema-red)  {
   --background: var(--red-12);           /* App background (-1) */
   --subtle-background: var(--red-11);    /* Subtle background (-2) */
   --ui-background: var(--red-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--red-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-red) {
+:where(.line-is-red) {
   color: var(--red-1);
   background-color: var(--red-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-red) {
+:is(.dark) :where(.line-is-red) {
   color: var(--red-1);
   background-color: var(--red-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-red-color) {
+:where(.line-is-red-color) {
   color: var(--red-12);
 }
 
-:is(:dark) :where(.is-red-color) {
+:is(:dark) :where(.line-is-red-color) {
   color: var(--red-1);
 }
 
-:where(.is-red-low-contrast) {
+:where(.line-is-red-low-contrast) {
   color: var(--red-11);
 }
 
-:is(.dark) :where(.is-red-low-contrast) {
+:is(.dark) :where(.line-is-red-low-contrast) {
   color: var(--red-2);
 }
 
-:where(.is-red-high-contrast) {
+:where(.line-is-red-high-contrast) {
   color: var(--red-12);
 }
 
-:is(.dark) :where(.is-red-high-contrast) {
+:is(.dark) :where(.line-is-red-high-contrast) {
   color: var(--red-1);
 }
 
-:where(.is-red-background) {
+:where(.line-is-red-background) {
   background-color: var(--red-1);
 }
 
-:is(.dark) :where(.is-red-background) {
+:is(.dark) :where(.line-is-red-background) {
   background-color: var(--red-12);
 }
 
-:where(.is-red-subtle-background) {
+:where(.line-is-red-subtle-background) {
   background-color: var(--red-2);
 }
 
-:is(.dark) :where(.is-red-subtle-background) {
+:is(.dark) :where(.line-is-red-subtle-background) {
   background-color: var(--red-11);
 }
 
-:where(.is-red-ui-background) {
+:where(.line-is-red-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--red-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-red-ui-background) {
+:is(.dark) :where(.line-is-red-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--red-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-red-ui-hover-background) {
+:where(.line-is-red-ui-hover-background) {
   background-color: var(--red-4);
 }
 
-:is(.dark) :where(.is-red-ui-hover-background) {
+:is(.dark) :where(.line-is-red-ui-hover-background) {
   background-color: var(--red-9);
 }
 
-:where(.is-red-ui-active-background) {
+:where(.line-is-red-ui-active-background) {
   background-color: var(--red-5);
 }
 
-:is(.dark) :where(.is-red-ui-active-background) {
+:is(.dark) :where(.line-is-red-ui-active-background) {
   background-color: var(--red-8);
 }
 
-:where(.is-red-subtle-element-background) {
+:where(.line-is-red-subtle-element-background) {
   background-color: var(--red-6);
 }
 
-:is(.dark) :where(.is-red-subtle-element-background) {
+:is(.dark) :where(.line-is-red-subtle-element-background) {
   background-color: var(--red-7);
 }
 
-:where(.is-red-ui-element-background) {
+:where(.line-is-red-ui-element-background) {
   background-color: var(--red-7);
 }
 
-:is(.dark) :where(.is-red-ui-element-background) {
+:is(.dark) :where(.line-is-red-ui-element-background) {
   background-color: var(--red-6);
 }
 
-:where(.is-red-ui-hover-background) {
+:where(.line-is-red-ui-hover-background) {
   background-color: var(--red-8);
 }
 
-:is(.dark) :where(.is-red-ui-hover-background) {
+:is(.dark) :where(.line-is-red-ui-hover-background) {
   background-color: var(--red-5);
 }
 
-:where(.is-red-solid-background) {
+:where(.line-is-red-solid-background) {
   background-color: var(--red-9);
 }
 
-:is(.dark) :where(.is-red-solid-background) {
+:is(.dark) :where(.line-is-red-solid-background) {
   background-color: var(--red-4);
 }
 
-:where(.is-red-hover-solid-background) {
+:where(.line-is-red-hover-solid-background) {
   background-color: var(--red-10);
 }
 
-:is(.dark) :where(.is-red-hover-solid-background) {
+:is(.dark) :where(.line-is-red-hover-solid-background) {
   background-color: var(--red-3);
 }
 
-:where(.is-red-low-contrast-background) {
+:where(.line-is-red-low-contrast-background) {
   background-color: var(--red-11);
 }
 
-:is(.dark) :where(.is-red-low-contrast-background) {
+:is(.dark) :where(.line-is-red-low-contrast-background) {
   background-color: var(--red-2);
 }
 
-:where(.is-red-high-contrast-background) {
+:where(.line-is-red-high-contrast-background) {
   background-color: var(--red-12);
 }
 
-:is(.dark) :where(.is-red-high-contrast-background) {
+:is(.dark) :where(.line-is-red-high-contrast-background) {
   background-color: var(--red-1);
 }
 
-:where(.is-red-border) {
+:where(.line-is-red-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--red-7);
   border-color: var(--red-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-red-border) {
+:is(.dark) :where(.line-is-red-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--red-6);
   border-color: var(--red-6);

--- a/packages/theme/src/schemas/sage.css
+++ b/packages/theme/src/schemas/sage.css
@@ -1,4 +1,4 @@
-:where(.schema-sage) {
+:where(.line-schema-sage) {
   --background: var(--sage-1);            /* App background (-1) */
   --subtle-background: var(--sage-2);     /* Subtle background (-2) */
   --ui-background: var(--sage-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--sage-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-sage)  {
+:is(.dark) :where(.line-schema-sage)  {
   --background: var(--sage-12);           /* App background (-1) */
   --subtle-background: var(--sage-11);    /* Subtle background (-2) */
   --ui-background: var(--sage-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--sage-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-sage) {
+:where(.line-is-sage) {
   color: var(--sage-1);
   background-color: var(--sage-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-sage) {
+:is(.dark) :where(.line-is-sage) {
   color: var(--sage-1);
   background-color: var(--sage-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-sage-color) {
+:where(.line-is-sage-color) {
   color: var(--sage-12);
 }
 
-:is(:dark) :where(.is-sage-color) {
+:is(:dark) :where(.line-is-sage-color) {
   color: var(--sage-1);
 }
 
-:where(.is-sage-low-contrast) {
+:where(.line-is-sage-low-contrast) {
   color: var(--sage-11);
 }
 
-:is(.dark) :where(.is-sage-low-contrast) {
+:is(.dark) :where(.line-is-sage-low-contrast) {
   color: var(--sage-2);
 }
 
-:where(.is-sage-high-contrast) {
+:where(.line-is-sage-high-contrast) {
   color: var(--sage-12);
 }
 
-:is(.dark) :where(.is-sage-high-contrast) {
+:is(.dark) :where(.line-is-sage-high-contrast) {
   color: var(--sage-1);
 }
 
-:where(.is-sage-background) {
+:where(.line-is-sage-background) {
   background-color: var(--sage-1);
 }
 
-:is(.dark) :where(.is-sage-background) {
+:is(.dark) :where(.line-is-sage-background) {
   background-color: var(--sage-12);
 }
 
-:where(.is-sage-subtle-background) {
+:where(.line-is-sage-subtle-background) {
   background-color: var(--sage-2);
 }
 
-:is(.dark) :where(.is-sage-subtle-background) {
+:is(.dark) :where(.line-is-sage-subtle-background) {
   background-color: var(--sage-11);
 }
 
-:where(.is-sage-ui-background) {
+:where(.line-is-sage-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--sage-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-sage-ui-background) {
+:is(.dark) :where(.line-is-sage-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--sage-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-sage-ui-hover-background) {
+:where(.line-is-sage-ui-hover-background) {
   background-color: var(--sage-4);
 }
 
-:is(.dark) :where(.is-sage-ui-hover-background) {
+:is(.dark) :where(.line-is-sage-ui-hover-background) {
   background-color: var(--sage-9);
 }
 
-:where(.is-sage-ui-active-background) {
+:where(.line-is-sage-ui-active-background) {
   background-color: var(--sage-5);
 }
 
-:is(.dark) :where(.is-sage-ui-active-background) {
+:is(.dark) :where(.line-is-sage-ui-active-background) {
   background-color: var(--sage-8);
 }
 
-:where(.is-sage-subtle-element-background) {
+:where(.line-is-sage-subtle-element-background) {
   background-color: var(--sage-6);
 }
 
-:is(.dark) :where(.is-sage-subtle-element-background) {
+:is(.dark) :where(.line-is-sage-subtle-element-background) {
   background-color: var(--sage-7);
 }
 
-:where(.is-sage-ui-element-background) {
+:where(.line-is-sage-ui-element-background) {
   background-color: var(--sage-7);
 }
 
-:is(.dark) :where(.is-sage-ui-element-background) {
+:is(.dark) :where(.line-is-sage-ui-element-background) {
   background-color: var(--sage-6);
 }
 
-:where(.is-sage-ui-hover-background) {
+:where(.line-is-sage-ui-hover-background) {
   background-color: var(--sage-8);
 }
 
-:is(.dark) :where(.is-sage-ui-hover-background) {
+:is(.dark) :where(.line-is-sage-ui-hover-background) {
   background-color: var(--sage-5);
 }
 
-:where(.is-sage-solid-background) {
+:where(.line-is-sage-solid-background) {
   background-color: var(--sage-9);
 }
 
-:is(.dark) :where(.is-sage-solid-background) {
+:is(.dark) :where(.line-is-sage-solid-background) {
   background-color: var(--sage-4);
 }
 
-:where(.is-sage-hover-solid-background) {
+:where(.line-is-sage-hover-solid-background) {
   background-color: var(--sage-10);
 }
 
-:is(.dark) :where(.is-sage-hover-solid-background) {
+:is(.dark) :where(.line-is-sage-hover-solid-background) {
   background-color: var(--sage-3);
 }
 
-:where(.is-sage-low-contrast-background) {
+:where(.line-is-sage-low-contrast-background) {
   background-color: var(--sage-11);
 }
 
-:is(.dark) :where(.is-sage-low-contrast-background) {
+:is(.dark) :where(.line-is-sage-low-contrast-background) {
   background-color: var(--sage-2);
 }
 
-:where(.is-sage-high-contrast-background) {
+:where(.line-is-sage-high-contrast-background) {
   background-color: var(--sage-12);
 }
 
-:is(.dark) :where(.is-sage-high-contrast-background) {
+:is(.dark) :where(.line-is-sage-high-contrast-background) {
   background-color: var(--sage-1);
 }
 
-:where(.is-sage-border) {
+:where(.line-is-sage-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--sage-7);
   border-color: var(--sage-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-sage-border) {
+:is(.dark) :where(.line-is-sage-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--sage-6);
   border-color: var(--sage-6);

--- a/packages/theme/src/schemas/sand.css
+++ b/packages/theme/src/schemas/sand.css
@@ -1,4 +1,4 @@
-:where(.schema-sand) {
+:where(.line-schema-sand) {
   --background: var(--sand-1);            /* App background (-1) */
   --subtle-background: var(--sand-2);     /* Subtle background (-2) */
   --ui-background: var(--sand-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--sand-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-sand)  {
+:is(.dark) :where(.line-schema-sand)  {
   --background: var(--sand-12);           /* App background (-1) */
   --subtle-background: var(--sand-11);    /* Subtle background (-2) */
   --ui-background: var(--sand-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--sand-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-sand) {
+:where(.line-is-sand) {
   color: var(--sand-1);
   background-color: var(--sand-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-sand) {
+:is(.dark) :where(.line-is-sand) {
   color: var(--sand-1);
   background-color: var(--sand-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-sand-color) {
+:where(.line-is-sand-color) {
   color: var(--sand-12);
 }
 
-:is(:dark) :where(.is-sand-color) {
+:is(:dark) :where(.line-is-sand-color) {
   color: var(--sand-1);
 }
 
-:where(.is-sand-low-contrast) {
+:where(.line-is-sand-low-contrast) {
   color: var(--sand-11);
 }
 
-:is(.dark) :where(.is-sand-low-contrast) {
+:is(.dark) :where(.line-is-sand-low-contrast) {
   color: var(--sand-2);
 }
 
-:where(.is-sand-high-contrast) {
+:where(.line-is-sand-high-contrast) {
   color: var(--sand-12);
 }
 
-:is(.dark) :where(.is-sand-high-contrast) {
+:is(.dark) :where(.line-is-sand-high-contrast) {
   color: var(--sand-1);
 }
 
-:where(.is-sand-background) {
+:where(.line-is-sand-background) {
   background-color: var(--sand-1);
 }
 
-:is(.dark) :where(.is-sand-background) {
+:is(.dark) :where(.line-is-sand-background) {
   background-color: var(--sand-12);
 }
 
-:where(.is-sand-subtle-background) {
+:where(.line-is-sand-subtle-background) {
   background-color: var(--sand-2);
 }
 
-:is(.dark) :where(.is-sand-subtle-background) {
+:is(.dark) :where(.line-is-sand-subtle-background) {
   background-color: var(--sand-11);
 }
 
-:where(.is-sand-ui-background) {
+:where(.line-is-sand-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--sand-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-sand-ui-background) {
+:is(.dark) :where(.line-is-sand-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--sand-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-sand-ui-hover-background) {
+:where(.line-is-sand-ui-hover-background) {
   background-color: var(--sand-4);
 }
 
-:is(.dark) :where(.is-sand-ui-hover-background) {
+:is(.dark) :where(.line-is-sand-ui-hover-background) {
   background-color: var(--sand-9);
 }
 
-:where(.is-sand-ui-active-background) {
+:where(.line-is-sand-ui-active-background) {
   background-color: var(--sand-5);
 }
 
-:is(.dark) :where(.is-sand-ui-active-background) {
+:is(.dark) :where(.line-is-sand-ui-active-background) {
   background-color: var(--sand-8);
 }
 
-:where(.is-sand-subtle-element-background) {
+:where(.line-is-sand-subtle-element-background) {
   background-color: var(--sand-6);
 }
 
-:is(.dark) :where(.is-sand-subtle-element-background) {
+:is(.dark) :where(.line-is-sand-subtle-element-background) {
   background-color: var(--sand-7);
 }
 
-:where(.is-sand-ui-element-background) {
+:where(.line-is-sand-ui-element-background) {
   background-color: var(--sand-7);
 }
 
-:is(.dark) :where(.is-sand-ui-element-background) {
+:is(.dark) :where(.line-is-sand-ui-element-background) {
   background-color: var(--sand-6);
 }
 
-:where(.is-sand-ui-hover-background) {
+:where(.line-is-sand-ui-hover-background) {
   background-color: var(--sand-8);
 }
 
-:is(.dark) :where(.is-sand-ui-hover-background) {
+:is(.dark) :where(.line-is-sand-ui-hover-background) {
   background-color: var(--sand-5);
 }
 
-:where(.is-sand-solid-background) {
+:where(.line-is-sand-solid-background) {
   background-color: var(--sand-9);
 }
 
-:is(.dark) :where(.is-sand-solid-background) {
+:is(.dark) :where(.line-is-sand-solid-background) {
   background-color: var(--sand-4);
 }
 
-:where(.is-sand-hover-solid-background) {
+:where(.line-is-sand-hover-solid-background) {
   background-color: var(--sand-10);
 }
 
-:is(.dark) :where(.is-sand-hover-solid-background) {
+:is(.dark) :where(.line-is-sand-hover-solid-background) {
   background-color: var(--sand-3);
 }
 
-:where(.is-sand-low-contrast-background) {
+:where(.line-is-sand-low-contrast-background) {
   background-color: var(--sand-11);
 }
 
-:is(.dark) :where(.is-sand-low-contrast-background) {
+:is(.dark) :where(.line-is-sand-low-contrast-background) {
   background-color: var(--sand-2);
 }
 
-:where(.is-sand-high-contrast-background) {
+:where(.line-is-sand-high-contrast-background) {
   background-color: var(--sand-12);
 }
 
-:is(.dark) :where(.is-sand-high-contrast-background) {
+:is(.dark) :where(.line-is-sand-high-contrast-background) {
   background-color: var(--sand-1);
 }
 
-:where(.is-sand-border) {
+:where(.line-is-sand-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--sand-7);
   border-color: var(--sand-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-sand-border) {
+:is(.dark) :where(.line-is-sand-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--sand-6);
   border-color: var(--sand-6);

--- a/packages/theme/src/schemas/sky.css
+++ b/packages/theme/src/schemas/sky.css
@@ -1,4 +1,4 @@
-:where(.schema-sky) {
+:where(.line-schema-sky) {
   --background: var(--sky-1);            /* App background (-1) */
   --subtle-background: var(--sky-2);     /* Subtle background (-2) */
   --ui-background: var(--sky-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--sky-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-sky)  {
+:is(.dark) :where(.line-schema-sky)  {
   --background: var(--sky-12);           /* App background (-1) */
   --subtle-background: var(--sky-11);    /* Subtle background (-2) */
   --ui-background: var(--sky-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--sky-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-sky) {
+:where(.line-is-sky) {
   color: var(--sky-12);
   background-color: var(--sky-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-sky) {
+:is(.dark) :where(.line-is-sky) {
   color: var(--sky-12);
   background-color: var(--sky-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-sky-color) {
+:where(.line-is-sky-color) {
   color: var(--sky-12);
 }
 
-:is(:dark) :where(.is-sky-color) {
+:is(:dark) :where(.line-is-sky-color) {
   color: var(--sky-1);
 }
 
-:where(.is-sky-low-contrast) {
+:where(.line-is-sky-low-contrast) {
   color: var(--sky-11);
 }
 
-:is(.dark) :where(.is-sky-low-contrast) {
+:is(.dark) :where(.line-is-sky-low-contrast) {
   color: var(--sky-2);
 }
 
-:where(.is-sky-high-contrast) {
+:where(.line-is-sky-high-contrast) {
   color: var(--sky-12);
 }
 
-:is(.dark) :where(.is-sky-high-contrast) {
+:is(.dark) :where(.line-is-sky-high-contrast) {
   color: var(--sky-1);
 }
 
-:where(.is-sky-background) {
+:where(.line-is-sky-background) {
   background-color: var(--sky-1);
 }
 
-:is(.dark) :where(.is-sky-background) {
+:is(.dark) :where(.line-is-sky-background) {
   background-color: var(--sky-12);
 }
 
-:where(.is-sky-subtle-background) {
+:where(.line-is-sky-subtle-background) {
   background-color: var(--sky-2);
 }
 
-:is(.dark) :where(.is-sky-subtle-background) {
+:is(.dark) :where(.line-is-sky-subtle-background) {
   background-color: var(--sky-11);
 }
 
-:where(.is-sky-ui-background) {
+:where(.line-is-sky-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--sky-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-sky-ui-background) {
+:is(.dark) :where(.line-is-sky-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--sky-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-sky-ui-hover-background) {
+:where(.line-is-sky-ui-hover-background) {
   background-color: var(--sky-4);
 }
 
-:is(.dark) :where(.is-sky-ui-hover-background) {
+:is(.dark) :where(.line-is-sky-ui-hover-background) {
   background-color: var(--sky-9);
 }
 
-:where(.is-sky-ui-active-background) {
+:where(.line-is-sky-ui-active-background) {
   background-color: var(--sky-5);
 }
 
-:is(.dark) :where(.is-sky-ui-active-background) {
+:is(.dark) :where(.line-is-sky-ui-active-background) {
   background-color: var(--sky-8);
 }
 
-:where(.is-sky-subtle-element-background) {
+:where(.line-is-sky-subtle-element-background) {
   background-color: var(--sky-6);
 }
 
-:is(.dark) :where(.is-sky-subtle-element-background) {
+:is(.dark) :where(.line-is-sky-subtle-element-background) {
   background-color: var(--sky-7);
 }
 
-:where(.is-sky-ui-element-background) {
+:where(.line-is-sky-ui-element-background) {
   background-color: var(--sky-7);
 }
 
-:is(.dark) :where(.is-sky-ui-element-background) {
+:is(.dark) :where(.line-is-sky-ui-element-background) {
   background-color: var(--sky-6);
 }
 
-:where(.is-sky-ui-hover-background) {
+:where(.line-is-sky-ui-hover-background) {
   background-color: var(--sky-8);
 }
 
-:is(.dark) :where(.is-sky-ui-hover-background) {
+:is(.dark) :where(.line-is-sky-ui-hover-background) {
   background-color: var(--sky-5);
 }
 
-:where(.is-sky-solid-background) {
+:where(.line-is-sky-solid-background) {
   background-color: var(--sky-9);
 }
 
-:is(.dark) :where(.is-sky-solid-background) {
+:is(.dark) :where(.line-is-sky-solid-background) {
   background-color: var(--sky-4);
 }
 
-:where(.is-sky-hover-solid-background) {
+:where(.line-is-sky-hover-solid-background) {
   background-color: var(--sky-10);
 }
 
-:is(.dark) :where(.is-sky-hover-solid-background) {
+:is(.dark) :where(.line-is-sky-hover-solid-background) {
   background-color: var(--sky-3);
 }
 
-:where(.is-sky-low-contrast-background) {
+:where(.line-is-sky-low-contrast-background) {
   background-color: var(--sky-11);
 }
 
-:is(.dark) :where(.is-sky-low-contrast-background) {
+:is(.dark) :where(.line-is-sky-low-contrast-background) {
   background-color: var(--sky-2);
 }
 
-:where(.is-sky-high-contrast-background) {
+:where(.line-is-sky-high-contrast-background) {
   background-color: var(--sky-12);
 }
 
-:is(.dark) :where(.is-sky-high-contrast-background) {
+:is(.dark) :where(.line-is-sky-high-contrast-background) {
   background-color: var(--sky-1);
 }
 
-:where(.is-sky-border) {
+:where(.line-is-sky-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--sky-7);
   border-color: var(--sky-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-sky-border) {
+:is(.dark) :where(.line-is-sky-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--sky-6);
   border-color: var(--sky-6);

--- a/packages/theme/src/schemas/slate.css
+++ b/packages/theme/src/schemas/slate.css
@@ -1,4 +1,4 @@
-:where(.schema-slate) {
+:where(.line-schema-slate) {
   --background: var(--slate-1);            /* App background (-1) */
   --subtle-background: var(--slate-2);     /* Subtle background (-2) */
   --ui-background: var(--slate-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--slate-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-slate)  {
+:is(.dark) :where(.line-schema-slate)  {
   --background: var(--slate-12);           /* App background (-1) */
   --subtle-background: var(--slate-11);    /* Subtle background (-2) */
   --ui-background: var(--slate-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--slate-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-slate) {
+:where(.line-is-slate) {
   color: var(--slate-1);
   background-color: var(--slate-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-slate) {
+:is(.dark) :where(.line-is-slate) {
   color: var(--slate-1);
   background-color: var(--slate-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-slate-color) {
+:where(.line-is-slate-color) {
   color: var(--slate-12);
 }
 
-:is(:dark) :where(.is-slate-color) {
+:is(:dark) :where(.line-is-slate-color) {
   color: var(--slate-1);
 }
 
-:where(.is-slate-low-contrast) {
+:where(.line-is-slate-low-contrast) {
   color: var(--slate-11);
 }
 
-:is(.dark) :where(.is-slate-low-contrast) {
+:is(.dark) :where(.line-is-slate-low-contrast) {
   color: var(--slate-2);
 }
 
-:where(.is-slate-high-contrast) {
+:where(.line-is-slate-high-contrast) {
   color: var(--slate-12);
 }
 
-:is(.dark) :where(.is-slate-high-contrast) {
+:is(.dark) :where(.line-is-slate-high-contrast) {
   color: var(--slate-1);
 }
 
-:where(.is-slate-background) {
+:where(.line-is-slate-background) {
   background-color: var(--slate-1);
 }
 
-:is(.dark) :where(.is-slate-background) {
+:is(.dark) :where(.line-is-slate-background) {
   background-color: var(--slate-12);
 }
 
-:where(.is-slate-subtle-background) {
+:where(.line-is-slate-subtle-background) {
   background-color: var(--slate-2);
 }
 
-:is(.dark) :where(.is-slate-subtle-background) {
+:is(.dark) :where(.line-is-slate-subtle-background) {
   background-color: var(--slate-11);
 }
 
-:where(.is-slate-ui-background) {
+:where(.line-is-slate-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--slate-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-slate-ui-background) {
+:is(.dark) :where(.line-is-slate-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--slate-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-slate-ui-hover-background) {
+:where(.line-is-slate-ui-hover-background) {
   background-color: var(--slate-4);
 }
 
-:is(.dark) :where(.is-slate-ui-hover-background) {
+:is(.dark) :where(.line-is-slate-ui-hover-background) {
   background-color: var(--slate-9);
 }
 
-:where(.is-slate-ui-active-background) {
+:where(.line-is-slate-ui-active-background) {
   background-color: var(--slate-5);
 }
 
-:is(.dark) :where(.is-slate-ui-active-background) {
+:is(.dark) :where(.line-is-slate-ui-active-background) {
   background-color: var(--slate-8);
 }
 
-:where(.is-slate-subtle-element-background) {
+:where(.line-is-slate-subtle-element-background) {
   background-color: var(--slate-6);
 }
 
-:is(.dark) :where(.is-slate-subtle-element-background) {
+:is(.dark) :where(.line-is-slate-subtle-element-background) {
   background-color: var(--slate-7);
 }
 
-:where(.is-slate-ui-element-background) {
+:where(.line-is-slate-ui-element-background) {
   background-color: var(--slate-7);
 }
 
-:is(.dark) :where(.is-slate-ui-element-background) {
+:is(.dark) :where(.line-is-slate-ui-element-background) {
   background-color: var(--slate-6);
 }
 
-:where(.is-slate-ui-hover-background) {
+:where(.line-is-slate-ui-hover-background) {
   background-color: var(--slate-8);
 }
 
-:is(.dark) :where(.is-slate-ui-hover-background) {
+:is(.dark) :where(.line-is-slate-ui-hover-background) {
   background-color: var(--slate-5);
 }
 
-:where(.is-slate-solid-background) {
+:where(.line-is-slate-solid-background) {
   background-color: var(--slate-9);
 }
 
-:is(.dark) :where(.is-slate-solid-background) {
+:is(.dark) :where(.line-is-slate-solid-background) {
   background-color: var(--slate-4);
 }
 
-:where(.is-slate-hover-solid-background) {
+:where(.line-is-slate-hover-solid-background) {
   background-color: var(--slate-10);
 }
 
-:is(.dark) :where(.is-slate-hover-solid-background) {
+:is(.dark) :where(.line-is-slate-hover-solid-background) {
   background-color: var(--slate-3);
 }
 
-:where(.is-slate-low-contrast-background) {
+:where(.line-is-slate-low-contrast-background) {
   background-color: var(--slate-11);
 }
 
-:is(.dark) :where(.is-slate-low-contrast-background) {
+:is(.dark) :where(.line-is-slate-low-contrast-background) {
   background-color: var(--slate-2);
 }
 
-:where(.is-slate-high-contrast-background) {
+:where(.line-is-slate-high-contrast-background) {
   background-color: var(--slate-12);
 }
 
-:is(.dark) :where(.is-slate-high-contrast-background) {
+:is(.dark) :where(.line-is-slate-high-contrast-background) {
   background-color: var(--slate-1);
 }
 
-:where(.is-slate-border) {
+:where(.line-is-slate-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--slate-7);
   border-color: var(--slate-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-slate-border) {
+:is(.dark) :where(.line-is-slate-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--slate-6);
   border-color: var(--slate-6);

--- a/packages/theme/src/schemas/teal.css
+++ b/packages/theme/src/schemas/teal.css
@@ -1,4 +1,4 @@
-:where(.schema-teal) {
+:where(.line-schema-teal) {
   --background: var(--teal-1);            /* App background (-1) */
   --subtle-background: var(--teal-2);     /* Subtle background (-2) */
   --ui-background: var(--teal-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--teal-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-teal)  {
+:is(.dark) :where(.line-schema-teal)  {
   --background: var(--teal-12);           /* App background (-1) */
   --subtle-background: var(--teal-11);    /* Subtle background (-2) */
   --ui-background: var(--teal-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--teal-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-teal) {
+:where(.line-is-teal) {
   color: var(--teal-1);
   background-color: var(--teal-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-teal) {
+:is(.dark) :where(.line-is-teal) {
   color: var(--teal-1);
   background-color: var(--teal-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-teal-color) {
+:where(.line-is-teal-color) {
   color: var(--teal-12);
 }
 
-:is(:dark) :where(.is-teal-color) {
+:is(:dark) :where(.line-is-teal-color) {
   color: var(--teal-1);
 }
 
-:where(.is-teal-low-contrast) {
+:where(.line-is-teal-low-contrast) {
   color: var(--teal-11);
 }
 
-:is(.dark) :where(.is-teal-low-contrast) {
+:is(.dark) :where(.line-is-teal-low-contrast) {
   color: var(--teal-2);
 }
 
-:where(.is-teal-high-contrast) {
+:where(.line-is-teal-high-contrast) {
   color: var(--teal-12);
 }
 
-:is(.dark) :where(.is-teal-high-contrast) {
+:is(.dark) :where(.line-is-teal-high-contrast) {
   color: var(--teal-1);
 }
 
-:where(.is-teal-background) {
+:where(.line-is-teal-background) {
   background-color: var(--teal-1);
 }
 
-:is(.dark) :where(.is-teal-background) {
+:is(.dark) :where(.line-is-teal-background) {
   background-color: var(--teal-12);
 }
 
-:where(.is-teal-subtle-background) {
+:where(.line-is-teal-subtle-background) {
   background-color: var(--teal-2);
 }
 
-:is(.dark) :where(.is-teal-subtle-background) {
+:is(.dark) :where(.line-is-teal-subtle-background) {
   background-color: var(--teal-11);
 }
 
-:where(.is-teal-ui-background) {
+:where(.line-is-teal-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--teal-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-teal-ui-background) {
+:is(.dark) :where(.line-is-teal-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--teal-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-teal-ui-hover-background) {
+:where(.line-is-teal-ui-hover-background) {
   background-color: var(--teal-4);
 }
 
-:is(.dark) :where(.is-teal-ui-hover-background) {
+:is(.dark) :where(.line-is-teal-ui-hover-background) {
   background-color: var(--teal-9);
 }
 
-:where(.is-teal-ui-active-background) {
+:where(.line-is-teal-ui-active-background) {
   background-color: var(--teal-5);
 }
 
-:is(.dark) :where(.is-teal-ui-active-background) {
+:is(.dark) :where(.line-is-teal-ui-active-background) {
   background-color: var(--teal-8);
 }
 
-:where(.is-teal-subtle-element-background) {
+:where(.line-is-teal-subtle-element-background) {
   background-color: var(--teal-6);
 }
 
-:is(.dark) :where(.is-teal-subtle-element-background) {
+:is(.dark) :where(.line-is-teal-subtle-element-background) {
   background-color: var(--teal-7);
 }
 
-:where(.is-teal-ui-element-background) {
+:where(.line-is-teal-ui-element-background) {
   background-color: var(--teal-7);
 }
 
-:is(.dark) :where(.is-teal-ui-element-background) {
+:is(.dark) :where(.line-is-teal-ui-element-background) {
   background-color: var(--teal-6);
 }
 
-:where(.is-teal-ui-hover-background) {
+:where(.line-is-teal-ui-hover-background) {
   background-color: var(--teal-8);
 }
 
-:is(.dark) :where(.is-teal-ui-hover-background) {
+:is(.dark) :where(.line-is-teal-ui-hover-background) {
   background-color: var(--teal-5);
 }
 
-:where(.is-teal-solid-background) {
+:where(.line-is-teal-solid-background) {
   background-color: var(--teal-9);
 }
 
-:is(.dark) :where(.is-teal-solid-background) {
+:is(.dark) :where(.line-is-teal-solid-background) {
   background-color: var(--teal-4);
 }
 
-:where(.is-teal-hover-solid-background) {
+:where(.line-is-teal-hover-solid-background) {
   background-color: var(--teal-10);
 }
 
-:is(.dark) :where(.is-teal-hover-solid-background) {
+:is(.dark) :where(.line-is-teal-hover-solid-background) {
   background-color: var(--teal-3);
 }
 
-:where(.is-teal-low-contrast-background) {
+:where(.line-is-teal-low-contrast-background) {
   background-color: var(--teal-11);
 }
 
-:is(.dark) :where(.is-teal-low-contrast-background) {
+:is(.dark) :where(.line-is-teal-low-contrast-background) {
   background-color: var(--teal-2);
 }
 
-:where(.is-teal-high-contrast-background) {
+:where(.line-is-teal-high-contrast-background) {
   background-color: var(--teal-12);
 }
 
-:is(.dark) :where(.is-teal-high-contrast-background) {
+:is(.dark) :where(.line-is-teal-high-contrast-background) {
   background-color: var(--teal-1);
 }
 
-:where(.is-teal-border) {
+:where(.line-is-teal-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--teal-7);
   border-color: var(--teal-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-teal-border) {
+:is(.dark) :where(.line-is-teal-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--teal-6);
   border-color: var(--teal-6);

--- a/packages/theme/src/schemas/tomato.css
+++ b/packages/theme/src/schemas/tomato.css
@@ -1,4 +1,4 @@
-:where(.schema-tomato) {
+:where(.line-schema-tomato) {
   --background: var(--tomato-1);            /* App background (-1) */
   --subtle-background: var(--tomato-2);     /* Subtle background (-2) */
   --ui-background: var(--tomato-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--tomato-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-tomato)  {
+:is(.dark) :where(.line-schema-tomato)  {
   --background: var(--tomato-12);           /* App background (-1) */
   --subtle-background: var(--tomato-11);    /* Subtle background (-2) */
   --ui-background: var(--tomato-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--tomato-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-tomato) {
+:where(.line-is-tomato) {
   color: var(--tomato-1);
   background-color: var(--tomato-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-tomato) {
+:is(.dark) :where(.line-is-tomato) {
   color: var(--tomato-1);
   background-color: var(--tomato-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-tomato-color) {
+:where(.line-is-tomato-color) {
   color: var(--tomato-12);
 }
 
-:is(:dark) :where(.is-tomato-color) {
+:is(:dark) :where(.line-is-tomato-color) {
   color: var(--tomato-1);
 }
 
-:where(.is-tomato-low-contrast) {
+:where(.line-is-tomato-low-contrast) {
   color: var(--tomato-11);
 }
 
-:is(.dark) :where(.is-tomato-low-contrast) {
+:is(.dark) :where(.line-is-tomato-low-contrast) {
   color: var(--tomato-2);
 }
 
-:where(.is-tomato-high-contrast) {
+:where(.line-is-tomato-high-contrast) {
   color: var(--tomato-12);
 }
 
-:is(.dark) :where(.is-tomato-high-contrast) {
+:is(.dark) :where(.line-is-tomato-high-contrast) {
   color: var(--tomato-1);
 }
 
-:where(.is-tomato-background) {
+:where(.line-is-tomato-background) {
   background-color: var(--tomato-1);
 }
 
-:is(.dark) :where(.is-tomato-background) {
+:is(.dark) :where(.line-is-tomato-background) {
   background-color: var(--tomato-12);
 }
 
-:where(.is-tomato-subtle-background) {
+:where(.line-is-tomato-subtle-background) {
   background-color: var(--tomato-2);
 }
 
-:is(.dark) :where(.is-tomato-subtle-background) {
+:is(.dark) :where(.line-is-tomato-subtle-background) {
   background-color: var(--tomato-11);
 }
 
-:where(.is-tomato-ui-background) {
+:where(.line-is-tomato-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--tomato-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-tomato-ui-background) {
+:is(.dark) :where(.line-is-tomato-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--tomato-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-tomato-ui-hover-background) {
+:where(.line-is-tomato-ui-hover-background) {
   background-color: var(--tomato-4);
 }
 
-:is(.dark) :where(.is-tomato-ui-hover-background) {
+:is(.dark) :where(.line-is-tomato-ui-hover-background) {
   background-color: var(--tomato-9);
 }
 
-:where(.is-tomato-ui-active-background) {
+:where(.line-is-tomato-ui-active-background) {
   background-color: var(--tomato-5);
 }
 
-:is(.dark) :where(.is-tomato-ui-active-background) {
+:is(.dark) :where(.line-is-tomato-ui-active-background) {
   background-color: var(--tomato-8);
 }
 
-:where(.is-tomato-subtle-element-background) {
+:where(.line-is-tomato-subtle-element-background) {
   background-color: var(--tomato-6);
 }
 
-:is(.dark) :where(.is-tomato-subtle-element-background) {
+:is(.dark) :where(.line-is-tomato-subtle-element-background) {
   background-color: var(--tomato-7);
 }
 
-:where(.is-tomato-ui-element-background) {
+:where(.line-is-tomato-ui-element-background) {
   background-color: var(--tomato-7);
 }
 
-:is(.dark) :where(.is-tomato-ui-element-background) {
+:is(.dark) :where(.line-is-tomato-ui-element-background) {
   background-color: var(--tomato-6);
 }
 
-:where(.is-tomato-ui-hover-background) {
+:where(.line-is-tomato-ui-hover-background) {
   background-color: var(--tomato-8);
 }
 
-:is(.dark) :where(.is-tomato-ui-hover-background) {
+:is(.dark) :where(.line-is-tomato-ui-hover-background) {
   background-color: var(--tomato-5);
 }
 
-:where(.is-tomato-solid-background) {
+:where(.line-is-tomato-solid-background) {
   background-color: var(--tomato-9);
 }
 
-:is(.dark) :where(.is-tomato-solid-background) {
+:is(.dark) :where(.line-is-tomato-solid-background) {
   background-color: var(--tomato-4);
 }
 
-:where(.is-tomato-hover-solid-background) {
+:where(.line-is-tomato-hover-solid-background) {
   background-color: var(--tomato-10);
 }
 
-:is(.dark) :where(.is-tomato-hover-solid-background) {
+:is(.dark) :where(.line-is-tomato-hover-solid-background) {
   background-color: var(--tomato-3);
 }
 
-:where(.is-tomato-low-contrast-background) {
+:where(.line-is-tomato-low-contrast-background) {
   background-color: var(--tomato-11);
 }
 
-:is(.dark) :where(.is-tomato-low-contrast-background) {
+:is(.dark) :where(.line-is-tomato-low-contrast-background) {
   background-color: var(--tomato-2);
 }
 
-:where(.is-tomato-high-contrast-background) {
+:where(.line-is-tomato-high-contrast-background) {
   background-color: var(--tomato-12);
 }
 
-:is(.dark) :where(.is-tomato-high-contrast-background) {
+:is(.dark) :where(.line-is-tomato-high-contrast-background) {
   background-color: var(--tomato-1);
 }
 
-:where(.is-tomato-border) {
+:where(.line-is-tomato-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--tomato-7);
   border-color: var(--tomato-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-tomato-border) {
+:is(.dark) :where(.line-is-tomato-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--tomato-6);
   border-color: var(--tomato-6);

--- a/packages/theme/src/schemas/violet.css
+++ b/packages/theme/src/schemas/violet.css
@@ -1,4 +1,4 @@
-:where(.schema-violet) {
+:where(.line-schema-violet) {
   --background: var(--violet-1);            /* App background (-1) */
   --subtle-background: var(--violet-2);     /* Subtle background (-2) */
   --ui-background: var(--violet-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--violet-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-violet)  {
+:is(.dark) :where(.line-schema-violet)  {
   --background: var(--violet-12);           /* App background (-1) */
   --subtle-background: var(--violet-11);    /* Subtle background (-2) */
   --ui-background: var(--violet-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--violet-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-violet) {
+:where(.line-is-violet) {
   color: var(--violet-1);
   background-color: var(--violet-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-violet) {
+:is(.dark) :where(.line-is-violet) {
   color: var(--violet-1);
   background-color: var(--violet-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-violet-color) {
+:where(.line-is-violet-color) {
   color: var(--violet-12);
 }
 
-:is(:dark) :where(.is-violet-color) {
+:is(:dark) :where(.line-is-violet-color) {
   color: var(--violet-1);
 }
 
-:where(.is-violet-low-contrast) {
+:where(.line-is-violet-low-contrast) {
   color: var(--violet-11);
 }
 
-:is(.dark) :where(.is-violet-low-contrast) {
+:is(.dark) :where(.line-is-violet-low-contrast) {
   color: var(--violet-2);
 }
 
-:where(.is-violet-high-contrast) {
+:where(.line-is-violet-high-contrast) {
   color: var(--violet-12);
 }
 
-:is(.dark) :where(.is-violet-high-contrast) {
+:is(.dark) :where(.line-is-violet-high-contrast) {
   color: var(--violet-1);
 }
 
-:where(.is-violet-background) {
+:where(.line-is-violet-background) {
   background-color: var(--violet-1);
 }
 
-:is(.dark) :where(.is-violet-background) {
+:is(.dark) :where(.line-is-violet-background) {
   background-color: var(--violet-12);
 }
 
-:where(.is-violet-subtle-background) {
+:where(.line-is-violet-subtle-background) {
   background-color: var(--violet-2);
 }
 
-:is(.dark) :where(.is-violet-subtle-background) {
+:is(.dark) :where(.line-is-violet-subtle-background) {
   background-color: var(--violet-11);
 }
 
-:where(.is-violet-ui-background) {
+:where(.line-is-violet-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--violet-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-violet-ui-background) {
+:is(.dark) :where(.line-is-violet-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--violet-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-violet-ui-hover-background) {
+:where(.line-is-violet-ui-hover-background) {
   background-color: var(--violet-4);
 }
 
-:is(.dark) :where(.is-violet-ui-hover-background) {
+:is(.dark) :where(.line-is-violet-ui-hover-background) {
   background-color: var(--violet-9);
 }
 
-:where(.is-violet-ui-active-background) {
+:where(.line-is-violet-ui-active-background) {
   background-color: var(--violet-5);
 }
 
-:is(.dark) :where(.is-violet-ui-active-background) {
+:is(.dark) :where(.line-is-violet-ui-active-background) {
   background-color: var(--violet-8);
 }
 
-:where(.is-violet-subtle-element-background) {
+:where(.line-is-violet-subtle-element-background) {
   background-color: var(--violet-6);
 }
 
-:is(.dark) :where(.is-violet-subtle-element-background) {
+:is(.dark) :where(.line-is-violet-subtle-element-background) {
   background-color: var(--violet-7);
 }
 
-:where(.is-violet-ui-element-background) {
+:where(.line-is-violet-ui-element-background) {
   background-color: var(--violet-7);
 }
 
-:is(.dark) :where(.is-violet-ui-element-background) {
+:is(.dark) :where(.line-is-violet-ui-element-background) {
   background-color: var(--violet-6);
 }
 
-:where(.is-violet-ui-hover-background) {
+:where(.line-is-violet-ui-hover-background) {
   background-color: var(--violet-8);
 }
 
-:is(.dark) :where(.is-violet-ui-hover-background) {
+:is(.dark) :where(.line-is-violet-ui-hover-background) {
   background-color: var(--violet-5);
 }
 
-:where(.is-violet-solid-background) {
+:where(.line-is-violet-solid-background) {
   background-color: var(--violet-9);
 }
 
-:is(.dark) :where(.is-violet-solid-background) {
+:is(.dark) :where(.line-is-violet-solid-background) {
   background-color: var(--violet-4);
 }
 
-:where(.is-violet-hover-solid-background) {
+:where(.line-is-violet-hover-solid-background) {
   background-color: var(--violet-10);
 }
 
-:is(.dark) :where(.is-violet-hover-solid-background) {
+:is(.dark) :where(.line-is-violet-hover-solid-background) {
   background-color: var(--violet-3);
 }
 
-:where(.is-violet-low-contrast-background) {
+:where(.line-is-violet-low-contrast-background) {
   background-color: var(--violet-11);
 }
 
-:is(.dark) :where(.is-violet-low-contrast-background) {
+:is(.dark) :where(.line-is-violet-low-contrast-background) {
   background-color: var(--violet-2);
 }
 
-:where(.is-violet-high-contrast-background) {
+:where(.line-is-violet-high-contrast-background) {
   background-color: var(--violet-12);
 }
 
-:is(.dark) :where(.is-violet-high-contrast-background) {
+:is(.dark) :where(.line-is-violet-high-contrast-background) {
   background-color: var(--violet-1);
 }
 
-:where(.is-violet-border) {
+:where(.line-is-violet-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--violet-7);
   border-color: var(--violet-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-violet-border) {
+:is(.dark) :where(.line-is-violet-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--violet-6);
   border-color: var(--violet-6);

--- a/packages/theme/src/schemas/yellow.css
+++ b/packages/theme/src/schemas/yellow.css
@@ -1,4 +1,4 @@
-:where(.schema-yellow) {
+:where(.line-schema-yellow) {
   --background: var(--yellow-1);            /* App background (-1) */
   --subtle-background: var(--yellow-2);     /* Subtle background (-2) */
   --ui-background: var(--yellow-3);         /* UI element background (-3) */
@@ -17,7 +17,7 @@
   --dark: var(--yellow-12);                 /* Dark text */
 }
 
-:is(.dark) :where(.schema-yellow)  {
+:is(.dark) :where(.line-schema-yellow)  {
   --background: var(--yellow-12);           /* App background (-1) */
   --subtle-background: var(--yellow-11);    /* Subtle background (-2) */
   --ui-background: var(--yellow-10);        /* UI element background (-3) */
@@ -32,7 +32,7 @@
   --high-contrast: var(--yellow-1);         /* High-contrast text (-12) */
 }
 
-:where(.is-yellow) {
+:where(.line-is-yellow) {
   color: var(--yellow-12);
   background-color: var(--yellow-9);
   transition: all ease-in-out 150ms;
@@ -42,7 +42,7 @@
   }
 }
 
-:is(.dark) :where(.is-yellow) {
+:is(.dark) :where(.line-is-yellow) {
   color: var(--yellow-12);
   background-color: var(--yellow-4);
   transition: all ease-in-out 150ms;
@@ -52,47 +52,47 @@
   }
 }
 
-:where(.is-yellow-color) {
+:where(.line-is-yellow-color) {
   color: var(--yellow-12);
 }
 
-:is(:dark) :where(.is-yellow-color) {
+:is(:dark) :where(.line-is-yellow-color) {
   color: var(--yellow-1);
 }
 
-:where(.is-yellow-low-contrast) {
+:where(.line-is-yellow-low-contrast) {
   color: var(--yellow-11);
 }
 
-:is(.dark) :where(.is-yellow-low-contrast) {
+:is(.dark) :where(.line-is-yellow-low-contrast) {
   color: var(--yellow-2);
 }
 
-:where(.is-yellow-high-contrast) {
+:where(.line-is-yellow-high-contrast) {
   color: var(--yellow-12);
 }
 
-:is(.dark) :where(.is-yellow-high-contrast) {
+:is(.dark) :where(.line-is-yellow-high-contrast) {
   color: var(--yellow-1);
 }
 
-:where(.is-yellow-background) {
+:where(.line-is-yellow-background) {
   background-color: var(--yellow-1);
 }
 
-:is(.dark) :where(.is-yellow-background) {
+:is(.dark) :where(.line-is-yellow-background) {
   background-color: var(--yellow-12);
 }
 
-:where(.is-yellow-subtle-background) {
+:where(.line-is-yellow-subtle-background) {
   background-color: var(--yellow-2);
 }
 
-:is(.dark) :where(.is-yellow-subtle-background) {
+:is(.dark) :where(.line-is-yellow-subtle-background) {
   background-color: var(--yellow-11);
 }
 
-:where(.is-yellow-ui-background) {
+:where(.line-is-yellow-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--yellow-3);
 
@@ -101,7 +101,7 @@
   }
 }
 
-:is(.dark) :where(.is-yellow-ui-background) {
+:is(.dark) :where(.line-is-yellow-ui-background) {
   transition: colors ease-in-out 150ms;
   background-color: var(--yellow-10);
 
@@ -110,79 +110,79 @@
   }
 }
 
-:where(.is-yellow-ui-hover-background) {
+:where(.line-is-yellow-ui-hover-background) {
   background-color: var(--yellow-4);
 }
 
-:is(.dark) :where(.is-yellow-ui-hover-background) {
+:is(.dark) :where(.line-is-yellow-ui-hover-background) {
   background-color: var(--yellow-9);
 }
 
-:where(.is-yellow-ui-active-background) {
+:where(.line-is-yellow-ui-active-background) {
   background-color: var(--yellow-5);
 }
 
-:is(.dark) :where(.is-yellow-ui-active-background) {
+:is(.dark) :where(.line-is-yellow-ui-active-background) {
   background-color: var(--yellow-8);
 }
 
-:where(.is-yellow-subtle-element-background) {
+:where(.line-is-yellow-subtle-element-background) {
   background-color: var(--yellow-6);
 }
 
-:is(.dark) :where(.is-yellow-subtle-element-background) {
+:is(.dark) :where(.line-is-yellow-subtle-element-background) {
   background-color: var(--yellow-7);
 }
 
-:where(.is-yellow-ui-element-background) {
+:where(.line-is-yellow-ui-element-background) {
   background-color: var(--yellow-7);
 }
 
-:is(.dark) :where(.is-yellow-ui-element-background) {
+:is(.dark) :where(.line-is-yellow-ui-element-background) {
   background-color: var(--yellow-6);
 }
 
-:where(.is-yellow-ui-hover-background) {
+:where(.line-is-yellow-ui-hover-background) {
   background-color: var(--yellow-8);
 }
 
-:is(.dark) :where(.is-yellow-ui-hover-background) {
+:is(.dark) :where(.line-is-yellow-ui-hover-background) {
   background-color: var(--yellow-5);
 }
 
-:where(.is-yellow-solid-background) {
+:where(.line-is-yellow-solid-background) {
   background-color: var(--yellow-9);
 }
 
-:is(.dark) :where(.is-yellow-solid-background) {
+:is(.dark) :where(.line-is-yellow-solid-background) {
   background-color: var(--yellow-4);
 }
 
-:where(.is-yellow-hover-solid-background) {
+:where(.line-is-yellow-hover-solid-background) {
   background-color: var(--yellow-10);
 }
 
-:is(.dark) :where(.is-yellow-hover-solid-background) {
+:is(.dark) :where(.line-is-yellow-hover-solid-background) {
   background-color: var(--yellow-3);
 }
 
-:where(.is-yellow-low-contrast-background) {
+:where(.line-is-yellow-low-contrast-background) {
   background-color: var(--yellow-11);
 }
 
-:is(.dark) :where(.is-yellow-low-contrast-background) {
+:is(.dark) :where(.line-is-yellow-low-contrast-background) {
   background-color: var(--yellow-2);
 }
 
-:where(.is-yellow-high-contrast-background) {
+:where(.line-is-yellow-high-contrast-background) {
   background-color: var(--yellow-12);
 }
 
-:is(.dark) :where(.is-yellow-high-contrast-background) {
+:is(.dark) :where(.line-is-yellow-high-contrast-background) {
   background-color: var(--yellow-1);
 }
 
-:where(.is-yellow-border) {
+:where(.line-is-yellow-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--yellow-7);
   border-color: var(--yellow-7);
@@ -193,7 +193,7 @@
   }
 }
 
-:is(.dark) :where(.is-yellow-border) {
+:is(.dark) :where(.line-is-yellow-border) {
   transition: colors ease-in-out 150ms;
   outline-color: var(--yellow-6);
   border-color: var(--yellow-6);

--- a/packages/theme/src/utils/general.css
+++ b/packages/theme/src/utils/general.css
@@ -10,73 +10,73 @@
   background-color: var(--ui-active-background);
 }
 
-.is-background {
+.line-is-background {
   background-color: var(--background);
 }
 
-.is-subtle-background {
+.line-is-subtle-background {
   background-color: var(--subtle-background);
 }
 
-.is-ui-background {
+.line-is-ui-background {
   transition: colors ease-in-out delay-150;
   background-color: var(--ui-background);
 }
 
-.is-hover-background {
+.line-is-hover-background {
   background-color: var(--ui-hover-background);
 }
 
-.is-active-background {
+.line-is-active-background {
   background-color: var(--ui-active-background);
 }
 
-.is-subtle-border {
+.line-is-subtle-border {
   border-color: var(--subtle-border);
   outline-color: var(--subtle-border);
 }
 
-.is-ui-border {
+.line-is-ui-border {
   transition: colors ease-in-out delay-150;
   border-color: var(--ui-border);
   outline-color: var(--ui-border);
 }
 
-.is-ui-hover {
+.line-is-ui-hover {
   border-color: var(--ui-border-hover);
   outline-color: var(--ui-border-hover);
 }
 
-.is-solid-background {
+.line-is-solid-background {
   transition:colors ease-in-out delay-150;
   background-color: var(--solid-background);
 }
 
-.is-hover-solid {
+.line-is-hover-solid {
   background-color: var(--solid-hover);
 }
 
-.is-low-contrast {
+.line-is-low-contrast {
   color: var(--low-contrast);
 }
 
-.is-high-contrast {
+.line-is-high-contrast {
   color: var(--high-contrast);
 }
 
-.is-light {
+.line-is-light {
   color: var(--light);
 }
 
-.is-dark {
+.line-is-dark {
   color: var(--dark);
 }
 
-.is-white {
+.line-is-white {
   color: var(--white);
 }
 
-.is-black {
+.line-is-black {
   color: var(--black);
 }
 
@@ -93,7 +93,7 @@
   }
 }
 
-.is-tiny {
+.line-is-tiny {
   height: 1rem;
   font-size: .6rem;
   padding: 0.1rem;


### PR DESCRIPTION
Rename .schema-* to .line-schema-* and .is-* to .line-is-* across all 28 schema CSS files, utils/general.css, and the demo index.html per PRD 9.14 branding requirements. The :is() pseudo-class selectors (504 occurrences) are preserved unchanged.