### PR TITLE
chore: rename core package to @websublime/line-core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
     },
     "packages/core": {
-      "name": "@websublime/vitamina-core",
+      "name": "@websublime/line-core",
       "version": "0.2.0",
       "dependencies": {
         "@websublime/line-theme": "workspace:*",
@@ -354,9 +354,9 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
-    "@websublime/line-theme": ["@websublime/line-theme@workspace:packages/theme"],
+    "@websublime/line-core": ["@websublime/line-core@workspace:packages/core"],
 
-    "@websublime/vitamina-core": ["@websublime/vitamina-core@workspace:packages/core"],
+    "@websublime/line-theme": ["@websublime/line-theme@workspace:packages/theme"],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@websublime/vitamina-core",
+  "name": "@websublime/line-core",
   "version": "0.2.0",
-  "description": "Core Lit functions and base classes for Vitamina",
+  "description": "Core Lit functions and base classes for line://ui",
   "type": "module",
   "scripts": {
     "dev": "vite --debug --force",


### PR DESCRIPTION
Rename @websublime/vitamina-core to @websublime/line-core in packages/core/package.json (name + description) and regenerate bun.lock. Theme dependency already references @websublime/line-theme.

Ref: P0-E1-T5 (line-ui-jox.5)