### PR TITLE
chore: rename @websublime/vitamina-core to @websublime/line-core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
     },
     "packages/core": {
-      "name": "@websublime/vitamina-core",
+      "name": "@websublime/line-core",
       "version": "0.2.0",
       "dependencies": {
         "@websublime/vitamina-theme": "workspace:*",
@@ -354,7 +354,7 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
-    "@websublime/vitamina-core": ["@websublime/vitamina-core@workspace:packages/core"],
+    "@websublime/line-core": ["@websublime/line-core@workspace:packages/core"],
 
     "@websublime/vitamina-theme": ["@websublime/vitamina-theme@workspace:packages/theme"],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@websublime/vitamina-core",
+  "name": "@websublime/line-core",
   "version": "0.2.0",
-  "description": "Core Lit functions and base classes for Vitamina",
+  "description": "Core Lit functions and base classes for line://ui",
   "type": "module",
   "scripts": {
     "dev": "vite --debug --force",


### PR DESCRIPTION
Rename core package name and description in package.json as part of the line://ui branding refactor (P0-E1-T5). Regenerated bun.lock accordingly.