### PR TITLE
refactor(core): rename ComponentElement to LineElement and ComponentM…

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,14 +9,19 @@
 */
 export type {
   ComponentMetadata,
-  ComponentMixinInterface,
   ControllerHost,
+  LineMixinInterface,
   WebComponentOptions
 } from './types/component';
 
-export type { ValueOf, Constructor } from './types/general';
+export type { Constructor, ValueOf } from './types/general';
 
 export type {
+  AttributePart,
+  BooleanAttributePart,
+  ChildPart,
+  CompiledTemplate,
+  CompiledTemplateResult,
   DirectiveParent,
   Disconnectable,
   ElementPart,
@@ -35,10 +40,5 @@ export type {
   StyleInfo,
   SVGTemplateResult,
   TemplateResult,
-  AttributePart,
-  BooleanAttributePart,
-  ChildPart,
-  CompiledTemplate,
-  CompiledTemplateResult,
   ValueSanitizer
 } from './types/lit';

--- a/packages/core/src/lib/component.ts
+++ b/packages/core/src/lib/component.ts
@@ -8,16 +8,14 @@
 |
 */
 
-import { PropertyValues, ReactiveElement } from 'lit';
+import type { PropertyValues, ReactiveElement } from 'lit';
 
-import type { ComponentMixinInterface } from '../types/component';
+import type { LineMixinInterface } from '../types/component';
 import type { Constructor } from '../types/general';
 import { property } from '../utilities/decorators';
 
-export function ComponentMixin<T extends Constructor<ReactiveElement>>(
-  constructor: T
-): T & Constructor<ComponentMixinInterface> {
-  class SuperElement extends constructor {
+export function LineMixin<T extends Constructor<ReactiveElement>>(superClass: T): T & Constructor<LineMixinInterface> {
+  class SuperElement extends superClass {
     /**
      * @public
      */

--- a/packages/core/src/lib/htmx-component.ts
+++ b/packages/core/src/lib/htmx-component.ts
@@ -8,16 +8,12 @@
 |
 */
 
-import type { ComponentMetadata, WebComponentOptions } from '../types/component';
-import { Constructor } from '../types/general';
+import type { WebComponentOptions } from '../types/component';
+import type { Constructor } from '../types/general';
 
-import { ComponentElement } from './web-component';
+import { LineElement } from './web-component';
 
-export class ComponentHtmx extends ComponentElement<WebComponentOptions> {
-  constructor(registry: ComponentMetadata) {
-    super(registry);
-  }
-}
+export class LineHtmxElement extends LineElement<WebComponentOptions> {}
 
 /**
  * Register a custom element Lit class component. This function will
@@ -25,11 +21,11 @@ export class ComponentHtmx extends ComponentElement<WebComponentOptions> {
  *
  * @public
  */
-export function defineHtmxComponent<ComponentHtmx extends ComponentElement>(
+export function defineHtmxComponent<HtmxComponent extends LineElement>(
   name: string,
-  component: Constructor<ComponentHtmx>,
+  component: Constructor<HtmxComponent>,
   options: WebComponentOptions = {}
-): Constructor<ComponentHtmx> {
+): Constructor<HtmxComponent> {
   Object.defineProperty(component.prototype, 'componentOptions', {
     enumerable: true,
     value: options,

--- a/packages/core/src/lib/ui/inspector.ts
+++ b/packages/core/src/lib/ui/inspector.ts
@@ -8,10 +8,10 @@
 |
 */
 
-import { LitElement, css, html, nothing } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { ComponentElement } from '../web-component';
+import type { LineElement } from '../web-component';
 
 @customElement('ui-inspector')
 export class UiInspector extends LitElement {
@@ -65,7 +65,7 @@ export class UiInspector extends LitElement {
 
   hasInspectorVisible = false;
 
-  host!: ComponentElement;
+  host!: LineElement;
 
   set isHoverInspector(value: boolean) {
     this.isInspecting = value;

--- a/packages/core/src/lib/web-component.ts
+++ b/packages/core/src/lib/web-component.ts
@@ -8,16 +8,16 @@
 |
 */
 
-import { LitElement, ReactiveElement } from 'lit';
+import { LitElement, type ReactiveElement } from 'lit';
 
 import type { ComponentMetadata, WebComponentOptions } from '../types/component';
 import type { Constructor } from '../types/general';
 import { property } from '../utilities/decorators';
 
-import { ComponentMixin } from './component';
+import { LineMixin } from './component';
 import { InspectController } from './controllers/inspect-controller';
 
-const id = Symbol.for('VITA');
+const id = Symbol.for('LINE');
 
 /**
  * Extend your components from this. Will have QA tag and metadata
@@ -25,9 +25,7 @@ const id = Symbol.for('VITA');
  *
  * @public
  */
-export class ComponentElement<Options = WebComponentOptions> extends ComponentMixin<Constructor<ReactiveElement>>(
-  LitElement
-) {
+export class LineElement<Options = WebComponentOptions> extends LineMixin<Constructor<ReactiveElement>>(LitElement) {
   readonly componentOptions!: Options;
   declare inspect: boolean;
 
@@ -51,7 +49,7 @@ export class ComponentElement<Options = WebComponentOptions> extends ComponentMi
     this.requestUpdate('options', oldValue);
   }
 
-  get isVita() {
+  get isLine() {
     return this.webComponentId === id;
   }
 
@@ -82,7 +80,7 @@ export class ComponentElement<Options = WebComponentOptions> extends ComponentMi
  *
  * @public
  */
-export function defineWebComponent<WebComponent extends ComponentElement>(
+export function defineWebComponent<WebComponent extends LineElement>(
   name: string,
   component: Constructor<WebComponent>,
   options: WebComponentOptions = {}

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,9 +1,8 @@
-import { css } from 'lit';
 import { html } from 'lit/html.js';
 
 // eslint-disable-next-line import/no-unassigned-import
 import './lib/ui/inspector.js';
-import { ComponentElement, defineWebComponent } from './lib/web-component.js';
+import { defineWebComponent, LineElement } from './lib/web-component.js';
 import type { ComponentMetadata } from './types/component.js';
 import { property } from './utilities/decorators.js';
 
@@ -25,7 +24,7 @@ const headMetadata: ComponentMetadata = {
   version: '0.0.1'
 };
 
-export class HeadComponent extends ComponentElement {
+export class HeadComponent extends LineElement {
   @property({ type: String })
   override title = 'HeadComponent';
 
@@ -38,7 +37,7 @@ export class HeadComponent extends ComponentElement {
   }
 }
 
-export class CardComponent extends ComponentElement {
+export class CardComponent extends LineElement {
   @property({ type: String })
   override title = 'Card Component!';
 

--- a/packages/core/src/types/component.ts
+++ b/packages/core/src/types/component.ts
@@ -8,14 +8,14 @@
 |
 */
 
-import { ReactiveElement } from 'lit';
+import type { ReactiveElement } from 'lit';
 
 export interface WebComponentOptions {
   // eslint-disable-next-line no-use-before-define
   [key: string]: unknown;
 }
 
-export interface ComponentMixinInterface {
+export interface LineMixinInterface {
   inspect: boolean;
   isLTR: boolean;
   dir: 'ltr' | 'rtl';


### PR DESCRIPTION
…ixin to LineMixin

Part of E1 branding refactor (line-ui-jox.6). Renames all base class references from the old vitamina naming to the line://ui naming convention:

- ComponentMixin → LineMixin (parameter renamed constructor → superClass)
- ComponentMixinInterface → LineMixinInterface
- ComponentElement → LineElement
- ComponentHtmx → LineHtmxElement
- isVita getter → isLine
- Symbol.for('VITA') → Symbol.for('LINE')

All imports, exports, and type references updated across packages/core. Pre-existing lint issues in touched files also fixed (import types, import ordering, unused imports, useless constructor, format).