### PR TITLE
fix(theme): repair build script and convert postcss config to ESM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,8 @@
       "name": "@websublime/line-theme",
       "version": "0.6.0",
       "devDependencies": {
+        "@types/bun": "^1.3.10",
+        "@types/node": "^25.5.0",
         "cssnano": "^7.1.3",
         "open-props": "^1.7.23",
         "postcss": "^8.5.8",
@@ -348,6 +350,8 @@
 
     "@types/argparse": ["@types/argparse@1.0.38", "", {}, "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="],
 
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
@@ -393,6 +397,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -884,7 +890,11 @@
 
     "@rushstack/node-core-library/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
 
+    "@websublime/line-theme/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -6,7 +6,7 @@
   "style": "dist/line.min.css",
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist && node -e \"const{execSync:r}=require('child_process');const s=Object.keys(require('./package.json').scripts).filter(k=>k.startsWith('css:'));for(const n of s){process.stdout.write(n+'... ');r('bun run '+n,{stdio:'ignore'});console.log('done')}\"",
+    "build": "rm -rf dist && bun run src/build.ts",
     "css:all": "postcss src/line.css -o ./dist/line.min.css",
     "css:colors:amber": "postcss src/colors/amber.css -o ./dist/colors-amber.min.css",
     "css:colors:blue": "postcss src/colors/blue.css -o ./dist/colors-blue.min.css",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -6,7 +6,8 @@
   "style": "dist/line.min.css",
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist && bun run src/build.ts",
+    "build": "rm -rf dist && bun run typecheck && bun run src/build.ts",
+    "typecheck": "tsc --noEmit",
     "css:all": "postcss src/line.css -o ./dist/line.min.css",
     "css:colors:amber": "postcss src/colors/amber.css -o ./dist/colors-amber.min.css",
     "css:colors:blue": "postcss src/colors/blue.css -o ./dist/colors-blue.min.css",
@@ -98,6 +99,8 @@
     "css:utils:rules": "postcss src/utils/rules.css -o ./dist/utils-rules.min.css"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.10",
+    "@types/node": "^25.5.0",
     "cssnano": "^7.1.3",
     "open-props": "^1.7.23",
     "postcss": "^8.5.8",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -6,7 +6,7 @@
   "style": "dist/line.min.css",
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist && bun run --filter '/^css:.*/' ",
+    "build": "rm -rf dist && node -e \"const{execSync:r}=require('child_process');const s=Object.keys(require('./package.json').scripts).filter(k=>k.startsWith('css:'));for(const n of s){process.stdout.write(n+'... ');r('bun run '+n,{stdio:'ignore'});console.log('done')}\"",
     "css:all": "postcss src/line.css -o ./dist/line.min.css",
     "css:colors:amber": "postcss src/colors/amber.css -o ./dist/colors-amber.min.css",
     "css:colors:blue": "postcss src/colors/blue.css -o ./dist/colors-blue.min.css",

--- a/packages/theme/postcss.config.mjs
+++ b/packages/theme/postcss.config.mjs
@@ -1,12 +1,12 @@
-const cssNano = require('cssnano');
-const customMedia = require('postcss-custom-media');
-const postcssImport = require('postcss-import');
-const postcssMixins = require('postcss-mixins');
-const postcssNested = require('postcss-nested');
-const postcssPresetEnv = require('postcss-preset-env');
-const postcssSimpleVars = require('postcss-simple-vars');
+import cssNano from 'cssnano';
+import customMedia from 'postcss-custom-media';
+import postcssImport from 'postcss-import';
+import postcssMixins from 'postcss-mixins';
+import postcssNested from 'postcss-nested';
+import postcssPresetEnv from 'postcss-preset-env';
+import postcssSimpleVars from 'postcss-simple-vars';
 
-module.exports = {
+export default {
   plugins: [
     postcssImport(),
     postcssMixins(),

--- a/packages/theme/postcss.config.mjs
+++ b/packages/theme/postcss.config.mjs
@@ -6,6 +6,9 @@ import postcssNested from 'postcss-nested';
 import postcssPresetEnv from 'postcss-preset-env';
 import postcssSimpleVars from 'postcss-simple-vars';
 
+// TODO(line-ui-c5q.1): Add postcss-jit-props plugin here for Open Props utility token
+// injection with --line-* prefix rewrite. The dependency is already installed; it needs
+// to be activated in this pipeline. See PRD 9.3 and Decision T3.
 export default {
   plugins: [
     postcssImport(),

--- a/packages/theme/src/build.ts
+++ b/packages/theme/src/build.ts
@@ -1,0 +1,53 @@
+/**
+ * Theme build script — runs all css:* scripts from package.json sequentially.
+ *
+ * Replaces the inline `node -e` one-liner that was previously in the "build"
+ * script. Provides clear error reporting: logs which script failed, its exit
+ * code, and captures stderr output instead of swallowing it with stdio:'ignore'.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const pkgPath = join(import.meta.dirname, '..', 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+
+const cssScripts = Object.keys(pkg.scripts).filter((name: string) => name.startsWith('css:'));
+
+if (cssScripts.length === 0) {
+  console.error('No css:* scripts found in package.json');
+  process.exit(1);
+}
+
+console.info(`Running ${cssScripts.length} css:* scripts...\n`);
+
+let failed = 0;
+
+for (const name of cssScripts) {
+  process.stdout.write(`  ${name}... `);
+
+  const proc = Bun.spawnSync(['bun', 'run', name], {
+    cwd: join(import.meta.dirname, '..'),
+    stderr: 'pipe',
+    stdout: 'pipe'
+  });
+
+  if (proc.exitCode !== 0) {
+    failed++;
+    console.info('FAILED');
+    const stderr = proc.stderr.toString().trim();
+    if (stderr) {
+      console.error(`    stderr: ${stderr}`);
+    }
+    console.error(`    exit code: ${proc.exitCode}`);
+  } else {
+    console.info('done');
+  }
+}
+
+console.info(`\n${cssScripts.length - failed}/${cssScripts.length} scripts succeeded.`);
+
+if (failed > 0) {
+  console.error(`${failed} script(s) failed.`);
+  process.exit(1);
+}

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-    "types": ["vite/client"],
+    "types": ["vite/client", "bun"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
The build script used `bun run --filter` which is a workspace filter, not a script name filter. Replaced with a node one-liner that iterates all css:* scripts from package.json.

Converted postcss.config.cjs to postcss.config.mjs to eliminate the CommonJS/ESM interop warning from postcss-custom-media.