### PR TITLE
refactor(core): rename ComponentElement to LineElement and ComponentM…

### DIFF
--- a/.claude/agents/lit-web-components-supervisor.md
+++ b/.claude/agents/lit-web-components-supervisor.md
@@ -183,8 +183,8 @@ packages/core/
 ## Standards
 
 - Extend `ComponentElement` for all new components; use `defineWebComponent()` to register
-- Tag prefix: `vita-` (e.g., `<vita-button>`, `<vita-dialog>`)
-- CSS custom property prefix: `--vita-`
+- Tag prefix: `line-` (e.g., `<line-button>`, `<line-dialog>`)
+- CSS custom property prefix: `--line-`
 - CSS parts: short, semantic, reused names (root, trigger, content, overlay, title)
 - TypeScript strict mode — zero `any` without justification, full type coverage on public APIs
 - Biome lint passes with zero errors before every commit (`bun run lint`)

--- a/.claude/agents/lit-web-components-supervisor.md
+++ b/.claude/agents/lit-web-components-supervisor.md
@@ -182,7 +182,7 @@ packages/core/
 
 ## Standards
 
-- Extend `ComponentElement` for all new components; use `defineWebComponent()` to register
+- Extend `LineElement` for all new components; use `defineWebComponent()` to register
 - Tag prefix: `line-` (e.g., `<line-button>`, `<line-dialog>`)
 - CSS custom property prefix: `--line-`
 - CSS parts: short, semantic, reused names (root, trigger, content, overlay, title)

--- a/.spec/BASE-SPEC.md
+++ b/.spec/BASE-SPEC.md
@@ -21,7 +21,7 @@ The current codebase in `packages/core/src/` provides:
 
 - **`ComponentMixin`** (`lib/component.ts`): A mixin applied to `ReactiveElement` that provides `dir` (LTR/RTL), `inspect` (boolean), and `isLTR` (getter). Minimal -- lifecycle hooks (`connectedCallback`, `disconnectedCallback`, `updated`) are overridden but empty.
 - **`ComponentElement`** (`lib/web-component.ts`): Extends `ComponentMixin(LitElement)`. Provides `registry` (frozen `ComponentMetadata`), `options` (generic typed), `isVita` (symbol check), and attaches `InspectController`. Constructor requires `ComponentMetadata`.
-- **`InspectController`** (`lib/controllers/inspect-controller.ts`): Reactive controller that reads `localStorage('vita-inspector')` on `hostConnected` and appends a `<ui-inspector>` element to the shadow root.
+- **`InspectController`** (`lib/controllers/inspect-controller.ts`): Reactive controller that reads `localStorage('line-inspector')` on `hostConnected` and appends a `<ui-inspector>` element to the shadow root.
 - **`UiInspector`** (`lib/ui/inspector.ts`): A full LitElement component (`<ui-inspector>`) that renders a hover overlay showing scope, version, and a link. Uses hard-coded gradient styles.
 - **`ComponentHtmx`** (`lib/htmx-component.ts`): Empty shell extending `ComponentElement`. No HTMX logic.
 - **`EventController`** (`lib/controllers/event-controller.ts`): Minimal controller with a `notify()` method that awaits `updateComplete`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,14 +9,19 @@
 */
 export type {
   ComponentMetadata,
-  ComponentMixinInterface,
   ControllerHost,
+  LineMixinInterface,
   WebComponentOptions
 } from './types/component';
 
