### PR TITLE
chore(theme): prefix 16 semantic CSS variables with --line-

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,9 @@
       },
       "correctness": {
         "noUnusedImports": "error",
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noUnknownMediaFeatureName": "off",
+        "noUnknownPseudoClass": "off"
       },
       "style": {
         "noParameterAssign": "error",

--- a/packages/theme/src/schemas/amber.css
+++ b/packages/theme/src/schemas/amber.css
@@ -1,35 +1,35 @@
 :where(.schema-amber) {
-  --background: var(--line-amber-1);            /* App background (-1) */
-  --subtle-background: var(--line-amber-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-amber-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-amber-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-amber-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-amber-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-amber-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-amber-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-amber-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-amber-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-amber-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-amber-12);        /* High-contrast text (-12) */
-  --light: var(--line-amber-1);                 /* Light text */
-  --dark: var(--line-amber-12);                 /* Dark text */
+  --line-background: var(--line-amber-1); /* App background (-1) */
+  --line-subtle-background: var(--line-amber-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-amber-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-amber-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-amber-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-amber-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-amber-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-amber-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-amber-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-amber-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-amber-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-amber-12); /* High-contrast text (-12) */
+  --line-light: var(--line-amber-1); /* Light text */
+  --line-dark: var(--line-amber-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-amber)   {
-  --background: var(--line-amber-12);           /* App background (-1) */
-  --subtle-background: var(--line-amber-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-amber-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-amber-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-amber-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-amber-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-amber-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-amber-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-amber-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-amber-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-amber-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-amber-1);         /* High-contrast text (-12) */
-  --light: var(--line-amber-12);                /* Light text */
-  --dark: var(--line-amber-1);                  /* Dark text */
+:is(.dark) :where(.schema-amber) {
+  --line-background: var(--line-amber-12); /* App background (-1) */
+  --line-subtle-background: var(--line-amber-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-amber-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-amber-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-amber-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-amber-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-amber-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-amber-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-amber-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-amber-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-amber-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-amber-1); /* High-contrast text (-12) */
+  --line-light: var(--line-amber-12); /* Light text */
+  --line-dark: var(--line-amber-1); /* Dark text */
 }
 
 :where(.is-amber) {
@@ -56,7 +56,7 @@
   color: var(--line-amber-12);
 }
 
-:is(:dark) :where(.is-amber-color) {
+:is(.dark) :where(.is-amber-color) {
   color: var(--line-amber-1);
 }
 

--- a/packages/theme/src/schemas/blue.css
+++ b/packages/theme/src/schemas/blue.css
@@ -1,33 +1,33 @@
 :where(.schema-blue) {
-  --background: var(--line-blue-1);            /* App background (-1) */
-  --subtle-background: var(--line-blue-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-blue-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-blue-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-blue-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-blue-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-blue-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-blue-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-blue-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-blue-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-blue-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-blue-12);        /* High-contrast text (-12) */
-  --light: var(--line-blue-1);                 /* Light text */
-  --dark: var(--line-blue-12);                 /* Dark text */
+  --line-background: var(--line-blue-1); /* App background (-1) */
+  --line-subtle-background: var(--line-blue-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-blue-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-blue-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-blue-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-blue-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-blue-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-blue-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-blue-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-blue-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-blue-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-blue-12); /* High-contrast text (-12) */
+  --line-light: var(--line-blue-1); /* Light text */
+  --line-dark: var(--line-blue-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-blue)  {
-  --background: var(--line-blue-12);           /* App background (-1) */
-  --subtle-background: var(--line-blue-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-blue-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-blue-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-blue-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-blue-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-blue-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-blue-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-blue-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-blue-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-blue-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-blue-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-blue) {
+  --line-background: var(--line-blue-12); /* App background (-1) */
+  --line-subtle-background: var(--line-blue-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-blue-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-blue-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-blue-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-blue-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-blue-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-blue-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-blue-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-blue-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-blue-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-blue-1); /* High-contrast text (-12) */
 }
 
 :where(.is-blue) {
@@ -54,7 +54,7 @@
   color: var(--line-blue-12);
 }
 
-:is(:dark) :where(.is-blue-color) {
+:is(.dark) :where(.is-blue-color) {
   color: var(--line-blue-1);
 }
 

--- a/packages/theme/src/schemas/bronze.css
+++ b/packages/theme/src/schemas/bronze.css
@@ -1,33 +1,33 @@
 :where(.schema-bronze) {
-  --background: var(--line-bronze-1);            /* App background (-1) */
-  --subtle-background: var(--line-bronze-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-bronze-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-bronze-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-bronze-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-bronze-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-bronze-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-bronze-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-bronze-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-bronze-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-bronze-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-bronze-12);        /* High-contrast text (-12) */
-  --light: var(--line-bronze-1);                 /* Light text */
-  --dark: var(--line-bronze-12);                 /* Dark text */
+  --line-background: var(--line-bronze-1); /* App background (-1) */
+  --line-subtle-background: var(--line-bronze-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-bronze-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-bronze-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-bronze-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-bronze-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-bronze-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-bronze-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-bronze-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-bronze-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-bronze-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-bronze-12); /* High-contrast text (-12) */
+  --line-light: var(--line-bronze-1); /* Light text */
+  --line-dark: var(--line-bronze-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-bronze)  {
-  --background: var(--line-bronze-12);           /* App background (-1) */
-  --subtle-background: var(--line-bronze-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-bronze-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-bronze-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-bronze-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-bronze-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-bronze-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-bronze-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-bronze-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-bronze-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-bronze-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-bronze-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-bronze) {
+  --line-background: var(--line-bronze-12); /* App background (-1) */
+  --line-subtle-background: var(--line-bronze-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-bronze-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-bronze-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-bronze-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-bronze-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-bronze-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-bronze-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-bronze-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-bronze-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-bronze-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-bronze-1); /* High-contrast text (-12) */
 }
 
 :where(.is-bronze) {
@@ -54,7 +54,7 @@
   color: var(--line-bronze-12);
 }
 
-:is(:dark) :where(.is-bronze-color) {
+:is(.dark) :where(.is-bronze-color) {
   color: var(--line-bronze-1);
 }
 

--- a/packages/theme/src/schemas/brown.css
+++ b/packages/theme/src/schemas/brown.css
@@ -1,33 +1,33 @@
 :where(.schema-brown) {
-  --background: var(--line-brown-1);            /* App background (-1) */
-  --subtle-background: var(--line-brown-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-brown-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-brown-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-brown-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-brown-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-brown-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-brown-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-brown-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-brown-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-brown-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-brown-12);        /* High-contrast text (-12) */
-  --light: var(--line-brown-1);                 /* Light text */
-  --dark: var(--line-brown-12);                 /* Dark text */
+  --line-background: var(--line-brown-1); /* App background (-1) */
+  --line-subtle-background: var(--line-brown-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-brown-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-brown-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-brown-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-brown-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-brown-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-brown-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-brown-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-brown-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-brown-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-brown-12); /* High-contrast text (-12) */
+  --line-light: var(--line-brown-1); /* Light text */
+  --line-dark: var(--line-brown-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-brown)  {
-  --background: var(--line-brown-12);           /* App background (-1) */
-  --subtle-background: var(--line-brown-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-brown-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-brown-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-brown-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-brown-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-brown-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-brown-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-brown-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-brown-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-brown-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-brown-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-brown) {
+  --line-background: var(--line-brown-12); /* App background (-1) */
+  --line-subtle-background: var(--line-brown-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-brown-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-brown-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-brown-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-brown-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-brown-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-brown-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-brown-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-brown-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-brown-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-brown-1); /* High-contrast text (-12) */
 }
 
 :where(.is-brown) {
@@ -54,7 +54,7 @@
   color: var(--line-brown-12);
 }
 
-:is(:dark) :where(.is-brown-color) {
+:is(.dark) :where(.is-brown-color) {
   color: var(--line-brown-1);
 }
 

--- a/packages/theme/src/schemas/crimson.css
+++ b/packages/theme/src/schemas/crimson.css
@@ -1,33 +1,33 @@
 :where(.schema-crimson) {
-  --background: var(--line-crimson-1);            /* App background (-1) */
-  --subtle-background: var(--line-crimson-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-crimson-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-crimson-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-crimson-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-crimson-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-crimson-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-crimson-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-crimson-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-crimson-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-crimson-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-crimson-12);        /* High-contrast text (-12) */
-  --light: var(--line-crimson-1);                 /* Light text */
-  --dark: var(--line-crimson-12);                 /* Dark text */
+  --line-background: var(--line-crimson-1); /* App background (-1) */
+  --line-subtle-background: var(--line-crimson-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-crimson-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-crimson-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-crimson-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-crimson-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-crimson-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-crimson-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-crimson-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-crimson-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-crimson-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-crimson-12); /* High-contrast text (-12) */
+  --line-light: var(--line-crimson-1); /* Light text */
+  --line-dark: var(--line-crimson-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-crimson)  {
-  --background: var(--line-crimson-12);           /* App background (-1) */
-  --subtle-background: var(--line-crimson-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-crimson-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-crimson-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-crimson-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-crimson-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-crimson-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-crimson-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-crimson-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-crimson-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-crimson-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-crimson-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-crimson) {
+  --line-background: var(--line-crimson-12); /* App background (-1) */
+  --line-subtle-background: var(--line-crimson-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-crimson-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-crimson-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-crimson-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-crimson-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-crimson-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-crimson-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-crimson-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-crimson-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-crimson-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-crimson-1); /* High-contrast text (-12) */
 }
 
 :where(.is-crimson) {
@@ -54,7 +54,7 @@
   color: var(--line-crimson-12);
 }
 
-:is(:dark) :where(.is-crimson-color) {
+:is(.dark) :where(.is-crimson-color) {
   color: var(--line-crimson-1);
 }
 

--- a/packages/theme/src/schemas/cyan.css
+++ b/packages/theme/src/schemas/cyan.css
@@ -1,33 +1,33 @@
 :where(.schema-cyan) {
-  --background: var(--line-cyan-1);            /* App background (-1) */
-  --subtle-background: var(--line-cyan-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-cyan-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-cyan-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-cyan-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-cyan-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-cyan-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-cyan-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-cyan-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-cyan-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-cyan-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-cyan-12);        /* High-contrast text (-12) */
-  --light: var(--line-cyan-1);                 /* Light text */
-  --dark: var(--line-cyan-12);                 /* Dark text */
+  --line-background: var(--line-cyan-1); /* App background (-1) */
+  --line-subtle-background: var(--line-cyan-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-cyan-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-cyan-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-cyan-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-cyan-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-cyan-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-cyan-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-cyan-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-cyan-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-cyan-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-cyan-12); /* High-contrast text (-12) */
+  --line-light: var(--line-cyan-1); /* Light text */
+  --line-dark: var(--line-cyan-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-cyan)  {
-  --background: var(--line-cyan-12);           /* App background (-1) */
-  --subtle-background: var(--line-cyan-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-cyan-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-cyan-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-cyan-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-cyan-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-cyan-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-cyan-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-cyan-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-cyan-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-cyan-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-cyan-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-cyan) {
+  --line-background: var(--line-cyan-12); /* App background (-1) */
+  --line-subtle-background: var(--line-cyan-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-cyan-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-cyan-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-cyan-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-cyan-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-cyan-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-cyan-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-cyan-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-cyan-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-cyan-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-cyan-1); /* High-contrast text (-12) */
 }
 
 :where(.is-cyan) {
@@ -54,7 +54,7 @@
   color: var(--line-cyan-12);
 }
 
-:is(:dark) :where(.is-cyan-color) {
+:is(.dark) :where(.is-cyan-color) {
   color: var(--line-cyan-1);
 }
 

--- a/packages/theme/src/schemas/gold.css
+++ b/packages/theme/src/schemas/gold.css
@@ -1,33 +1,33 @@
 :where(.schema-gold) {
-  --background: var(--line-gold-1);            /* App background (-1) */
-  --subtle-background: var(--line-gold-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-gold-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-gold-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-gold-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-gold-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-gold-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-gold-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-gold-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-gold-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-gold-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-gold-12);        /* High-contrast text (-12) */
-  --light: var(--line-gold-1);                 /* Light text */
-  --dark: var(--line-gold-12);                 /* Dark text */
+  --line-background: var(--line-gold-1); /* App background (-1) */
+  --line-subtle-background: var(--line-gold-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-gold-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-gold-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-gold-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-gold-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-gold-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-gold-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-gold-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-gold-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-gold-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-gold-12); /* High-contrast text (-12) */
+  --line-light: var(--line-gold-1); /* Light text */
+  --line-dark: var(--line-gold-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-gold)  {
-  --background: var(--line-gold-12);           /* App background (-1) */
-  --subtle-background: var(--line-gold-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-gold-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-gold-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-gold-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-gold-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-gold-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-gold-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-gold-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-gold-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-gold-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-gold-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-gold) {
+  --line-background: var(--line-gold-12); /* App background (-1) */
+  --line-subtle-background: var(--line-gold-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-gold-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-gold-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-gold-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-gold-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-gold-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-gold-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-gold-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-gold-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-gold-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-gold-1); /* High-contrast text (-12) */
 }
 
 :where(.is-gold) {
@@ -54,7 +54,7 @@
   color: var(--line-gold-12);
 }
 
-:is(:dark) :where(.is-gold-color) {
+:is(.dark) :where(.is-gold-color) {
   color: var(--line-gold-1);
 }
 

--- a/packages/theme/src/schemas/grass.css
+++ b/packages/theme/src/schemas/grass.css
@@ -1,33 +1,33 @@
 :where(.schema-grass) {
-  --background: var(--line-grass-1);            /* App background (-1) */
-  --subtle-background: var(--line-grass-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-grass-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-grass-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-grass-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-grass-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-grass-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-grass-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-grass-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-grass-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-grass-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-grass-12);        /* High-contrast text (-12) */
-  --light: var(--line-grass-1);                 /* Light text */
-  --dark: var(--line-grass-12);                 /* Dark text */
+  --line-background: var(--line-grass-1); /* App background (-1) */
+  --line-subtle-background: var(--line-grass-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-grass-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-grass-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-grass-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-grass-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-grass-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-grass-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-grass-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-grass-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-grass-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-grass-12); /* High-contrast text (-12) */
+  --line-light: var(--line-grass-1); /* Light text */
+  --line-dark: var(--line-grass-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-grass)  {
-  --background: var(--line-grass-12);           /* App background (-1) */
-  --subtle-background: var(--line-grass-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-grass-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-grass-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-grass-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-grass-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-grass-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-grass-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-grass-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-grass-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-grass-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-grass-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-grass) {
+  --line-background: var(--line-grass-12); /* App background (-1) */
+  --line-subtle-background: var(--line-grass-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-grass-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-grass-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-grass-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-grass-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-grass-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-grass-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-grass-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-grass-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-grass-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-grass-1); /* High-contrast text (-12) */
 }
 
 :where(.is-grass) {
@@ -54,7 +54,7 @@
   color: var(--line-grass-12);
 }
 
-:is(:dark) :where(.is-grass-color) {
+:is(.dark) :where(.is-grass-color) {
   color: var(--line-grass-1);
 }
 

--- a/packages/theme/src/schemas/gray.css
+++ b/packages/theme/src/schemas/gray.css
@@ -1,33 +1,33 @@
 :where(.schema-gray) {
-  --background: var(--line-gray-1);            /* App background (-1) */
-  --subtle-background: var(--line-gray-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-gray-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-gray-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-gray-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-gray-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-gray-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-gray-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-gray-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-gray-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-gray-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-gray-12);        /* High-contrast text (-12) */
-  --light: var(--line-gray-1);                 /* Light text */
-  --dark: var(--line-gray-12);                 /* Dark text */
+  --line-background: var(--line-gray-1); /* App background (-1) */
+  --line-subtle-background: var(--line-gray-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-gray-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-gray-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-gray-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-gray-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-gray-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-gray-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-gray-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-gray-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-gray-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-gray-12); /* High-contrast text (-12) */
+  --line-light: var(--line-gray-1); /* Light text */
+  --line-dark: var(--line-gray-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-gray)  {
-  --background: var(--line-gray-12);           /* App background (-1) */
-  --subtle-background: var(--line-gray-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-gray-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-gray-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-gray-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-gray-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-gray-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-gray-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-gray-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-gray-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-gray-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-gray-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-gray) {
+  --line-background: var(--line-gray-12); /* App background (-1) */
+  --line-subtle-background: var(--line-gray-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-gray-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-gray-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-gray-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-gray-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-gray-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-gray-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-gray-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-gray-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-gray-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-gray-1); /* High-contrast text (-12) */
 }
 
 :where(.is-gray) {

--- a/packages/theme/src/schemas/green.css
+++ b/packages/theme/src/schemas/green.css
@@ -1,33 +1,33 @@
 :where(.schema-green) {
-  --background: var(--line-green-1);            /* App background (-1) */
-  --subtle-background: var(--line-green-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-green-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-green-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-green-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-green-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-green-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-green-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-green-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-green-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-green-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-green-12);        /* High-contrast text (-12) */
-  --light: var(--line-green-1);                 /* Light text */
-  --dark: var(--line-green-12);                 /* Dark text */
+  --line-background: var(--line-green-1); /* App background (-1) */
+  --line-subtle-background: var(--line-green-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-green-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-green-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-green-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-green-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-green-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-green-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-green-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-green-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-green-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-green-12); /* High-contrast text (-12) */
+  --line-light: var(--line-green-1); /* Light text */
+  --line-dark: var(--line-green-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-green)  {
-  --background: var(--line-green-12);           /* App background (-1) */
-  --subtle-background: var(--line-green-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-green-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-green-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-green-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-green-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-green-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-green-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-green-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-green-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-green-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-green-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-green) {
+  --line-background: var(--line-green-12); /* App background (-1) */
+  --line-subtle-background: var(--line-green-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-green-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-green-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-green-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-green-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-green-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-green-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-green-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-green-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-green-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-green-1); /* High-contrast text (-12) */
 }
 
 :where(.is-green) {
@@ -54,7 +54,7 @@
   color: var(--line-green-12);
 }
 
-:is(:dark) :where(.is-green-color) {
+:is(.dark) :where(.is-green-color) {
   color: var(--line-green-1);
 }
 

--- a/packages/theme/src/schemas/indigo.css
+++ b/packages/theme/src/schemas/indigo.css
@@ -1,33 +1,33 @@
 :where(.schema-indigo) {
-  --background: var(--line-indigo-1);            /* App background (-1) */
-  --subtle-background: var(--line-indigo-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-indigo-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-indigo-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-indigo-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-indigo-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-indigo-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-indigo-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-indigo-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-indigo-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-indigo-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-indigo-12);        /* High-contrast text (-12) */
-  --light: var(--line-indigo-1);                 /* Light text */
-  --dark: var(--line-indigo-12);                 /* Dark text */
+  --line-background: var(--line-indigo-1); /* App background (-1) */
+  --line-subtle-background: var(--line-indigo-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-indigo-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-indigo-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-indigo-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-indigo-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-indigo-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-indigo-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-indigo-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-indigo-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-indigo-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-indigo-12); /* High-contrast text (-12) */
+  --line-light: var(--line-indigo-1); /* Light text */
+  --line-dark: var(--line-indigo-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-indigo)  {
-  --background: var(--line-indigo-12);           /* App background (-1) */
-  --subtle-background: var(--line-indigo-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-indigo-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-indigo-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-indigo-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-indigo-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-indigo-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-indigo-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-indigo-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-indigo-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-indigo-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-indigo-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-indigo) {
+  --line-background: var(--line-indigo-12); /* App background (-1) */
+  --line-subtle-background: var(--line-indigo-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-indigo-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-indigo-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-indigo-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-indigo-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-indigo-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-indigo-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-indigo-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-indigo-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-indigo-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-indigo-1); /* High-contrast text (-12) */
 }
 
 :where(.is-indigo) {
@@ -54,7 +54,7 @@
   color: var(--line-indigo-12);
 }
 
-:is(:dark) :where(.is-indigo-color) {
+:is(.dark) :where(.is-indigo-color) {
   color: var(--line-indigo-1);
 }
 

--- a/packages/theme/src/schemas/lime.css
+++ b/packages/theme/src/schemas/lime.css
@@ -1,33 +1,33 @@
 :where(.schema-lime) {
-  --background: var(--line-lime-1);            /* App background (-1) */
-  --subtle-background: var(--line-lime-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-lime-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-lime-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-lime-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-lime-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-lime-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-lime-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-lime-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-lime-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-lime-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-lime-12);        /* High-contrast text (-12) */
-  --light: var(--line-lime-1);                 /* Light text */
-  --dark: var(--line-lime-12);                 /* Dark text */
+  --line-background: var(--line-lime-1); /* App background (-1) */
+  --line-subtle-background: var(--line-lime-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-lime-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-lime-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-lime-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-lime-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-lime-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-lime-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-lime-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-lime-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-lime-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-lime-12); /* High-contrast text (-12) */
+  --line-light: var(--line-lime-1); /* Light text */
+  --line-dark: var(--line-lime-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-lime)  {
-  --background: var(--line-lime-12);           /* App background (-1) */
-  --subtle-background: var(--line-lime-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-lime-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-lime-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-lime-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-lime-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-lime-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-lime-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-lime-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-lime-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-lime-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-lime-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-lime) {
+  --line-background: var(--line-lime-12); /* App background (-1) */
+  --line-subtle-background: var(--line-lime-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-lime-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-lime-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-lime-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-lime-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-lime-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-lime-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-lime-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-lime-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-lime-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-lime-1); /* High-contrast text (-12) */
 }
 
 :where(.is-lime) {
@@ -54,7 +54,7 @@
   color: var(--line-lime-12);
 }
 
-:is(:dark) :where(.is-lime-color) {
+:is(.dark) :where(.is-lime-color) {
   color: var(--line-lime-1);
 }
 

--- a/packages/theme/src/schemas/mauve.css
+++ b/packages/theme/src/schemas/mauve.css
@@ -1,33 +1,33 @@
 :where(.schema-mauve) {
-  --background: var(--line-mauve-1);            /* App background (-1) */
-  --subtle-background: var(--line-mauve-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-mauve-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-mauve-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-mauve-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-mauve-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-mauve-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-mauve-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-mauve-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-mauve-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-mauve-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-mauve-12);        /* High-contrast text (-12) */
-  --light: var(--line-mauve-1);                 /* Light text */
-  --dark: var(--line-mauve-12);                 /* Dark text */
+  --line-background: var(--line-mauve-1); /* App background (-1) */
+  --line-subtle-background: var(--line-mauve-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-mauve-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-mauve-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-mauve-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-mauve-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-mauve-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-mauve-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-mauve-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-mauve-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-mauve-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-mauve-12); /* High-contrast text (-12) */
+  --line-light: var(--line-mauve-1); /* Light text */
+  --line-dark: var(--line-mauve-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-mauve)  {
-  --background: var(--line-mauve-12);           /* App background (-1) */
-  --subtle-background: var(--line-mauve-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-mauve-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-mauve-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-mauve-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-mauve-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-mauve-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-mauve-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-mauve-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-mauve-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-mauve-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-mauve-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-mauve) {
+  --line-background: var(--line-mauve-12); /* App background (-1) */
+  --line-subtle-background: var(--line-mauve-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-mauve-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-mauve-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-mauve-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-mauve-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-mauve-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-mauve-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-mauve-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-mauve-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-mauve-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-mauve-1); /* High-contrast text (-12) */
 }
 
 :where(.is-mauve) {
@@ -54,7 +54,7 @@
   color: var(--line-mauve-12);
 }
 
-:is(:dark) :where(.is-mauve-color) {
+:is(.dark) :where(.is-mauve-color) {
   color: var(--line-mauve-1);
 }
 

--- a/packages/theme/src/schemas/mint.css
+++ b/packages/theme/src/schemas/mint.css
@@ -1,35 +1,35 @@
 :where(.schema-mint) {
-  --background: var(--line-mint-1);            /* App background (-1) */
-  --subtle-background: var(--line-mint-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-mint-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-mint-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-mint-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-mint-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-mint-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-mint-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-mint-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-mint-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-mint-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-mint-12);        /* High-contrast text (-12) */
-  --light: var(--line-mint-1);                 /* Light text */
-  --white: var(--line-mint-1);                 /* White text */
-  --black: var(--line-mint-12);                /* Black text */
-  --dark: var(--line-mint-12);                 /* Dark text */
+  --line-background: var(--line-mint-1); /* App background (-1) */
+  --line-subtle-background: var(--line-mint-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-mint-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-mint-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-mint-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-mint-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-mint-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-mint-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-mint-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-mint-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-mint-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-mint-12); /* High-contrast text (-12) */
+  --line-light: var(--line-mint-1); /* Light text */
+  --line-white: var(--line-mint-1); /* White text */
+  --line-black: var(--line-mint-12); /* Black text */
+  --line-dark: var(--line-mint-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-mint)  {
-  --background: var(--line-mint-12);           /* App background (-1) */
-  --subtle-background: var(--line-mint-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-mint-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-mint-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-mint-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-mint-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-mint-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-mint-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-mint-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-mint-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-mint-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-mint-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-mint) {
+  --line-background: var(--line-mint-12); /* App background (-1) */
+  --line-subtle-background: var(--line-mint-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-mint-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-mint-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-mint-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-mint-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-mint-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-mint-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-mint-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-mint-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-mint-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-mint-1); /* High-contrast text (-12) */
 }
 
 :where(.is-mint) {
@@ -56,7 +56,7 @@
   color: var(--line-mint-12);
 }
 
-:is(:dark) :where(.is-mint-color) {
+:is(.dark) :where(.is-mint-color) {
   color: var(--line-mint-1);
 }
 

--- a/packages/theme/src/schemas/olive.css
+++ b/packages/theme/src/schemas/olive.css
@@ -1,35 +1,35 @@
 :where(.schema-olive) {
-  --background: var(--line-olive-1);            /* App background (-1) */
-  --subtle-background: var(--line-olive-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-olive-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-olive-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-olive-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-olive-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-olive-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-olive-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-olive-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-olive-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-olive-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-olive-12);        /* High-contrast text (-12) */
-  --light: var(--line-olive-1);                 /* Light text */
-  --white: var(--line-olive-1);                 /* White text */
-  --black: var(--line-olive-12);                /* Black text */
-  --dark: var(--line-olive-12);                 /* Dark text */
+  --line-background: var(--line-olive-1); /* App background (-1) */
+  --line-subtle-background: var(--line-olive-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-olive-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-olive-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-olive-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-olive-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-olive-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-olive-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-olive-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-olive-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-olive-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-olive-12); /* High-contrast text (-12) */
+  --line-light: var(--line-olive-1); /* Light text */
+  --line-white: var(--line-olive-1); /* White text */
+  --line-black: var(--line-olive-12); /* Black text */
+  --line-dark: var(--line-olive-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-olive)  {
-  --background: var(--line-olive-12);           /* App background (-1) */
-  --subtle-background: var(--line-olive-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-olive-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-olive-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-olive-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-olive-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-olive-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-olive-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-olive-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-olive-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-olive-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-olive-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-olive) {
+  --line-background: var(--line-olive-12); /* App background (-1) */
+  --line-subtle-background: var(--line-olive-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-olive-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-olive-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-olive-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-olive-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-olive-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-olive-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-olive-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-olive-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-olive-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-olive-1); /* High-contrast text (-12) */
 }
 
 :where(.is-olive) {
@@ -56,7 +56,7 @@
   color: var(--line-olive-12);
 }
 
-:is(:dark) :where(.is-olive-color) {
+:is(.dark) :where(.is-olive-color) {
   color: var(--line-olive-1);
 }
 

--- a/packages/theme/src/schemas/orange.css
+++ b/packages/theme/src/schemas/orange.css
@@ -1,35 +1,35 @@
 :where(.schema-orange) {
-  --background: var(--line-orange-1);            /* App background (-1) */
-  --subtle-background: var(--line-orange-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-orange-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-orange-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-orange-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-orange-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-orange-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-orange-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-orange-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-orange-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-orange-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-orange-12);        /* High-contrast text (-12) */
-  --light: var(--line-orange-1);                 /* Light text */
-  --white: var(--line-orange-1);                 /* White text */
-  --black: var(--line-orange-12);                /* Black text */
-  --dark: var(--line-orange-12);                 /* Dark text */
+  --line-background: var(--line-orange-1); /* App background (-1) */
+  --line-subtle-background: var(--line-orange-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-orange-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-orange-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-orange-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-orange-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-orange-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-orange-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-orange-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-orange-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-orange-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-orange-12); /* High-contrast text (-12) */
+  --line-light: var(--line-orange-1); /* Light text */
+  --line-white: var(--line-orange-1); /* White text */
+  --line-black: var(--line-orange-12); /* Black text */
+  --line-dark: var(--line-orange-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-orange)  {
-  --background: var(--line-orange-12);           /* App background (-1) */
-  --subtle-background: var(--line-orange-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-orange-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-orange-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-orange-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-orange-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-orange-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-orange-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-orange-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-orange-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-orange-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-orange-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-orange) {
+  --line-background: var(--line-orange-12); /* App background (-1) */
+  --line-subtle-background: var(--line-orange-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-orange-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-orange-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-orange-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-orange-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-orange-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-orange-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-orange-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-orange-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-orange-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-orange-1); /* High-contrast text (-12) */
 }
 
 :where(.is-orange) {
@@ -56,7 +56,7 @@
   color: var(--line-orange-12);
 }
 
-:is(:dark) :where(.is-orange-color) {
+:is(.dark) :where(.is-orange-color) {
   color: var(--line-orange-1);
 }
 

--- a/packages/theme/src/schemas/pink.css
+++ b/packages/theme/src/schemas/pink.css
@@ -1,35 +1,35 @@
 :where(.schema-pink) {
-  --background: var(--line-pink-1);            /* App background (-1) */
-  --subtle-background: var(--line-pink-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-pink-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-pink-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-pink-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-pink-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-pink-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-pink-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-pink-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-pink-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-pink-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-pink-12);        /* High-contrast text (-12) */
-  --light: var(--line-pink-1);                 /* Light text */
-  --white: var(--line-pink-1);                 /* White text */
-  --black: var(--line-pink-12);                /* Black text */
-  --dark: var(--line-pink-12);                 /* Dark text */
+  --line-background: var(--line-pink-1); /* App background (-1) */
+  --line-subtle-background: var(--line-pink-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-pink-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-pink-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-pink-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-pink-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-pink-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-pink-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-pink-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-pink-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-pink-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-pink-12); /* High-contrast text (-12) */
+  --line-light: var(--line-pink-1); /* Light text */
+  --line-white: var(--line-pink-1); /* White text */
+  --line-black: var(--line-pink-12); /* Black text */
+  --line-dark: var(--line-pink-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-pink)  {
-  --background: var(--line-pink-12);           /* App background (-1) */
-  --subtle-background: var(--line-pink-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-pink-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-pink-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-pink-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-pink-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-pink-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-pink-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-pink-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-pink-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-pink-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-pink-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-pink) {
+  --line-background: var(--line-pink-12); /* App background (-1) */
+  --line-subtle-background: var(--line-pink-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-pink-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-pink-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-pink-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-pink-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-pink-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-pink-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-pink-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-pink-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-pink-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-pink-1); /* High-contrast text (-12) */
 }
 
 :where(.is-pink) {
@@ -56,7 +56,7 @@
   color: var(--line-pink-12);
 }
 
-:is(:dark) :where(.is-pink-color) {
+:is(.dark) :where(.is-pink-color) {
   color: var(--line-pink-1);
 }
 

--- a/packages/theme/src/schemas/plum.css
+++ b/packages/theme/src/schemas/plum.css
@@ -1,35 +1,35 @@
 :where(.schema-plum) {
-  --background: var(--line-plum-1);            /* App background (-1) */
-  --subtle-background: var(--line-plum-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-plum-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-plum-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-plum-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-plum-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-plum-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-plum-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-plum-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-plum-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-plum-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-plum-12);        /* High-contrast text (-12) */
-  --light: var(--line-plum-1);                 /* Light text */
-  --white: var(--line-plum-1);                 /* White text */
-  --black: var(--line-plum-12);                /* Black text */
-  --dark: var(--line-plum-12);                 /* Dark text */
+  --line-background: var(--line-plum-1); /* App background (-1) */
+  --line-subtle-background: var(--line-plum-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-plum-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-plum-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-plum-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-plum-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-plum-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-plum-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-plum-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-plum-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-plum-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-plum-12); /* High-contrast text (-12) */
+  --line-light: var(--line-plum-1); /* Light text */
+  --line-white: var(--line-plum-1); /* White text */
+  --line-black: var(--line-plum-12); /* Black text */
+  --line-dark: var(--line-plum-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-plum)  {
-  --background: var(--line-plum-12);           /* App background (-1) */
-  --subtle-background: var(--line-plum-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-plum-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-plum-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-plum-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-plum-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-plum-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-plum-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-plum-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-plum-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-plum-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-plum-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-plum) {
+  --line-background: var(--line-plum-12); /* App background (-1) */
+  --line-subtle-background: var(--line-plum-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-plum-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-plum-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-plum-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-plum-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-plum-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-plum-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-plum-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-plum-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-plum-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-plum-1); /* High-contrast text (-12) */
 }
 
 :where(.is-plum) {
@@ -56,7 +56,7 @@
   color: var(--line-plum-12);
 }
 
-:is(:dark) :where(.is-plum-color) {
+:is(.dark) :where(.is-plum-color) {
   color: var(--line-plum-1);
 }
 

--- a/packages/theme/src/schemas/purple.css
+++ b/packages/theme/src/schemas/purple.css
@@ -1,35 +1,35 @@
 :where(.schema-purple) {
-  --background: var(--line-purple-1);            /* App background (-1) */
-  --subtle-background: var(--line-purple-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-purple-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-purple-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-purple-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-purple-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-purple-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-purple-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-purple-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-purple-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-purple-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-purple-12);        /* High-contrast text (-12) */
-  --light: var(--line-purple-1);                 /* Light text */
-  --white: var(--line-purple-1);                 /* White text */
-  --black: var(--line-purple-12);                /* Black text */
-  --dark: var(--line-purple-12);                 /* Dark text */
+  --line-background: var(--line-purple-1); /* App background (-1) */
+  --line-subtle-background: var(--line-purple-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-purple-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-purple-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-purple-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-purple-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-purple-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-purple-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-purple-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-purple-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-purple-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-purple-12); /* High-contrast text (-12) */
+  --line-light: var(--line-purple-1); /* Light text */
+  --line-white: var(--line-purple-1); /* White text */
+  --line-black: var(--line-purple-12); /* Black text */
+  --line-dark: var(--line-purple-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-purple)  {
-  --background: var(--line-purple-12);           /* App background (-1) */
-  --subtle-background: var(--line-purple-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-purple-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-purple-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-purple-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-purple-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-purple-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-purple-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-purple-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-purple-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-purple-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-purple-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-purple) {
+  --line-background: var(--line-purple-12); /* App background (-1) */
+  --line-subtle-background: var(--line-purple-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-purple-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-purple-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-purple-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-purple-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-purple-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-purple-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-purple-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-purple-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-purple-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-purple-1); /* High-contrast text (-12) */
 }
 
 :where(.is-purple) {
@@ -56,7 +56,7 @@
   color: var(--line-purple-12);
 }
 
-:is(:dark) :where(.is-purple-color) {
+:is(.dark) :where(.is-purple-color) {
   color: var(--line-purple-1);
 }
 

--- a/packages/theme/src/schemas/red.css
+++ b/packages/theme/src/schemas/red.css
@@ -1,35 +1,35 @@
 :where(.schema-red) {
-  --background: var(--line-red-1);            /* App background (-1) */
-  --subtle-background: var(--line-red-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-red-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-red-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-red-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-red-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-red-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-red-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-red-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-red-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-red-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-red-12);        /* High-contrast text (-12) */
-  --light: var(--line-red-1);                 /* Light text */
-  --white: var(--line-red-1);                 /* White text */
-  --black: var(--line-red-12);                /* Black text */
-  --dark: var(--line-red-12);                 /* Dark text */
+  --line-background: var(--line-red-1); /* App background (-1) */
+  --line-subtle-background: var(--line-red-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-red-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-red-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-red-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-red-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-red-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-red-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-red-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-red-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-red-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-red-12); /* High-contrast text (-12) */
+  --line-light: var(--line-red-1); /* Light text */
+  --line-white: var(--line-red-1); /* White text */
+  --line-black: var(--line-red-12); /* Black text */
+  --line-dark: var(--line-red-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-red)  {
-  --background: var(--line-red-12);           /* App background (-1) */
-  --subtle-background: var(--line-red-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-red-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-red-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-red-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-red-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-red-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-red-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-red-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-red-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-red-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-red-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-red) {
+  --line-background: var(--line-red-12); /* App background (-1) */
+  --line-subtle-background: var(--line-red-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-red-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-red-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-red-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-red-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-red-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-red-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-red-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-red-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-red-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-red-1); /* High-contrast text (-12) */
 }
 
 :where(.is-red) {
@@ -56,7 +56,7 @@
   color: var(--line-red-12);
 }
 
-:is(:dark) :where(.is-red-color) {
+:is(.dark) :where(.is-red-color) {
   color: var(--line-red-1);
 }
 

--- a/packages/theme/src/schemas/sage.css
+++ b/packages/theme/src/schemas/sage.css
@@ -1,35 +1,35 @@
 :where(.schema-sage) {
-  --background: var(--line-sage-1);            /* App background (-1) */
-  --subtle-background: var(--line-sage-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-sage-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-sage-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-sage-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-sage-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-sage-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-sage-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-sage-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-sage-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-sage-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-sage-12);        /* High-contrast text (-12) */
-  --light: var(--line-sage-1);                 /* Light text */
-  --white: var(--line-sage-1);                 /* White text */
-  --black: var(--line-sage-12);                /* Black text */
-  --dark: var(--line-sage-12);                 /* Dark text */
+  --line-background: var(--line-sage-1); /* App background (-1) */
+  --line-subtle-background: var(--line-sage-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-sage-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-sage-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-sage-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-sage-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-sage-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-sage-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-sage-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-sage-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-sage-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-sage-12); /* High-contrast text (-12) */
+  --line-light: var(--line-sage-1); /* Light text */
+  --line-white: var(--line-sage-1); /* White text */
+  --line-black: var(--line-sage-12); /* Black text */
+  --line-dark: var(--line-sage-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-sage)  {
-  --background: var(--line-sage-12);           /* App background (-1) */
-  --subtle-background: var(--line-sage-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-sage-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-sage-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-sage-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-sage-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-sage-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-sage-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-sage-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-sage-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-sage-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-sage-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-sage) {
+  --line-background: var(--line-sage-12); /* App background (-1) */
+  --line-subtle-background: var(--line-sage-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-sage-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-sage-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-sage-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-sage-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-sage-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-sage-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-sage-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-sage-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-sage-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-sage-1); /* High-contrast text (-12) */
 }
 
 :where(.is-sage) {
@@ -56,7 +56,7 @@
   color: var(--line-sage-12);
 }
 
-:is(:dark) :where(.is-sage-color) {
+:is(.dark) :where(.is-sage-color) {
   color: var(--line-sage-1);
 }
 

--- a/packages/theme/src/schemas/sand.css
+++ b/packages/theme/src/schemas/sand.css
@@ -1,35 +1,35 @@
 :where(.schema-sand) {
-  --background: var(--line-sand-1);            /* App background (-1) */
-  --subtle-background: var(--line-sand-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-sand-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-sand-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-sand-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-sand-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-sand-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-sand-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-sand-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-sand-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-sand-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-sand-12);        /* High-contrast text (-12) */
-  --light: var(--line-sand-1);                 /* Light text */
-  --white: var(--line-sand-1);                 /* White text */
-  --black: var(--line-sand-12);                /* Black text */
-  --dark: var(--line-sand-12);                 /* Dark text */
+  --line-background: var(--line-sand-1); /* App background (-1) */
+  --line-subtle-background: var(--line-sand-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-sand-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-sand-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-sand-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-sand-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-sand-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-sand-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-sand-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-sand-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-sand-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-sand-12); /* High-contrast text (-12) */
+  --line-light: var(--line-sand-1); /* Light text */
+  --line-white: var(--line-sand-1); /* White text */
+  --line-black: var(--line-sand-12); /* Black text */
+  --line-dark: var(--line-sand-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-sand)  {
-  --background: var(--line-sand-12);           /* App background (-1) */
-  --subtle-background: var(--line-sand-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-sand-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-sand-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-sand-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-sand-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-sand-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-sand-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-sand-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-sand-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-sand-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-sand-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-sand) {
+  --line-background: var(--line-sand-12); /* App background (-1) */
+  --line-subtle-background: var(--line-sand-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-sand-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-sand-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-sand-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-sand-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-sand-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-sand-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-sand-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-sand-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-sand-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-sand-1); /* High-contrast text (-12) */
 }
 
 :where(.is-sand) {
@@ -56,7 +56,7 @@
   color: var(--line-sand-12);
 }
 
-:is(:dark) :where(.is-sand-color) {
+:is(.dark) :where(.is-sand-color) {
   color: var(--line-sand-1);
 }
 

--- a/packages/theme/src/schemas/sky.css
+++ b/packages/theme/src/schemas/sky.css
@@ -1,35 +1,35 @@
 :where(.schema-sky) {
-  --background: var(--line-sky-1);            /* App background (-1) */
-  --subtle-background: var(--line-sky-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-sky-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-sky-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-sky-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-sky-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-sky-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-sky-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-sky-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-sky-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-sky-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-sky-12);        /* High-contrast text (-12) */
-  --light: var(--line-sky-1);                 /* Light text */
-  --white: var(--line-sky-1);                 /* White text */
-  --black: var(--line-sky-12);                /* Black text */
-  --dark: var(--line-sky-12);                 /* Dark text */
+  --line-background: var(--line-sky-1); /* App background (-1) */
+  --line-subtle-background: var(--line-sky-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-sky-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-sky-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-sky-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-sky-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-sky-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-sky-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-sky-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-sky-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-sky-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-sky-12); /* High-contrast text (-12) */
+  --line-light: var(--line-sky-1); /* Light text */
+  --line-white: var(--line-sky-1); /* White text */
+  --line-black: var(--line-sky-12); /* Black text */
+  --line-dark: var(--line-sky-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-sky)  {
-  --background: var(--line-sky-12);           /* App background (-1) */
-  --subtle-background: var(--line-sky-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-sky-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-sky-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-sky-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-sky-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-sky-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-sky-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-sky-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-sky-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-sky-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-sky-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-sky) {
+  --line-background: var(--line-sky-12); /* App background (-1) */
+  --line-subtle-background: var(--line-sky-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-sky-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-sky-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-sky-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-sky-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-sky-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-sky-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-sky-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-sky-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-sky-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-sky-1); /* High-contrast text (-12) */
 }
 
 :where(.is-sky) {
@@ -56,7 +56,7 @@
   color: var(--line-sky-12);
 }
 
-:is(:dark) :where(.is-sky-color) {
+:is(.dark) :where(.is-sky-color) {
   color: var(--line-sky-1);
 }
 

--- a/packages/theme/src/schemas/slate.css
+++ b/packages/theme/src/schemas/slate.css
@@ -1,35 +1,35 @@
 :where(.schema-slate) {
-  --background: var(--line-slate-1);            /* App background (-1) */
-  --subtle-background: var(--line-slate-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-slate-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-slate-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-slate-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-slate-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-slate-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-slate-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-slate-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-slate-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-slate-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-slate-12);        /* High-contrast text (-12) */
-  --light: var(--line-slate-1);                 /* Light text */
-  --white: var(--line-slate-1);                 /* White text */
-  --black: var(--line-slate-12);                /* Black text */
-  --dark: var(--line-slate-12);                 /* Dark text */
+  --line-background: var(--line-slate-1); /* App background (-1) */
+  --line-subtle-background: var(--line-slate-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-slate-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-slate-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-slate-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-slate-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-slate-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-slate-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-slate-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-slate-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-slate-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-slate-12); /* High-contrast text (-12) */
+  --line-light: var(--line-slate-1); /* Light text */
+  --line-white: var(--line-slate-1); /* White text */
+  --line-black: var(--line-slate-12); /* Black text */
+  --line-dark: var(--line-slate-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-slate)  {
-  --background: var(--line-slate-12);           /* App background (-1) */
-  --subtle-background: var(--line-slate-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-slate-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-slate-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-slate-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-slate-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-slate-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-slate-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-slate-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-slate-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-slate-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-slate-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-slate) {
+  --line-background: var(--line-slate-12); /* App background (-1) */
+  --line-subtle-background: var(--line-slate-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-slate-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-slate-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-slate-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-slate-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-slate-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-slate-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-slate-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-slate-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-slate-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-slate-1); /* High-contrast text (-12) */
 }
 
 :where(.is-slate) {
@@ -56,7 +56,7 @@
   color: var(--line-slate-12);
 }
 
-:is(:dark) :where(.is-slate-color) {
+:is(.dark) :where(.is-slate-color) {
   color: var(--line-slate-1);
 }
 

--- a/packages/theme/src/schemas/teal.css
+++ b/packages/theme/src/schemas/teal.css
@@ -1,35 +1,35 @@
 :where(.schema-teal) {
-  --background: var(--line-teal-1);            /* App background (-1) */
-  --subtle-background: var(--line-teal-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-teal-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-teal-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-teal-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-teal-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-teal-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-teal-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-teal-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-teal-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-teal-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-teal-12);        /* High-contrast text (-12) */
-  --light: var(--line-teal-1);                 /* Light text */
-  --white: var(--line-teal-1);                 /* White text */
-  --black: var(--line-teal-12);                /* Black text */
-  --dark: var(--line-teal-12);                 /* Dark text */
+  --line-background: var(--line-teal-1); /* App background (-1) */
+  --line-subtle-background: var(--line-teal-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-teal-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-teal-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-teal-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-teal-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-teal-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-teal-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-teal-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-teal-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-teal-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-teal-12); /* High-contrast text (-12) */
+  --line-light: var(--line-teal-1); /* Light text */
+  --line-white: var(--line-teal-1); /* White text */
+  --line-black: var(--line-teal-12); /* Black text */
+  --line-dark: var(--line-teal-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-teal)  {
-  --background: var(--line-teal-12);           /* App background (-1) */
-  --subtle-background: var(--line-teal-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-teal-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-teal-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-teal-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-teal-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-teal-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-teal-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-teal-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-teal-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-teal-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-teal-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-teal) {
+  --line-background: var(--line-teal-12); /* App background (-1) */
+  --line-subtle-background: var(--line-teal-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-teal-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-teal-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-teal-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-teal-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-teal-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-teal-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-teal-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-teal-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-teal-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-teal-1); /* High-contrast text (-12) */
 }
 
 :where(.is-teal) {
@@ -56,7 +56,7 @@
   color: var(--line-teal-12);
 }
 
-:is(:dark) :where(.is-teal-color) {
+:is(.dark) :where(.is-teal-color) {
   color: var(--line-teal-1);
 }
 

--- a/packages/theme/src/schemas/tomato.css
+++ b/packages/theme/src/schemas/tomato.css
@@ -1,35 +1,35 @@
 :where(.schema-tomato) {
-  --background: var(--line-tomato-1);            /* App background (-1) */
-  --subtle-background: var(--line-tomato-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-tomato-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-tomato-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-tomato-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-tomato-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-tomato-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-tomato-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-tomato-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-tomato-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-tomato-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-tomato-12);        /* High-contrast text (-12) */
-  --light: var(--line-tomato-1);                 /* Light text */
-  --white: var(--line-tomato-1);                 /* White text */
-  --black: var(--line-tomato-12);                /* Black text */
-  --dark: var(--line-tomato-12);                 /* Dark text */
+  --line-background: var(--line-tomato-1); /* App background (-1) */
+  --line-subtle-background: var(--line-tomato-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-tomato-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-tomato-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-tomato-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-tomato-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-tomato-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-tomato-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-tomato-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-tomato-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-tomato-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-tomato-12); /* High-contrast text (-12) */
+  --line-light: var(--line-tomato-1); /* Light text */
+  --line-white: var(--line-tomato-1); /* White text */
+  --line-black: var(--line-tomato-12); /* Black text */
+  --line-dark: var(--line-tomato-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-tomato)  {
-  --background: var(--line-tomato-12);           /* App background (-1) */
-  --subtle-background: var(--line-tomato-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-tomato-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-tomato-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-tomato-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-tomato-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-tomato-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-tomato-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-tomato-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-tomato-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-tomato-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-tomato-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-tomato) {
+  --line-background: var(--line-tomato-12); /* App background (-1) */
+  --line-subtle-background: var(--line-tomato-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-tomato-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-tomato-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-tomato-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-tomato-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-tomato-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-tomato-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-tomato-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-tomato-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-tomato-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-tomato-1); /* High-contrast text (-12) */
 }
 
 :where(.is-tomato) {
@@ -56,7 +56,7 @@
   color: var(--line-tomato-12);
 }
 
-:is(:dark) :where(.is-tomato-color) {
+:is(.dark) :where(.is-tomato-color) {
   color: var(--line-tomato-1);
 }
 

--- a/packages/theme/src/schemas/violet.css
+++ b/packages/theme/src/schemas/violet.css
@@ -1,35 +1,35 @@
 :where(.schema-violet) {
-  --background: var(--line-violet-1);            /* App background (-1) */
-  --subtle-background: var(--line-violet-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-violet-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-violet-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-violet-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-violet-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-violet-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-violet-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-violet-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-violet-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-violet-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-violet-12);        /* High-contrast text (-12) */
-  --light: var(--line-violet-1);                 /* Light text */
-  --white: var(--line-violet-1);                 /* White text */
-  --black: var(--line-violet-12);                /* Black text */
-  --dark: var(--line-violet-12);                 /* Dark text */
+  --line-background: var(--line-violet-1); /* App background (-1) */
+  --line-subtle-background: var(--line-violet-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-violet-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-violet-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-violet-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-violet-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-violet-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-violet-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-violet-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-violet-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-violet-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-violet-12); /* High-contrast text (-12) */
+  --line-light: var(--line-violet-1); /* Light text */
+  --line-white: var(--line-violet-1); /* White text */
+  --line-black: var(--line-violet-12); /* Black text */
+  --line-dark: var(--line-violet-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-violet)  {
-  --background: var(--line-violet-12);           /* App background (-1) */
-  --subtle-background: var(--line-violet-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-violet-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-violet-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-violet-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-violet-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-violet-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-violet-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-violet-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-violet-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-violet-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-violet-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-violet) {
+  --line-background: var(--line-violet-12); /* App background (-1) */
+  --line-subtle-background: var(--line-violet-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-violet-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-violet-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-violet-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-violet-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-violet-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-violet-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-violet-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-violet-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-violet-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-violet-1); /* High-contrast text (-12) */
 }
 
 :where(.is-violet) {
@@ -56,7 +56,7 @@
   color: var(--line-violet-12);
 }
 
-:is(:dark) :where(.is-violet-color) {
+:is(.dark) :where(.is-violet-color) {
   color: var(--line-violet-1);
 }
 

--- a/packages/theme/src/schemas/yellow.css
+++ b/packages/theme/src/schemas/yellow.css
@@ -1,35 +1,35 @@
 :where(.schema-yellow) {
-  --background: var(--line-yellow-1);            /* App background (-1) */
-  --subtle-background: var(--line-yellow-2);     /* Subtle background (-2) */
-  --ui-background: var(--line-yellow-3);         /* UI element background (-3) */
-  --ui-hover-background: var(--line-yellow-4);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-yellow-5);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-yellow-6);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-yellow-7);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-yellow-8);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-yellow-9);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-yellow-10);          /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-yellow-11);         /* Low-contrast text (-11) */
-  --high-contrast: var(--line-yellow-12);        /* High-contrast text (-12) */
-  --light: var(--line-yellow-1);                 /* Light text */
-  --white: var(--line-yellow-1);                 /* White text */
-  --black: var(--line-yellow-12);                /* Black text */
-  --dark: var(--line-yellow-12);                 /* Dark text */
+  --line-background: var(--line-yellow-1); /* App background (-1) */
+  --line-subtle-background: var(--line-yellow-2); /* Subtle background (-2) */
+  --line-ui-background: var(--line-yellow-3); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-yellow-4); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-yellow-5); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-yellow-6); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-yellow-7); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-yellow-8); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-yellow-9); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-yellow-10); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-yellow-11); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-yellow-12); /* High-contrast text (-12) */
+  --line-light: var(--line-yellow-1); /* Light text */
+  --line-white: var(--line-yellow-1); /* White text */
+  --line-black: var(--line-yellow-12); /* Black text */
+  --line-dark: var(--line-yellow-12); /* Dark text */
 }
 
-:is(.dark) :where(.schema-yellow)  {
-  --background: var(--line-yellow-12);           /* App background (-1) */
-  --subtle-background: var(--line-yellow-11);    /* Subtle background (-2) */
-  --ui-background: var(--line-yellow-10);        /* UI element background (-3) */
-  --ui-hover-background: var(--line-yellow-9);   /* Hovered UI element background  (-4)*/
-  --ui-active-background: var(--line-yellow-8);  /* Active / Selected UI element background (-5) */
-  --subtle-border: var(--line-yellow-7);         /* Subtle borders and separators (-6) */
-  --ui-border: var(--line-yellow-6);             /* UI element border and focus rings (-7) */
-  --ui-border-hover: var(--line-yellow-5);       /* Hovered UI element border (-8) */
-  --solid-background: var(--line-yellow-4);      /* Solid backgrounds (-9) */
-  --solid-hover: var(--line-yellow-3);           /* Hovered solid backgrounds (-10) */
-  --low-contrast: var(--line-yellow-2);          /* Low-contrast text (-11) */
-  --high-contrast: var(--line-yellow-1);         /* High-contrast text (-12) */
+:is(.dark) :where(.schema-yellow) {
+  --line-background: var(--line-yellow-12); /* App background (-1) */
+  --line-subtle-background: var(--line-yellow-11); /* Subtle background (-2) */
+  --line-ui-background: var(--line-yellow-10); /* UI element background (-3) */
+  --line-ui-hover-background: var(--line-yellow-9); /* Hovered UI element background  (-4)*/
+  --line-ui-active-background: var(--line-yellow-8); /* Active / Selected UI element background (-5) */
+  --line-subtle-border: var(--line-yellow-7); /* Subtle borders and separators (-6) */
+  --line-ui-border: var(--line-yellow-6); /* UI element border and focus rings (-7) */
+  --line-ui-border-hover: var(--line-yellow-5); /* Hovered UI element border (-8) */
+  --line-solid-background: var(--line-yellow-4); /* Solid backgrounds (-9) */
+  --line-solid-hover: var(--line-yellow-3); /* Hovered solid backgrounds (-10) */
+  --line-low-contrast: var(--line-yellow-2); /* Low-contrast text (-11) */
+  --line-high-contrast: var(--line-yellow-1); /* High-contrast text (-12) */
 }
 
 :where(.is-yellow) {
@@ -56,7 +56,7 @@
   color: var(--line-yellow-12);
 }
 
-:is(:dark) :where(.is-yellow-color) {
+:is(.dark) :where(.is-yellow-color) {
   color: var(--line-yellow-1);
 }
 

--- a/packages/theme/src/style.css
+++ b/packages/theme/src/style.css
@@ -1,68 +1,68 @@
-@import './utils/rules.css';
-@import './utils/normalize.css';
-@import './utils/general.css';
+@import "./utils/rules.css";
+@import "./utils/normalize.css";
+@import "./utils/general.css";
 
-@import './themes/gray-theme.css';
-@import './themes/mauve-theme.css';
-@import './themes/slate-theme.css';
-@import './themes/sage-theme.css';
-@import './themes/olive-theme.css';
-@import './themes/sand-theme.css';
-@import './themes/tomato-theme.css';
-@import './themes/red-theme.css';
-@import './themes/crimson-theme.css';
-@import './themes/pink-theme.css';
-@import './themes/plum-theme.css';
-@import './themes/purple-theme.css';
-@import './themes/violet-theme.css';
-@import './themes/indigo-theme.css';
-@import './themes/blue-theme.css';
-@import './themes/cyan-theme.css';
-@import './themes/teal-theme.css';
-@import './themes/green-theme.css';
-@import './themes/grass-theme.css';
-@import './themes/brown-theme.css';
-@import './themes/bronze-theme.css';
-@import './themes/gold-theme.css';
-@import './themes/sky-theme.css';
-@import './themes/mint-theme.css';
-@import './themes/lime-theme.css';
-@import './themes/yellow-theme.css';
-@import './themes/amber-theme.css';
-@import './themes/orange-theme.css';
+@import "./themes/gray-theme.css";
+@import "./themes/mauve-theme.css";
+@import "./themes/slate-theme.css";
+@import "./themes/sage-theme.css";
+@import "./themes/olive-theme.css";
+@import "./themes/sand-theme.css";
+@import "./themes/tomato-theme.css";
+@import "./themes/red-theme.css";
+@import "./themes/crimson-theme.css";
+@import "./themes/pink-theme.css";
+@import "./themes/plum-theme.css";
+@import "./themes/purple-theme.css";
+@import "./themes/violet-theme.css";
+@import "./themes/indigo-theme.css";
+@import "./themes/blue-theme.css";
+@import "./themes/cyan-theme.css";
+@import "./themes/teal-theme.css";
+@import "./themes/green-theme.css";
+@import "./themes/grass-theme.css";
+@import "./themes/brown-theme.css";
+@import "./themes/bronze-theme.css";
+@import "./themes/gold-theme.css";
+@import "./themes/sky-theme.css";
+@import "./themes/mint-theme.css";
+@import "./themes/lime-theme.css";
+@import "./themes/yellow-theme.css";
+@import "./themes/amber-theme.css";
+@import "./themes/orange-theme.css";
 
-@import './custom/gray-custom.css';
-@import './custom/mauve-custom.css';
-@import './custom/slate-custom.css';
-@import './custom/sage-custom.css';
-@import './custom/olive-custom.css';
-@import './custom/sand-custom.css';
-@import './custom/tomato-custom.css';
-@import './custom/red-custom.css';
-@import './custom/crimson-custom.css';
-@import './custom/pink-custom.css';
-@import './custom/plum-custom.css';
-@import './custom/purple-custom.css';
-@import './custom/violet-custom.css';
-@import './custom/indigo-custom.css';
-@import './custom/blue-custom.css';
-@import './custom/cyan-custom.css';
-@import './custom/teal-custom.css';
-@import './custom/green-custom.css';
-@import './custom/grass-custom.css';
-@import './custom/brown-custom.css';
-@import './custom/bronze-custom.css';
-@import './custom/gold-custom.css';
-@import './custom/sky-custom.css';
-@import './custom/mint-custom.css';
-@import './custom/lime-custom.css';
-@import './custom/yellow-custom.css';
-@import './custom/amber-custom.css';
-@import './custom/orange-custom.css';
+@import "./custom/gray-custom.css";
+@import "./custom/mauve-custom.css";
+@import "./custom/slate-custom.css";
+@import "./custom/sage-custom.css";
+@import "./custom/olive-custom.css";
+@import "./custom/sand-custom.css";
+@import "./custom/tomato-custom.css";
+@import "./custom/red-custom.css";
+@import "./custom/crimson-custom.css";
+@import "./custom/pink-custom.css";
+@import "./custom/plum-custom.css";
+@import "./custom/purple-custom.css";
+@import "./custom/violet-custom.css";
+@import "./custom/indigo-custom.css";
+@import "./custom/blue-custom.css";
+@import "./custom/cyan-custom.css";
+@import "./custom/teal-custom.css";
+@import "./custom/green-custom.css";
+@import "./custom/grass-custom.css";
+@import "./custom/brown-custom.css";
+@import "./custom/bronze-custom.css";
+@import "./custom/gold-custom.css";
+@import "./custom/sky-custom.css";
+@import "./custom/mint-custom.css";
+@import "./custom/lime-custom.css";
+@import "./custom/yellow-custom.css";
+@import "./custom/amber-custom.css";
+@import "./custom/orange-custom.css";
 
 body {
-  color: var(--low-contrast);
-  background-color: var(--background);
+  color: var(--line-low-contrast);
+  background-color: var(--line-background);
 }
 
 .page-title {
@@ -91,7 +91,6 @@ body {
   }
 }
 
-
 .ui-nav {
   width: 100%;
   padding: 0.75rem;
@@ -99,7 +98,7 @@ body {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  border-color: var(--ui-border);
+  border-color: var(--line-ui-border);
   border-bottom-width: 1px;
 
   &-title {
@@ -123,12 +122,11 @@ body {
     align-items: center;
     justify-content: center;
 
-
-    @media(--md-n-above) {
+    @media (--md-n-above) {
       display: flex;
     }
 
-    @media(--md-n-below) {
+    @media (--md-n-below) {
       flex-direction: column;
       align-items: center;
     }
@@ -147,13 +145,13 @@ body {
 }
 
 .ui-theme-button {
-  color: var(--high-contrast);
-  border-color: var(--ui-border);
-  outline-color: var(--ui-border);
+  color: var(--line-high-contrast);
+  border-color: var(--line-ui-border);
+  outline-color: var(--line-ui-border);
 
   &:hover {
-    border-color: var(--ui-border-hover);
-    outline-color: var(--ui-border-hover);
+    border-color: var(--line-ui-border-hover);
+    outline-color: var(--line-ui-border-hover);
   }
 }
 
@@ -167,29 +165,28 @@ body {
 
   div {
     height: var(--size-7);
-    outline-color: var(--ui-border);
+    outline-color: var(--line-ui-border);
     outline-style: solid;
     outline-width: 1px;
-    color: var(--low-contrast);
+    color: var(--line-low-contrast);
   }
 }
 
 .ui-light {
-  background-color: var(--light);
+  background-color: var(--line-light);
 }
 
 .ui-dark {
-  background-color: var(--dark);
+  background-color: var(--line-dark);
 }
 
 .ui-white {
-  background-color: var(--white);
+  background-color: var(--line-white);
 }
 
 .ui-black {
-  background-color: var(--black);
+  background-color: var(--line-black);
 }
-
 
 .ui-tokens {
   grid-template-columns: repeat(8, minmax(0, 1fr));

--- a/packages/theme/src/utils/general.css
+++ b/packages/theme/src/utils/general.css
@@ -1,83 +1,84 @@
-::-moz-selection { /* Code for Firefox */
+::-moz-selection {
+  /* Code for Firefox */
   transition: all ease-in-out delay-150;
-  color: var(--low-contrast);
-  background-color: var(--ui-active-background);
+  color: var(--line-low-contrast);
+  background-color: var(--line-ui-active-background);
 }
 
 ::selection {
   transition: all ease-in-out delay-150;
-  color: var(--low-contrast);
-  background-color: var(--ui-active-background);
+  color: var(--line-low-contrast);
+  background-color: var(--line-ui-active-background);
 }
 
 .is-background {
-  background-color: var(--background);
+  background-color: var(--line-background);
 }
 
 .is-subtle-background {
-  background-color: var(--subtle-background);
+  background-color: var(--line-subtle-background);
 }
 
 .is-ui-background {
   transition: colors ease-in-out delay-150;
-  background-color: var(--ui-background);
+  background-color: var(--line-ui-background);
 }
 
 .is-hover-background {
-  background-color: var(--ui-hover-background);
+  background-color: var(--line-ui-hover-background);
 }
 
 .is-active-background {
-  background-color: var(--ui-active-background);
+  background-color: var(--line-ui-active-background);
 }
 
 .is-subtle-border {
-  border-color: var(--subtle-border);
-  outline-color: var(--subtle-border);
+  border-color: var(--line-subtle-border);
+  outline-color: var(--line-subtle-border);
 }
 
 .is-ui-border {
   transition: colors ease-in-out delay-150;
-  border-color: var(--ui-border);
-  outline-color: var(--ui-border);
+  border-color: var(--line-ui-border);
+  outline-color: var(--line-ui-border);
 }
 
 .is-ui-hover {
-  border-color: var(--ui-border-hover);
-  outline-color: var(--ui-border-hover);
+  border-color: var(--line-ui-border-hover);
+  outline-color: var(--line-ui-border-hover);
 }
 
 .is-solid-background {
-  transition:colors ease-in-out delay-150;
-  background-color: var(--solid-background);
+  transition: colors ease-in-out delay-150;
+  background-color: var(--line-solid-background);
 }
 
 .is-hover-solid {
-  background-color: var(--solid-hover);
+  background-color: var(--line-solid-hover);
 }
 
 .is-low-contrast {
-  color: var(--low-contrast);
+  color: var(--line-low-contrast);
 }
 
 .is-high-contrast {
-  color: var(--high-contrast);
+  color: var(--line-high-contrast);
 }
 
 .is-light {
-  color: var(--light);
+  color: var(--line-light);
 }
 
 .is-dark {
-  color: var(--dark);
+  color: var(--line-dark);
 }
 
 .is-white {
-  color: var(--white);
+  color: var(--line-white);
 }
 
 .is-black {
-  color: var(--black);
+  color: var(--line-black);
 }
 
 .carousel {
@@ -95,7 +96,7 @@
 
 .is-tiny {
   height: 1rem;
-  font-size: .6rem;
+  font-size: 0.6rem;
   padding: 0.1rem;
 }
 

--- a/packages/theme/src/utils/rules.css
+++ b/packages/theme/src/utils/rules.css
@@ -1,38 +1,38 @@
 @media (prefers-color-scheme: light) {
   :root {
-    --background: hsl(0, 0%, 99.0%);            /* App background (-1) */
-    --subtle-background: hsl(0, 0%, 97.5%);     /* Subtle background (-2) */
-    --ui-background: hsl(0, 0%, 94.6%);         /* UI element background (-3) */
-    --ui-hover-background: hsl(0, 0%, 92.0%);   /* Hovered UI element background  (-4)*/
-    --ui-active-background: hsl(0, 0%, 89.5%);  /* Active / Selected UI element background (-5) */
-    --subtle-border: hsl(0, 0%, 86.8%);         /* Subtle borders and separators (-6) */
-    --ui-border: hsl(0, 0%, 83.0%);             /* UI element border and focus rings (-7) */
-    --ui-border-hover: hsl(0, 0%, 73.2%);       /* Hovered UI element border (-8) */
-    --solid-background: hsl(0, 0%, 55.2%);      /* Solid backgrounds (-9) */
-    --solid-hover: hsl(0, 0%, 50.3%);           /* Hovered solid backgrounds (-10) */
-    --low-contrast: hsl(0, 0%, 39.3%);          /* Low-contrast text (-11) */
-    --high-contrast: hsl(0, 0%, 12.5%);         /* High-contrast text (-12) */
-    --white: #f1f1f1;                           /* White text */
-    --black: #030303;                           /* Black text */
+    --line-background: hsl(0, 0%, 99.0%); /* App background (-1) */
+    --line-subtle-background: hsl(0, 0%, 97.5%); /* Subtle background (-2) */
+    --line-ui-background: hsl(0, 0%, 94.6%); /* UI element background (-3) */
+    --line-ui-hover-background: hsl(0, 0%, 92.0%); /* Hovered UI element background  (-4)*/
+    --line-ui-active-background: hsl(0, 0%, 89.5%); /* Active / Selected UI element background (-5) */
+    --line-subtle-border: hsl(0, 0%, 86.8%); /* Subtle borders and separators (-6) */
+    --line-ui-border: hsl(0, 0%, 83.0%); /* UI element border and focus rings (-7) */
+    --line-ui-border-hover: hsl(0, 0%, 73.2%); /* Hovered UI element border (-8) */
+    --line-solid-background: hsl(0, 0%, 55.2%); /* Solid backgrounds (-9) */
+    --line-solid-hover: hsl(0, 0%, 50.3%); /* Hovered solid backgrounds (-10) */
+    --line-low-contrast: hsl(0, 0%, 39.3%); /* Low-contrast text (-11) */
+    --line-high-contrast: hsl(0, 0%, 12.5%); /* High-contrast text (-12) */
+    --line-white: #f1f1f1; /* White text */
+    --line-black: #030303; /* Black text */
   }
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: hsl(0, 0%, 9.5%);             /* App background (-1) */
-    --subtle-background: hsl(0, 0%, 10.5%);     /* Subtle background (-2) */
-    --ui-background: hsl(0, 0%, 15.8%);         /* UI element background (-3) */
-    --ui-hover-background: hsl(0, 0%, 18.9%);   /* Hovered UI element background  (-4)*/
-    --ui-active-background: hsl(0, 0%, 21.7%);  /* Active / Selected UI element background (-5) */
-    --subtle-border: hsl(0, 0%, 24.7%);         /* Subtle borders and separators (-6) */
-    --ui-border: hsl(0, 0%, 29.1%);             /* UI element border and focus rings (-7) */
-    --ui-border-hover: hsl(0, 0%, 37.5%);       /* Hovered UI element border (-8) */
-    --solid-background: hsl(0, 0%, 43.0%);      /* Solid backgrounds (-9) */
-    --solid-hover: hsl(0, 0%, 50.7%);           /* Hovered solid backgrounds (-10) */
-    --low-contrast: hsl(0, 0%, 69.5%);          /* Low-contrast text (-11) */
-    --high-contrast: hsl(0, 0%, 93.5%);         /* High-contrast text (-12) */
-    --white: #f1f1f1;                           /* White text */
-    --black: #030303;                           /* Black text */
+    --line-background: hsl(0, 0%, 9.5%); /* App background (-1) */
+    --line-subtle-background: hsl(0, 0%, 10.5%); /* Subtle background (-2) */
+    --line-ui-background: hsl(0, 0%, 15.8%); /* UI element background (-3) */
+    --line-ui-hover-background: hsl(0, 0%, 18.9%); /* Hovered UI element background  (-4)*/
+    --line-ui-active-background: hsl(0, 0%, 21.7%); /* Active / Selected UI element background (-5) */
+    --line-subtle-border: hsl(0, 0%, 24.7%); /* Subtle borders and separators (-6) */
+    --line-ui-border: hsl(0, 0%, 29.1%); /* UI element border and focus rings (-7) */
+    --line-ui-border-hover: hsl(0, 0%, 37.5%); /* Hovered UI element border (-8) */
+    --line-solid-background: hsl(0, 0%, 43.0%); /* Solid backgrounds (-9) */
+    --line-solid-hover: hsl(0, 0%, 50.7%); /* Hovered solid backgrounds (-10) */
+    --line-low-contrast: hsl(0, 0%, 69.5%); /* Low-contrast text (-11) */
+    --line-high-contrast: hsl(0, 0%, 93.5%); /* High-contrast text (-12) */
+    --line-white: #f1f1f1; /* White text */
+    --line-black: #030303; /* Black text */
   }
 }
 
@@ -47,9 +47,11 @@
 }
 
 :where(html) {
-  --font-sans: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;
-  --font-serif: ui-serif,serif;
-  --font-mono: Dank Mono,Operator Mono,Inconsolata,Fira Mono,ui-monospace,SF Mono,Monaco,Droid Sans Mono,Source Code Pro,monospace;
+  --font-sans: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  --font-serif: ui-serif, serif;
+  --font-mono:
+    Dank Mono, Operator Mono, Inconsolata, Fira Mono, ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro,
+    monospace;
   --font-weight-1: 100;
   --font-weight-2: 200;
   --font-weight-3: 300;
@@ -59,7 +61,7 @@
   --font-weight-7: 700;
   --font-weight-8: 800;
   --font-weight-9: 900;
-  --font-lineheight-0: .95;
+  --font-lineheight-0: 0.95;
   --font-lineheight-1: 1.1;
   --font-lineheight-2: 1.25;
   --font-lineheight-3: 1.375;
@@ -67,20 +69,20 @@
   --font-lineheight-5: 1.75;
   --font-lineheight-6: 2;
   --font-lineheight-7: 2.25;
-  --font-lineheight-8: 2.50;
+  --font-lineheight-8: 2.5;
   --font-lineheight-9: 3;
-  --font-letterspacing-0: -.05em;
-  --font-letterspacing-1: .025em;
-  --font-letterspacing-2: .050em;
-  --font-letterspacing-3: .075em;
-  --font-letterspacing-4: .150em;
-  --font-letterspacing-5: .500em;
-  --font-letterspacing-6: .750em;
+  --font-letterspacing-0: -0.05em;
+  --font-letterspacing-1: 0.025em;
+  --font-letterspacing-2: 0.05em;
+  --font-letterspacing-3: 0.075em;
+  --font-letterspacing-4: 0.15em;
+  --font-letterspacing-5: 0.5em;
+  --font-letterspacing-6: 0.75em;
   --font-letterspacing-7: 1em;
-  --font-letterspacing-8: 1.50em;
+  --font-letterspacing-8: 1.5em;
   --font-letterspacing-9: 2em;
-  --font-size-0: .5rem;
-  --font-size-1: .75rem;
+  --font-size-0: 0.5rem;
+  --font-size-1: 0.75rem;
   --font-size-2: 1rem;
   --font-size-3: 1.1rem;
   --font-size-4: 1.25rem;
@@ -89,17 +91,17 @@
   --font-size-7: 2.5rem;
   --font-size-8: 3rem;
   --font-size-9: 3.5rem;
-  --font-size-fluid-0: clamp(.75rem, 2vw, 1rem);
+  --font-size-fluid-0: clamp(0.75rem, 2vw, 1rem);
   --font-size-fluid-1: clamp(1rem, 4vw, 1.5rem);
   --font-size-fluid-2: clamp(1.5rem, 6vw, 2.5rem);
   --font-size-fluid-3: clamp(2rem, 9vw, 3.5rem);
 }
 
 :where(html) {
-  --size-000: -.5rem;
-  --size-00: -.25rem;
-  --size-1: .25rem;
-  --size-2: .5rem;
+  --size-000: -0.5rem;
+  --size-00: -0.25rem;
+  --size-1: 0.25rem;
+  --size-2: 0.5rem;
   --size-3: 1rem;
   --size-4: 1.25rem;
   --size-5: 1.5rem;
@@ -113,7 +115,7 @@
   --size-13: 15rem;
   --size-14: 20rem;
   --size-15: 30rem;
-  --size-fluid-1: clamp(.5rem, 1vw, 1rem);
+  --size-fluid-1: clamp(0.5rem, 1vw, 1rem);
   --size-fluid-2: clamp(1rem, 2vw, 1.5rem);
   --size-fluid-3: clamp(1.5rem, 3vw, 2rem);
   --size-fluid-4: clamp(2rem, 4vw, 3rem);
@@ -136,10 +138,10 @@
   --size-lg: 1024px;
   --size-xl: 1440px;
   --size-xxl: 1920px;
-  --size-relative-000: -.5ch;
-  --size-relative-00: -.25ch;
-  --size-relative-1: .25ch;
-  --size-relative-2: .5ch;
+  --size-relative-000: -0.5ch;
+  --size-relative-00: -0.25ch;
+  --size-relative-1: 0.25ch;
+  --size-relative-2: 0.5ch;
   --size-relative-3: 1ch;
   --size-relative-4: 1.25ch;
   --size-relative-5: 1.5ch;
@@ -158,7 +160,7 @@
 :where(html) {
   --shadow-color: 220 3% 15%;
   --shadow-strength: 1%;
-  --inner-shadow-highlight: inset 0 -.5px 0 0 #fff2, inset 0 .5px 0 0 #0007;
+  --inner-shadow-highlight: inset 0 -0.5px 0 0 #fff2, inset 0 0.5px 0 0 #0007;
   --shadow-1: 0 1px 2px -1px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%));
   --shadow-2:
     0 3px 5px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 3%)),
@@ -192,10 +194,14 @@
     0 41px 33px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 6%)),
     0 100px 80px -2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 7%));
   --inner-shadow-0: inset 0 0 0 1px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%));
-  --inner-shadow-1: inset 0 1px 2px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
-  --inner-shadow-2: inset 0 1px 4px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
-  --inner-shadow-3: inset 0 2px 8px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
-  --inner-shadow-4: inset 0 2px 14px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
+  --inner-shadow-1:
+    inset 0 1px 2px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
+  --inner-shadow-2:
+    inset 0 1px 4px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
+  --inner-shadow-3:
+    inset 0 2px 8px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
+  --inner-shadow-4:
+    inset 0 2px 14px 0 hsl(var(--shadow-color) / calc(var(--shadow-strength) + 9%)), var(--inner-shadow-highlight);
 }
 
 :where(html):is(.dark) {


### PR DESCRIPTION
Rename all unprefixed semantic variables to use the --line-* prefix per PRD 9.14 branding requirements. Variables renamed:

--background, --subtle-background, --ui-background, --ui-hover-background, --ui-active-background, --subtle-border, --ui-border, --ui-border-hover, --solid-background, --solid-hover, --low-contrast, --high-contrast, --light, --dark, --white, --black

All now prefixed as --line-*.

Applied across 28 schema files, rules.css, general.css, and style.css (825 occurrences). Palette variables (--line-{color}-N) untouched.

Also fixes:
- Pre-existing :is(:dark) typo to :is(.dark) in 27 schema files
- Biome formatting alignment in all modified files
- Disables noUnknownMediaFeatureName and noUnknownPseudoClass Biome rules (false positives for PostCSS custom-media and custom selectors)