-export type { ValueOf, Constructor } from './types/general';
+export type { Constructor, ValueOf } from './types/general';
 
 export type {
+  AttributePart,
+  BooleanAttributePart,
+  ChildPart,
+  CompiledTemplate,
+  CompiledTemplateResult,
   DirectiveParent,
   Disconnectable,
   ElementPart,
@@ -35,10 +40,5 @@ export type {
   StyleInfo,
   SVGTemplateResult,
   TemplateResult,
-  AttributePart,
-  BooleanAttributePart,
-  ChildPart,
-  CompiledTemplate,
-  CompiledTemplateResult,
   ValueSanitizer
 } from './types/lit';

--- a/packages/core/src/lib/component.ts
+++ b/packages/core/src/lib/component.ts
@@ -8,16 +8,14 @@
 |
 */
 
-import { PropertyValues, ReactiveElement } from 'lit';
+import type { PropertyValues, ReactiveElement } from 'lit';
 
-import type { ComponentMixinInterface } from '../types/component';
+import type { LineMixinInterface } from '../types/component';
 import type { Constructor } from '../types/general';
 import { property } from '../utilities/decorators';
 
-export function ComponentMixin<T extends Constructor<ReactiveElement>>(
-  constructor: T
-): T & Constructor<ComponentMixinInterface> {
-  class SuperElement extends constructor {
+export function LineMixin<T extends Constructor<ReactiveElement>>(superClass: T): T & Constructor<LineMixinInterface> {
+  class SuperElement extends superClass {
     /**
      * @public
      */

--- a/packages/core/src/lib/controllers/inspect-controller.ts
+++ b/packages/core/src/lib/controllers/inspect-controller.ts
@@ -8,7 +8,7 @@
 |
 */
 
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 import type { ControllerHost } from '../../types/component';
 import { storage } from '../storage';
@@ -16,7 +16,7 @@ import { storage } from '../storage';
 /**
  * Inspector controller can give information about the component
  * metadata. It will also highlight the component when the mouse is over it.
- * A local storage variable (vita-inspector property key) is used to enable/disable the inspector.
+ * A local storage variable (line-inspector property key) is used to enable/disable the inspector.
  * The inspector will be enabled by default when the component
  * is created if the local storage variable is set or when
  * property inspect is present in the component.
@@ -32,14 +32,13 @@ export class InspectController implements ReactiveController {
   private host: ControllerHost;
 
   constructor(host: ControllerHost) {
-    (this.host = host).addController(this);
-
+    this.host = host;
     host.addController(this);
   }
 
   hostConnected() {
     // eslint-disable-next-line unicorn/no-useless-undefined
-    const enabled = storage.local.get('vita-inspector', undefined);
+    const enabled = storage.local.get('line-inspector', undefined);
 
     if (enabled && !this.host.inspect) {
       this.host.inspect = true;

--- a/packages/core/src/lib/htmx-component.ts
+++ b/packages/core/src/lib/htmx-component.ts
@@ -8,16 +8,12 @@
 |
 */
 
-import type { ComponentMetadata, WebComponentOptions } from '../types/component';
-import { Constructor } from '../types/general';
+import type { WebComponentOptions } from '../types/component';
+import type { Constructor } from '../types/general';
 
-import { ComponentElement } from './web-component';
+import { LineElement } from './web-component';
 
-export class ComponentHtmx extends ComponentElement<WebComponentOptions> {
-  constructor(registry: ComponentMetadata) {
-    super(registry);
-  }
-}
+export class LineHtmxElement extends LineElement<WebComponentOptions> {}
 
 /**
  * Register a custom element Lit class component. This function will
@@ -25,11 +21,11 @@ export class ComponentHtmx extends ComponentElement<WebComponentOptions> {
  *
  * @public
  */
-export function defineHtmxComponent<ComponentHtmx extends ComponentElement>(
+export function defineHtmxComponent<HtmxComponent extends LineElement>(
   name: string,
-  component: Constructor<ComponentHtmx>,
+  component: Constructor<HtmxComponent>,
   options: WebComponentOptions = {}
-): Constructor<ComponentHtmx> {
+): Constructor<HtmxComponent> {
   Object.defineProperty(component.prototype, 'componentOptions', {
     enumerable: true,
     value: options,

--- a/packages/core/src/lib/storage.ts
+++ b/packages/core/src/lib/storage.ts
@@ -21,7 +21,7 @@ function wrapStorage(storage: Storage) {
     // eslint-disable-next-line unicorn/no-useless-undefined
     get<T = unknown>(key: string, defaults: unknown = undefined): T {
       const item = storage.getItem(key);
-      return item ? (isStringified(item) ? JSON.parse(item) : item) : defaults;
+      return (item ? (isStringified(item) ? JSON.parse(item) : item) : defaults) as T;
     },
     getAll() {
       // eslint-disable-next-line unicorn/no-useless-undefined

--- a/packages/core/src/lib/ui/inspector.ts
+++ b/packages/core/src/lib/ui/inspector.ts
@@ -16,7 +16,7 @@ import type { LineElement } from '../web-component';
 @customElement('ui-inspector')
 export class UiInspector extends LitElement {
   static override styles = css`
-    .vita-inspector-container {
+    .line-inspector-container {
       display: flex;
       justify-content: center;
       white-space: nowrap;
@@ -27,7 +27,7 @@ export class UiInspector extends LitElement {
       gap: 4px;
     }
 
-    .vita-inspector-info:before {
+    .line-inspector-info:before {
       background: linear-gradient(to left top, #ff6995, #3ecdff);
       border-radius: inherit;
       content: '';
@@ -40,19 +40,19 @@ export class UiInspector extends LitElement {
       z-index: -1;
     }
 
-    .vita-pkg-scope {
+    .line-pkg-scope {
       border-top-left-radius: 4px;
       border-bottom-left-radius: 4px;
     }
 
-    .vita-pkg-version {
+    .line-pkg-version {
       border-top-right-radius: 4px;
       border-bottom-right-radius: 4px;
     }
 
-    .vita-pkg-scope,
-    .vita-pkg-scope > a,
-    .vita-pkg-version {
+    .line-pkg-scope,
+    .line-pkg-scope > a,
+    .line-pkg-version {
       background: #bd40f2;
       padding: 2px 4px;
       font-weight: 400;
@@ -127,7 +127,7 @@ export class UiInspector extends LitElement {
 
     return html`
       <style>
-        .vita-inspector-info {
+        .line-inspector-info {
           position: absolute;
           border-radius: 11px;
           box-sizing: border-box;
@@ -139,21 +139,21 @@ export class UiInspector extends LitElement {
           height: ${offsetHeight + 4}px;
         }
 
-        .vita-inspector-container {
+        .line-inspector-container {
           top: ${boundary}px;
           pointer-events: all;
         }
       </style>
-      <div class="vita-inspector-info">
+      <div class="line-inspector-info">
         <div
-          class="vita-inspector-container"
+          class="line-inspector-container"
           @mouseenter="${() => (this.isHoverInspector = true)}"
           @mouseleave="${() => (this.isHoverInspector = false)}"
         >
-          <div class="vita-pkg-scope">
+          <div class="line-pkg-scope">
             <a href="${link}" target="_blank" rel="noopener noreferrer">${scope}</a>
           </div>
-          <div class="vita-pkg-version">${version}</div>
+          <div class="line-pkg-version">${version}</div>
         </div>
       </div>
     `;

--- a/packages/core/src/lib/ui/inspector.ts
+++ b/packages/core/src/lib/ui/inspector.ts
@@ -8,10 +8,10 @@
 |
 */
 
-import { LitElement, css, html, nothing } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { ComponentElement } from '../web-component';
+import type { LineElement } from '../web-component';
 
 @customElement('ui-inspector')
 export class UiInspector extends LitElement {
@@ -65,7 +65,7 @@ export class UiInspector extends LitElement {
 
   hasInspectorVisible = false;
 
-  host!: ComponentElement;
+  host!: LineElement;
 
   set isHoverInspector(value: boolean) {
     this.isInspecting = value;

--- a/packages/core/src/lib/web-component.ts
+++ b/packages/core/src/lib/web-component.ts
@@ -8,16 +8,16 @@
 |
 */
 
-import { LitElement, ReactiveElement } from 'lit';
+import { LitElement, type ReactiveElement } from 'lit';
 
 import type { ComponentMetadata, WebComponentOptions } from '../types/component';
 import type { Constructor } from '../types/general';
 import { property } from '../utilities/decorators';
 
-import { ComponentMixin } from './component';
+import { LineMixin } from './component';
 import { InspectController } from './controllers/inspect-controller';
 
-const id = Symbol.for('VITA');
+const id = Symbol.for('LINE');
 
 /**
  * Extend your components from this. Will have QA tag and metadata
@@ -25,9 +25,7 @@ const id = Symbol.for('VITA');
  *
  * @public
  */
-export class ComponentElement<Options = WebComponentOptions> extends ComponentMixin<Constructor<ReactiveElement>>(
-  LitElement
-) {
+export class LineElement<Options = WebComponentOptions> extends LineMixin<Constructor<ReactiveElement>>(LitElement) {
   readonly componentOptions!: Options;
   declare inspect: boolean;
 
@@ -51,7 +49,7 @@ export class ComponentElement<Options = WebComponentOptions> extends ComponentMi
     this.requestUpdate('options', oldValue);
   }
 
-  get isVita() {
+  get isLine() {
     return this.webComponentId === id;
   }
 
@@ -82,7 +80,7 @@ export class ComponentElement<Options = WebComponentOptions> extends ComponentMi
  *
  * @public
  */
-export function defineWebComponent<WebComponent extends ComponentElement>(
+export function defineWebComponent<WebComponent extends LineElement>(
   name: string,
   component: Constructor<WebComponent>,
   options: WebComponentOptions = {}

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,9 +1,8 @@
-import { css } from 'lit';
 import { html } from 'lit/html.js';
 
 // eslint-disable-next-line import/no-unassigned-import
 import './lib/ui/inspector.js';
-import { ComponentElement, defineWebComponent } from './lib/web-component.js';
+import { defineWebComponent, LineElement } from './lib/web-component.js';
 import type { ComponentMetadata } from './types/component.js';
 import { property } from './utilities/decorators.js';
 
@@ -25,7 +24,7 @@ const headMetadata: ComponentMetadata = {
   version: '0.0.1'
 };
 
-export class HeadComponent extends ComponentElement {
+export class HeadComponent extends LineElement {
   @property({ type: String })
   override title = 'HeadComponent';
 
@@ -38,7 +37,7 @@ export class HeadComponent extends ComponentElement {
   }
 }
 
-export class CardComponent extends ComponentElement {
+export class CardComponent extends LineElement {
   @property({ type: String })
   override title = 'Card Component!';
 

--- a/packages/core/src/types/component.ts
+++ b/packages/core/src/types/component.ts
@@ -8,14 +8,14 @@
 |
 */
 
-import { ReactiveElement } from 'lit';
+import type { ReactiveElement } from 'lit';
 
 export interface WebComponentOptions {
   // eslint-disable-next-line no-use-before-define
   [key: string]: unknown;
 }
 
-export interface ComponentMixinInterface {
+export interface LineMixinInterface {
   inspect: boolean;
   isLTR: boolean;
   dir: 'ltr' | 'rtl';


### PR DESCRIPTION
…ixin to LineMixin

Part of E1 branding refactor (line-ui-jox.6). Renames all base class
references from the old vitamina naming to the line://ui naming convention:

- ComponentMixin → LineMixin (parameter renamed constructor → superClass)
- ComponentMixinInterface → LineMixinInterface
- ComponentElement → LineElement
- ComponentHtmx → LineHtmxElement
- isVita getter → isLine
- Symbol.for('VITA') → Symbol.for('LINE')

All imports, exports, and type references updated across packages/core.
Pre-existing lint issues in touched files also fixed (import types,
import ordering, unused imports, useless constructor, format).