### PR TITLE
feat(theme): create tokens/ directory with full 1:1 Open Props match

### DIFF
--- a/docs/DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md
+++ b/docs/DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md
@@ -306,313 +306,96 @@ code, not design system utilities.
 
 ## 4. Phase 1 — Foundation Token Layer (L1)
 
-> **Goal:** Create `tokens.css` — the color-free, opinion-free token layer.
+> **Goal:** Create `tokens/` directory — the color-free, opinion-free token layer.
 
-### Step 1.1 — Create `src/tokens.css`
+### Step 1.1 — Create `src/tokens/` directory with per-family CSS files
 
-Extract all foundation scales from the prefixed `rules.css` into a new file.
-Add the missing scales (z-index, opacity, motion, radius, border-width,
-focus-ring, aspect-ratio).
+The foundation token layer is split into per-family CSS files for independent
+importability, with a barrel `tokens.css` that re-exports all families.
+
+**Architecture:**
+
+```
+packages/theme/src/tokens/
+  tokens.css            # Barrel — @imports all family files below
+  typography.css        # Font families (19), weights (9), line-heights (10),
+                        #   letter-spacings (10), font-sizes static (10) + fluid (4)
+  sizing.css            # Rem (16), px (16), fluid (10), content (3),
+                        #   header (3), breakpoints (7), relative (18)
+  borders.css           # Border sizes (5), radii (6), drawn (6), round (1),
+                        #   blob (5), conditional (6)
+  shadows.css           # shadow-color, shadow-strength, shadow-1..6,
+                        #   inner-shadow-0..4, inner-shadow-highlight + dark mode
+  easing.css            # All 81 OP easing tokens (standard, in, out, in-out,
+                        #   elastic, step, spring, bounce, named curves)
+  zindex.css            # OP layers (6) + semantic z-index extensions (8)
+  aspects.css           # All 6 OP aspect ratios (including golden)
+  durations.css         # OP practical durations (7) + semantic extensions (5)
+  opacity.css           # 3 semantic tokens (disabled, overlay, placeholder)
+  focus.css             # 3 tokens (ring-width, ring-offset, ring-color)
+  colors-absolute.css   # black, white + color-scheme declarations
+```
+
+**Token count:** ~302 unique CSS custom property declarations (plus 3 dark
+mode shadow overrides). This is a full 1:1 Open Props match plus line://
+extensions for semantics that Open Props does not provide.
+
+**Key design decisions:**
+
+- All custom properties use the `--line-` prefix
+- All selectors use `:where(html)` for zero specificity
+- Dark mode shadow overrides use `:where(html):is(.dark)`
+- All values are hardcoded — no runtime `var()` dependency on Open Props
+- Font families include all 19 OP stacks plus 3 custom aliases (sans/serif/mono)
+- Line-heights extended from OP 7 to 10 tokens (added 2.25, 2.5, 3)
+- Letter-spacings extended from OP 8 to 10 tokens (added 1.5em, 2em)
+- Font-sizes renumbered: OP `--font-size-00..8` becomes `--line-font-size-0..9`
+- Shadows inline the strength calc() instead of using OP's intermediate `--shadow-strength-N` variables
+- Z-index uses semantic names (dropdown/sticky/fixed/overlay/modal/popover/toast/tooltip) alongside OP's generic layers
+- Easing includes all 81 OP tokens (no reduction to 5 semantic aliases)
+- Opacity placeholder value is 0.6 (distinct from disabled's 0.5)
+
+Each family file can be imported independently via package.json exports
+(configured in a separate task).
+
+**Barrel file** (`src/tokens.css`):
 
 ```css
-/* ═══════════════════════════════════════════════════════════
-   tokens.css — line://ui Foundation Tokens (L1)
-
-   Color-free. Semantic-free. Pure scales.
-   Import this alone for a headless setup with consistent
-   spacing, typography, and motion.
-   ═══════════════════════════════════════════════════════════ */
-
-/* ── Typography ── */
-
-:where(html) {
-  --line-font-sans: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu,
-    Cantarell, Noto Sans, sans-serif;
-  --line-font-serif: ui-serif, serif;
-  --line-font-mono: Dank Mono, Operator Mono, Inconsolata, Fira Mono,
-    ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro, monospace;
-
-  /* Weight */
-  --line-font-weight-1: 100;
-  --line-font-weight-2: 200;
-  --line-font-weight-3: 300;
-  --line-font-weight-4: 400;
-  --line-font-weight-5: 500;
-  --line-font-weight-6: 600;
-  --line-font-weight-7: 700;
-  --line-font-weight-8: 800;
-  --line-font-weight-9: 900;
-
-  /* Line Height */
-  --line-font-lineheight-0: 0.95;
-  --line-font-lineheight-1: 1.1;
-  --line-font-lineheight-2: 1.25;
-  --line-font-lineheight-3: 1.375;
-  --line-font-lineheight-4: 1.5;
-  --line-font-lineheight-5: 1.75;
-  --line-font-lineheight-6: 2;
-  --line-font-lineheight-7: 2.25;
-  --line-font-lineheight-8: 2.5;
-  --line-font-lineheight-9: 3;
-
-  /* Letter Spacing */
-  --line-font-letterspacing-0: -0.05em;
-  --line-font-letterspacing-1: 0.025em;
-  --line-font-letterspacing-2: 0.05em;
-  --line-font-letterspacing-3: 0.075em;
-  --line-font-letterspacing-4: 0.15em;
-  --line-font-letterspacing-5: 0.5em;
-  --line-font-letterspacing-6: 0.75em;
-  --line-font-letterspacing-7: 1em;
-  --line-font-letterspacing-8: 1.5em;
-  --line-font-letterspacing-9: 2em;
-
-  /* Font Size */
-  --line-font-size-0: 0.5rem;
-  --line-font-size-1: 0.75rem;
-  --line-font-size-2: 1rem;
-  --line-font-size-3: 1.1rem;
-  --line-font-size-4: 1.25rem;
-  --line-font-size-5: 1.5rem;
-  --line-font-size-6: 2rem;
-  --line-font-size-7: 2.5rem;
-  --line-font-size-8: 3rem;
-  --line-font-size-9: 3.5rem;
-  --line-font-size-fluid-0: clamp(0.75rem, 2vw, 1rem);
-  --line-font-size-fluid-1: clamp(1rem, 4vw, 1.5rem);
-  --line-font-size-fluid-2: clamp(1.5rem, 6vw, 2.5rem);
-  --line-font-size-fluid-3: clamp(2rem, 9vw, 3.5rem);
-}
-
-/* ── Sizing / Spacing ── */
-
-:where(html) {
-  --line-size-000: -0.5rem;
-  --line-size-00: -0.25rem;
-  --line-size-1: 0.25rem;
-  --line-size-2: 0.5rem;
-  --line-size-3: 1rem;
-  --line-size-4: 1.25rem;
-  --line-size-5: 1.5rem;
-  --line-size-6: 1.75rem;
-  --line-size-7: 2rem;
-  --line-size-8: 3rem;
-  --line-size-9: 4rem;
-  --line-size-10: 5rem;
-  --line-size-11: 7.5rem;
-  --line-size-12: 10rem;
-  --line-size-13: 15rem;
-  --line-size-14: 20rem;
-  --line-size-15: 30rem;
-
-  /* Fluid */
-  --line-size-fluid-1: clamp(0.5rem, 1vw, 1rem);
-  --line-size-fluid-2: clamp(1rem, 2vw, 1.5rem);
-  --line-size-fluid-3: clamp(1.5rem, 3vw, 2rem);
-  --line-size-fluid-4: clamp(2rem, 4vw, 3rem);
-  --line-size-fluid-5: clamp(4rem, 5vw, 5rem);
-  --line-size-fluid-6: clamp(5rem, 7vw, 7.5rem);
-  --line-size-fluid-7: clamp(7.5rem, 10vw, 10rem);
-  --line-size-fluid-8: clamp(10rem, 20vw, 15rem);
-  --line-size-fluid-9: clamp(15rem, 30vw, 20rem);
-  --line-size-fluid-10: clamp(20rem, 40vw, 30rem);
-
-  /* Content widths */
-  --line-size-content-1: 20ch;
-  --line-size-content-2: 45ch;
-  --line-size-content-3: 60ch;
-
-  /* Header widths */
-  --line-size-header-1: 20ch;
-  --line-size-header-2: 25ch;
-  --line-size-header-3: 35ch;
-
-  /* Breakpoints */
-  --line-size-xxs: 240px;
-  --line-size-xs: 360px;
-  --line-size-sm: 480px;
-  --line-size-md: 768px;
-  --line-size-lg: 1024px;
-  --line-size-xl: 1440px;
-  --line-size-xxl: 1920px;
-
-  /* Relative (ch-based) */
-  --line-size-relative-000: -0.5ch;
-  --line-size-relative-00: -0.25ch;
-  --line-size-relative-1: 0.25ch;
-  --line-size-relative-2: 0.5ch;
-  --line-size-relative-3: 1ch;
-  --line-size-relative-4: 1.25ch;
-  --line-size-relative-5: 1.5ch;
-  --line-size-relative-6: 1.75ch;
-  --line-size-relative-7: 2ch;
-  --line-size-relative-8: 3ch;
-  --line-size-relative-9: 4ch;
-  --line-size-relative-10: 5ch;
-  --line-size-relative-11: 7.5ch;
-  --line-size-relative-12: 10ch;
-  --line-size-relative-13: 15ch;
-  --line-size-relative-14: 20ch;
-  --line-size-relative-15: 30ch;
-}
-
-/* ── Border Radius ── */
-
-:where(html) {
-  --line-radius-1: 0.125rem;  /* 2px  — pills, tags */
-  --line-radius-2: 0.25rem;   /* 4px  — inputs, buttons */
-  --line-radius-3: 0.5rem;    /* 8px  — cards, dialogs */
-  --line-radius-4: 0.75rem;   /* 12px — large cards */
-  --line-radius-5: 1rem;      /* 16px — hero sections */
-  --line-radius-round: 9999px;/* Full round — avatars, pills */
-}
-
-/* ── Border Width ── */
-
-:where(html) {
-  --line-border-1: 1px;       /* Default borders */
-  --line-border-2: 2px;       /* Emphasis borders, focus rings */
-  --line-border-3: 4px;       /* Heavy dividers */
-}
-
-/* ── Shadows / Elevation ── */
-
-:where(html) {
-  --line-shadow-color: 220 3% 15%;
-  --line-shadow-strength: 1%;
-  --line-inner-shadow-highlight: inset 0 -0.5px 0 0 #fff2, inset 0 0.5px 0 0 #0007;
-
-  --line-shadow-1: 0 1px 2px -1px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%));
-  --line-shadow-2:
-    0 3px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 7px 14px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%));
-  --line-shadow-3:
-    0 -1px 3px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
-    0 1px 2px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
-    0 2px 5px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
-    0 4px 12px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
-    0 12px 15px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 7%));
-  --line-shadow-4:
-    0 -2px 5px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
-    0 1px 1px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 2px 2px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 5px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
-    0 9px 9px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
-    0 16px 16px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 6%));
-  --line-shadow-5:
-    0 -1px 2px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
-    0 2px 1px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 5px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 10px 10px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
-    0 20px 20px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
-    0 40px 40px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 7%));
-  --line-shadow-6:
-    0 -1px 2px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
-    0 3px 2px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 7px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
-    0 12px 10px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
-    0 22px 18px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
-    0 41px 33px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 6%)),
-    0 100px 80px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 7%));
-  --line-inner-shadow-0: inset 0 0 0 1px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%));
-  --line-inner-shadow-1:
-    inset 0 1px 2px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
-    var(--line-inner-shadow-highlight);
-  --line-inner-shadow-2:
-    inset 0 1px 4px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
-    var(--line-inner-shadow-highlight);
-  --line-inner-shadow-3:
-    inset 0 2px 8px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
-    var(--line-inner-shadow-highlight);
-  --line-inner-shadow-4:
-    inset 0 2px 14px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
-    var(--line-inner-shadow-highlight);
-}
-
-:where(html):is(.dark) {
-  --line-shadow-color: 220 40% 2%;
-  --line-shadow-strength: 25%;
-}
-
-/* ── Z-Index ── */
-
-:where(html) {
-  --line-z-dropdown: 50;
-  --line-z-sticky: 100;
-  --line-z-fixed: 200;
-  --line-z-overlay: 300;
-  --line-z-modal: 400;
-  --line-z-popover: 500;
-  --line-z-toast: 600;
-  --line-z-tooltip: 700;
-}
-
-/* ── Opacity ── */
-
-:where(html) {
-  --line-opacity-disabled: 0.5;
-  --line-opacity-overlay: 0.75;
-  --line-opacity-placeholder: 0.5;
-}
-
-/* ── Motion: Duration ── */
-
-:where(html) {
-  --line-duration-instant: 50ms;
-  --line-duration-fast: 150ms;
-  --line-duration-normal: 300ms;
-  --line-duration-slow: 500ms;
-  --line-duration-glacial: 1000ms;
-}
-
-/* ── Motion: Easing ── */
-
-:where(html) {
-  --line-ease-default: cubic-bezier(0.4, 0, 0.2, 1);
-  --line-ease-in: cubic-bezier(0.4, 0, 1, 1);
-  --line-ease-out: cubic-bezier(0, 0, 0.2, 1);
-  --line-ease-in-out: cubic-bezier(0.4, 0, 0.6, 1);
-  --line-ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-}
-
-/* ── Focus Ring ── */
-
-:where(html) {
-  --line-ring-width: 2px;
-  --line-ring-offset: 2px;
-  --line-ring-color: var(--line-ui-border, hsl(0 0% 83%));
-  /* Fallback value ensures ring works even without semantic layer */
-}
-
-/* ── Aspect Ratio ── */
-
-:where(html) {
-  --line-ratio-square: 1;
-  --line-ratio-landscape: 4 / 3;
-  --line-ratio-portrait: 3 / 4;
-  --line-ratio-wide: 16 / 9;
-  --line-ratio-ultrawide: 21 / 9;
-}
-
-/* ── Absolute Colors ── */
-
-:where(html) {
-  --line-white: #f1f1f1;
-  --line-black: #030303;
-}
-
-/* ── Color Scheme ── */
-
-:where(html) {
-  &.dark { color-scheme: dark; }
-  &.light { color-scheme: light; }
-}
+@import "./tokens/typography.css";
+@import "./tokens/sizing.css";
+@import "./tokens/borders.css";
+@import "./tokens/shadows.css";
+@import "./tokens/easing.css";
+@import "./tokens/zindex.css";
+@import "./tokens/aspects.css";
+@import "./tokens/durations.css";
+@import "./tokens/opacity.css";
+@import "./tokens/focus.css";
+@import "./tokens/colors-absolute.css";
 ```
+
+**Token families summary:**
+
+| File | Tokens | Source |
+|------|--------|--------|
+| `typography.css` | 61 | OP 19 families + 9 weights + 7 line-heights (+3 ext) + 8 letter-spacings (+2 ext) + 10 static sizes (renumbered) + 4 fluid |
+| `sizing.css` | 74 | OP 16 rem + 16 px + 10 fluid + 3 content + 3 header + 7 breakpoint + 18 relative |
+| `borders.css` | 29 | OP 5 border-sizes + 6 radii + 6 drawn + 1 round + 5 blob + 6 conditional |
+| `shadows.css` | 17+3 | OP shadow-color, strength, highlight, shadow-1..6, inner-shadow-0..4 + 3 dark overrides |
+| `easing.css` | 81 | OP all 81 (standard, in, out, in-out, elastic, step, spring, bounce, named) |
+| `zindex.css` | 14 | OP 6 layers + 8 semantic extensions |
+| `aspects.css` | 6 | OP all 6 (square, landscape, portrait, widescreen, ultrawide, golden) |
+| `durations.css` | 12 | OP 7 practical + 5 semantic extensions |
+| `opacity.css` | 3 | line:// only (disabled, overlay, placeholder) |
+| `focus.css` | 3 | line:// only (ring-width, ring-offset, ring-color) |
+| `colors-absolute.css` | 2+cs | line:// only (white, black, color-scheme) |
+| **Total** | **~305** | |
 
 ### Step 1.2 — Delete the old `rules.css`
 
-After extracting tokens.css and semantic-defaults.css (next phase), delete
-`src/utils/rules.css`. All its content will live in the two new files.
+After extracting `tokens/` and `semantic-defaults.css` (next phase), delete
+`src/utils/rules.css`. All its content will live in the new token files and
+the semantic defaults layer.
 
 ---
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -9,6 +9,7 @@
     "build": "rm -rf dist && bun run typecheck && bun run src/build.ts",
     "typecheck": "tsc --noEmit",
     "css:all": "postcss src/line.css -o ./dist/line.min.css",
+    "css:tokens": "postcss src/tokens.css -o ./dist/tokens.min.css",
     "css:colors:amber": "postcss src/colors/amber.css -o ./dist/colors-amber.min.css",
     "css:colors:blue": "postcss src/colors/blue.css -o ./dist/colors-blue.min.css",
     "css:colors:bronze": "postcss src/colors/bronze.css -o ./dist/colors-bronze.min.css",

--- a/packages/theme/src/line.css
+++ b/packages/theme/src/line.css
@@ -1,3 +1,4 @@
+@import "./tokens.css";
 @import "./utils/rules.css";
 @import "./utils/normalize.css";
 @import "./utils/general.css";

--- a/packages/theme/src/tokens.css
+++ b/packages/theme/src/tokens.css
@@ -1,0 +1,21 @@
+/* ═══════════════════════════════════════════════════════════
+   tokens.css — line://ui Foundation Tokens (L1)
+
+   Color-free. Semantic-free. Pure scales.
+   Import this alone for a headless setup with consistent
+   spacing, typography, and motion.
+
+   Barrel file — imports all token families from tokens/.
+   ═══════════════════════════════════════════════════════════ */
+
+@import "./tokens/typography.css";
+@import "./tokens/sizing.css";
+@import "./tokens/borders.css";
+@import "./tokens/shadows.css";
+@import "./tokens/easing.css";
+@import "./tokens/zindex.css";
+@import "./tokens/aspects.css";
+@import "./tokens/durations.css";
+@import "./tokens/opacity.css";
+@import "./tokens/focus.css";
+@import "./tokens/colors-absolute.css";

--- a/packages/theme/src/tokens/aspects.css
+++ b/packages/theme/src/tokens/aspects.css
@@ -1,0 +1,14 @@
+/* ═══════════════════════════════════════════════════════════
+   aspects.css — line://ui Aspect Ratio Tokens
+
+   Full 1:1 Open Props match — all 6 aspect ratio tokens.
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  --line-ratio-square: 1;
+  --line-ratio-landscape: 4 / 3;
+  --line-ratio-portrait: 3 / 4;
+  --line-ratio-widescreen: 16 / 9;
+  --line-ratio-ultrawide: 18 / 5;
+  --line-ratio-golden: 1.618 / 1;
+}

--- a/packages/theme/src/tokens/borders.css
+++ b/packages/theme/src/tokens/borders.css
@@ -1,0 +1,68 @@
+/* ═══════════════════════════════════════════════════════════
+   borders.css — line://ui Border Tokens
+
+   Border sizes (OP 5), radii (OP 6), drawn radii (OP 6),
+   round (OP 1), blob radii (OP 5), conditional radii (OP 6).
+
+   Full 1:1 Open Props match (29 tokens).
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Border Sizes (OP 5) ── */
+
+:where(html) {
+  --line-border-size-1: 1px;
+  --line-border-size-2: 2px;
+  --line-border-size-3: 5px;
+  --line-border-size-4: 10px;
+  --line-border-size-5: 25px;
+}
+
+/* ── Border Radius (OP 6) ── */
+
+:where(html) {
+  --line-radius-1: 2px;
+  --line-radius-2: 5px;
+  --line-radius-3: 1rem;
+  --line-radius-4: 2rem;
+  --line-radius-5: 4rem;
+  --line-radius-6: 8rem;
+}
+
+/* ── Radius Drawn (OP 6) ── */
+
+:where(html) {
+  --line-radius-drawn-1: 255px 15px 225px 15px / 15px 225px 15px 255px;
+  --line-radius-drawn-2: 125px 10px 20px 185px / 25px 205px 205px 25px;
+  --line-radius-drawn-3: 15px 255px 15px 225px / 225px 15px 255px 15px;
+  --line-radius-drawn-4: 15px 25px 155px 25px / 225px 150px 25px 115px;
+  --line-radius-drawn-5: 250px 25px 15px 20px / 15px 80px 105px 115px;
+  --line-radius-drawn-6: 28px 100px 20px 15px / 150px 30px 205px 225px;
+}
+
+/* ── Radius Round (OP 1) ── */
+
+:where(html) {
+  --line-radius-round: 1e5px;
+}
+
+/* ── Radius Blob (OP 5) ── */
+
+:where(html) {
+  --line-radius-blob-1: 30% 70% 70% 30% / 53% 30% 70% 47%;
+  --line-radius-blob-2: 53% 47% 34% 66% / 63% 46% 54% 37%;
+  --line-radius-blob-3: 37% 63% 56% 44% / 49% 56% 44% 51%;
+  --line-radius-blob-4: 63% 37% 37% 63% / 43% 37% 63% 57%;
+  --line-radius-blob-5: 49% 51% 48% 52% / 57% 44% 56% 43%;
+}
+
+/* ── Radius Conditional (OP 6) ──
+   These reference --line-radius-* tokens above. */
+
+:where(html) {
+  --line-radius-conditional-1: clamp(0px, calc(100vw - 100%) * 1e5, var(--line-radius-1));
+  --line-radius-conditional-2: clamp(0px, calc(100vw - 100%) * 1e5, var(--line-radius-2));
+  --line-radius-conditional-3: clamp(0px, calc(100vw - 100%) * 1e5, var(--line-radius-3));
+  --line-radius-conditional-4: clamp(0px, calc(100vw - 100%) * 1e5, var(--line-radius-4));
+  --line-radius-conditional-5: clamp(0px, calc(100vw - 100%) * 1e5, var(--line-radius-5));
+  --line-radius-conditional-6: clamp(0px, calc(100vw - 100%) * 1e5, var(--line-radius-6));
+}

--- a/packages/theme/src/tokens/colors-absolute.css
+++ b/packages/theme/src/tokens/colors-absolute.css
@@ -1,0 +1,22 @@
+/* ═══════════════════════════════════════════════════════════
+   colors-absolute.css — line://ui Absolute Color & Color Scheme Tokens
+
+   2 absolute colors + color-scheme declarations.
+   line:// extensions (not in Open Props core token system).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  --line-white: #f1f1f1;
+  --line-black: #030303;
+}
+
+/* ── Color Scheme ── */
+
+:where(html) {
+  &.dark {
+    color-scheme: dark;
+  }
+  &.light {
+    color-scheme: light;
+  }
+}

--- a/packages/theme/src/tokens/colors-absolute.css
+++ b/packages/theme/src/tokens/colors-absolute.css
@@ -12,11 +12,10 @@
 
 /* ── Color Scheme ── */
 
-:where(html) {
-  &.dark {
-    color-scheme: dark;
-  }
-  &.light {
-    color-scheme: light;
-  }
+:where(html):is(.dark) {
+  color-scheme: dark;
+}
+
+:where(html):is(.light) {
+  color-scheme: light;
 }

--- a/packages/theme/src/tokens/durations.css
+++ b/packages/theme/src/tokens/durations.css
@@ -20,9 +20,9 @@
 /* ── Semantic Duration Extensions (5) ── */
 
 :where(html) {
+  --line-duration-xfast: 50ms;
   --line-duration-fast: 150ms;
   --line-duration-normal: 300ms;
   --line-duration-slow: 500ms;
   --line-duration-glacial: 1000ms;
-  --line-duration-xslow: 50ms;
 }

--- a/packages/theme/src/tokens/durations.css
+++ b/packages/theme/src/tokens/durations.css
@@ -1,0 +1,28 @@
+/* ═══════════════════════════════════════════════════════════
+   durations.css — line://ui Duration / Timing Tokens
+
+   Open Props practical durations (7) + line:// semantic
+   extensions (5).
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── OP Practical Durations (7) ── */
+
+:where(html) {
+  --line-duration-instant: 0ms;
+  --line-duration-quick-1: 80ms;
+  --line-duration-quick-2: 120ms;
+  --line-duration-moderate-1: 180ms;
+  --line-duration-moderate-2: 260ms;
+  --line-duration-gentle-1: 320ms;
+  --line-duration-gentle-2: 420ms;
+}
+
+/* ── Semantic Duration Extensions (5) ── */
+
+:where(html) {
+  --line-duration-fast: 150ms;
+  --line-duration-normal: 300ms;
+  --line-duration-slow: 500ms;
+  --line-duration-glacial: 1000ms;
+  --line-duration-xslow: 50ms;
+}

--- a/packages/theme/src/tokens/easing.css
+++ b/packages/theme/src/tokens/easing.css
@@ -1,0 +1,435 @@
+/* ═══════════════════════════════════════════════════════════
+   easing.css — line://ui Easing Tokens
+
+   Full 1:1 Open Props match — all 81 easing tokens:
+   Standard (5), ease-in (5), ease-out (5), ease-in-out (5),
+   elastic-out (5), elastic-in (5), elastic-in-out (5),
+   step (5), elastic aliases (5), squish aliases (5),
+   spring (5, linear()), bounce (5, linear()),
+   named curves (21: circ, cubic, expo, quad, quart, quint, sine).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  /* ── Standard (5) ── */
+  --line-ease-1: cubic-bezier(0.25, 0, 0.5, 1);
+  --line-ease-2: cubic-bezier(0.25, 0, 0.4, 1);
+  --line-ease-3: cubic-bezier(0.25, 0, 0.3, 1);
+  --line-ease-4: cubic-bezier(0.25, 0, 0.2, 1);
+  --line-ease-5: cubic-bezier(0.25, 0, 0.1, 1);
+
+  /* ── Ease In (5) ── */
+  --line-ease-in-1: cubic-bezier(0.25, 0, 1, 1);
+  --line-ease-in-2: cubic-bezier(0.5, 0, 1, 1);
+  --line-ease-in-3: cubic-bezier(0.7, 0, 1, 1);
+  --line-ease-in-4: cubic-bezier(0.9, 0, 1, 1);
+  --line-ease-in-5: cubic-bezier(1, 0, 1, 1);
+
+  /* ── Ease Out (5) ── */
+  --line-ease-out-1: cubic-bezier(0, 0, 0.75, 1);
+  --line-ease-out-2: cubic-bezier(0, 0, 0.5, 1);
+  --line-ease-out-3: cubic-bezier(0, 0, 0.3, 1);
+  --line-ease-out-4: cubic-bezier(0, 0, 0.1, 1);
+  --line-ease-out-5: cubic-bezier(0, 0, 0, 1);
+
+  /* ── Ease In-Out (5) ── */
+  --line-ease-in-out-1: cubic-bezier(0.1, 0, 0.9, 1);
+  --line-ease-in-out-2: cubic-bezier(0.3, 0, 0.7, 1);
+  --line-ease-in-out-3: cubic-bezier(0.5, 0, 0.5, 1);
+  --line-ease-in-out-4: cubic-bezier(0.7, 0, 0.3, 1);
+  --line-ease-in-out-5: cubic-bezier(0.9, 0, 0.1, 1);
+
+  /* ── Elastic Out (5) ── */
+  --line-ease-elastic-out-1: cubic-bezier(0.5, 0.75, 0.75, 1.25);
+  --line-ease-elastic-out-2: cubic-bezier(0.5, 1, 0.75, 1.25);
+  --line-ease-elastic-out-3: cubic-bezier(0.5, 1.25, 0.75, 1.25);
+  --line-ease-elastic-out-4: cubic-bezier(0.5, 1.5, 0.75, 1.25);
+  --line-ease-elastic-out-5: cubic-bezier(0.5, 1.75, 0.75, 1.25);
+
+  /* ── Elastic In (5) ── */
+  --line-ease-elastic-in-1: cubic-bezier(0.5, -0.25, 0.75, 1);
+  --line-ease-elastic-in-2: cubic-bezier(0.5, -0.5, 0.75, 1);
+  --line-ease-elastic-in-3: cubic-bezier(0.5, -0.75, 0.75, 1);
+  --line-ease-elastic-in-4: cubic-bezier(0.5, -1, 0.75, 1);
+  --line-ease-elastic-in-5: cubic-bezier(0.5, -1.25, 0.75, 1);
+
+  /* ── Elastic In-Out (5) ── */
+  --line-ease-elastic-in-out-1: cubic-bezier(0.5, -0.1, 0.1, 1.5);
+  --line-ease-elastic-in-out-2: cubic-bezier(0.5, -0.3, 0.1, 1.5);
+  --line-ease-elastic-in-out-3: cubic-bezier(0.5, -0.5, 0.1, 1.5);
+  --line-ease-elastic-in-out-4: cubic-bezier(0.5, -0.7, 0.1, 1.5);
+  --line-ease-elastic-in-out-5: cubic-bezier(0.5, -0.9, 0.1, 1.5);
+
+  /* ── Step (5) ── */
+  --line-ease-step-1: steps(2);
+  --line-ease-step-2: steps(3);
+  --line-ease-step-3: steps(4);
+  --line-ease-step-4: steps(7);
+  --line-ease-step-5: steps(10);
+
+  /* ── Elastic Aliases (5) — alias to elastic-out ── */
+  --line-ease-elastic-1: var(--line-ease-elastic-out-1);
+  --line-ease-elastic-2: var(--line-ease-elastic-out-2);
+  --line-ease-elastic-3: var(--line-ease-elastic-out-3);
+  --line-ease-elastic-4: var(--line-ease-elastic-out-4);
+  --line-ease-elastic-5: var(--line-ease-elastic-out-5);
+
+  /* ── Squish Aliases (5) — alias to elastic-in-out ── */
+  --line-ease-squish-1: var(--line-ease-elastic-in-out-1);
+  --line-ease-squish-2: var(--line-ease-elastic-in-out-2);
+  --line-ease-squish-3: var(--line-ease-elastic-in-out-3);
+  --line-ease-squish-4: var(--line-ease-elastic-in-out-4);
+  --line-ease-squish-5: var(--line-ease-elastic-in-out-5);
+
+  /* ── Spring (5) — linear() easing functions ── */
+  --line-ease-spring-1: linear(
+    0,
+    0.006,
+    0.025 2.8%,
+    0.101 6.1%,
+    0.539 18.9%,
+    0.721 25.3%,
+    0.849 31.5%,
+    0.937 38.1%,
+    0.968 41.8%,
+    0.991 45.7%,
+    1.006 50.1%,
+    1.015 55%,
+    1.017 63.9%,
+    1.001
+  );
+  --line-ease-spring-2: linear(
+    0,
+    0.007,
+    0.029 2.2%,
+    0.118 4.7%,
+    0.625 14.4%,
+    0.826 19%,
+    0.902,
+    0.962,
+    1.008 26.1%,
+    1.041 28.7%,
+    1.064 32.1%,
+    1.07 36%,
+    1.061 40.5%,
+    1.015 53.4%,
+    0.999 61.6%,
+    0.995 71.2%,
+    1
+  );
+  --line-ease-spring-3: linear(
+    0,
+    0.009,
+    0.035 2.1%,
+    0.141 4.4%,
+    0.723 12.9%,
+    0.938 16.7%,
+    1.017,
+    1.077,
+    1.121,
+    1.149 24.3%,
+    1.159,
+    1.163,
+    1.161,
+    1.154 29.9%,
+    1.129 32.8%,
+    1.051 39.6%,
+    1.017 43.1%,
+    0.991,
+    0.977 51%,
+    0.974 53.8%,
+    0.975 57.1%,
+    0.997 69.8%,
+    1.003 76.9%,
+    1
+  );
+  --line-ease-spring-4: linear(
+    0,
+    0.009,
+    0.037 1.7%,
+    0.153 3.6%,
+    0.776 10.3%,
+    1.001,
+    1.142 16%,
+    1.185,
+    1.209 19%,
+    1.215 19.9% 20.8%,
+    1.199,
+    1.165 25%,
+    1.056 30.3%,
+    1.008 33%,
+    0.973,
+    0.955 39.2%,
+    0.953 41.1%,
+    0.957 43.3%,
+    0.998 53.3%,
+    1.009 59.1% 63.7%,
+    0.998 78.9%,
+    1
+  );
+  --line-ease-spring-5: linear(
+    0,
+    0.01,
+    0.04 1.6%,
+    0.161 3.3%,
+    0.816 9.4%,
+    1.046,
+    1.189 14.4%,
+    1.231,
+    1.254 17%,
+    1.259,
+    1.257 18.6%,
+    1.236,
+    1.194 22.3%,
+    1.057 27%,
+    0.999 29.4%,
+    0.955 32.1%,
+    0.942,
+    0.935 34.9%,
+    0.933,
+    0.939 38.4%,
+    1 47.3%,
+    1.011,
+    1.017 52.6%,
+    1.016 56.4%,
+    1 65.2%,
+    0.996 70.2%,
+    1.001 87.2%,
+    1
+  );
+
+  /* ── Bounce (5) — linear() easing functions ── */
+  --line-ease-bounce-1: linear(
+    0,
+    0.004,
+    0.016,
+    0.035,
+    0.063,
+    0.098,
+    0.141,
+    0.191,
+    0.25,
+    0.316,
+    0.391 36.8%,
+    0.563,
+    0.766,
+    1 58.8%,
+    0.946,
+    0.908 69.1%,
+    0.895,
+    0.885,
+    0.879,
+    0.878,
+    0.879,
+    0.885,
+    0.895,
+    0.908 89.7%,
+    0.946,
+    1
+  );
+  --line-ease-bounce-2: linear(
+    0,
+    0.004,
+    0.016,
+    0.035,
+    0.063,
+    0.098,
+    0.141 15.1%,
+    0.25,
+    0.391,
+    0.562,
+    0.765,
+    1,
+    0.892 45.2%,
+    0.849,
+    0.815,
+    0.788,
+    0.769,
+    0.757,
+    0.753,
+    0.757,
+    0.769,
+    0.788,
+    0.815,
+    0.85,
+    0.892 75.2%,
+    1 80.2%,
+    0.973,
+    0.954,
+    0.943,
+    0.939,
+    0.943,
+    0.954,
+    0.973,
+    1
+  );
+  --line-ease-bounce-3: linear(
+    0,
+    0.004,
+    0.016,
+    0.035,
+    0.062,
+    0.098,
+    0.141 11.4%,
+    0.25,
+    0.39,
+    0.562,
+    0.764,
+    1 30.3%,
+    0.847 34.8%,
+    0.787,
+    0.737,
+    0.699,
+    0.672,
+    0.655,
+    0.65,
+    0.656,
+    0.672,
+    0.699,
+    0.738,
+    0.787,
+    0.847 61.7%,
+    1 66.2%,
+    0.946,
+    0.908,
+    0.885 74.2%,
+    0.879,
+    0.878,
+    0.879,
+    0.885 79.5%,
+    0.908,
+    0.946,
+    1 87.4%,
+    0.981,
+    0.968,
+    0.96,
+    0.957,
+    0.96,
+    0.968,
+    0.981,
+    1
+  );
+  --line-ease-bounce-4: linear(
+    0,
+    0.004,
+    0.016 3%,
+    0.062,
+    0.141,
+    0.25,
+    0.391,
+    0.562 18.2%,
+    1 24.3%,
+    0.81,
+    0.676 32.3%,
+    0.629,
+    0.595,
+    0.575,
+    0.568,
+    0.575,
+    0.595,
+    0.629,
+    0.676 48.2%,
+    0.811,
+    1 56.2%,
+    0.918,
+    0.86,
+    0.825,
+    0.814,
+    0.825,
+    0.86,
+    0.918,
+    1 77.2%,
+    0.94 80.6%,
+    0.925,
+    0.92,
+    0.925,
+    0.94 87.5%,
+    1 90.9%,
+    0.974,
+    0.965,
+    0.974,
+    1
+  );
+  --line-ease-bounce-5: linear(
+    0,
+    0.004,
+    0.016 2.5%,
+    0.063,
+    0.141,
+    0.25 10.1%,
+    0.562,
+    1 20.2%,
+    0.783,
+    0.627,
+    0.534 30.9%,
+    0.511,
+    0.503,
+    0.511,
+    0.534 38%,
+    0.627,
+    0.782,
+    1 48.7%,
+    0.892,
+    0.815,
+    0.769 56.3%,
+    0.757,
+    0.753,
+    0.757,
+    0.769 61.3%,
+    0.815,
+    0.892,
+    1 68.8%,
+    0.908 72.4%,
+    0.885,
+    0.878,
+    0.885,
+    0.908 79.4%,
+    1 83%,
+    0.954 85.5%,
+    0.943,
+    0.939,
+    0.943,
+    0.954 90.5%,
+    1 93%,
+    0.977,
+    0.97,
+    0.977,
+    1
+  );
+
+  /* ── Named Mathematical Curves (21) ── */
+
+  /* Circ */
+  --line-ease-circ-in: cubic-bezier(0.6, 0.04, 0.98, 0.335);
+  --line-ease-circ-in-out: cubic-bezier(0.785, 0.135, 0.15, 0.86);
+  --line-ease-circ-out: cubic-bezier(0.075, 0.82, 0.165, 1);
+
+  /* Cubic */
+  --line-ease-cubic-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  --line-ease-cubic-in-out: cubic-bezier(0.645, 0.045, 0.355, 1);
+  --line-ease-cubic-out: cubic-bezier(0.215, 0.61, 0.355, 1);
+
+  /* Expo */
+  --line-ease-expo-in: cubic-bezier(0.95, 0.05, 0.795, 0.035);
+  --line-ease-expo-in-out: cubic-bezier(1, 0, 0, 1);
+  --line-ease-expo-out: cubic-bezier(0.19, 1, 0.22, 1);
+
+  /* Quad */
+  --line-ease-quad-in: cubic-bezier(0.55, 0.085, 0.68, 0.53);
+  --line-ease-quad-in-out: cubic-bezier(0.455, 0.03, 0.515, 0.955);
+  --line-ease-quad-out: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  /* Quart */
+  --line-ease-quart-in: cubic-bezier(0.895, 0.03, 0.685, 0.22);
+  --line-ease-quart-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+  --line-ease-quart-out: cubic-bezier(0.165, 0.84, 0.44, 1);
+
+  /* Quint */
+  --line-ease-quint-in: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+  --line-ease-quint-in-out: cubic-bezier(0.86, 0, 0.07, 1);
+  --line-ease-quint-out: cubic-bezier(0.23, 1, 0.32, 1);
+
+  /* Sine */
+  --line-ease-sine-in: cubic-bezier(0.47, 0, 0.745, 0.715);
+  --line-ease-sine-in-out: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+  --line-ease-sine-out: cubic-bezier(0.39, 0.575, 0.565, 1);
+}

--- a/packages/theme/src/tokens/focus.css
+++ b/packages/theme/src/tokens/focus.css
@@ -1,0 +1,13 @@
+/* ═══════════════════════════════════════════════════════════
+   focus.css — line://ui Focus Ring Tokens
+
+   3 tokens — line:// extensions (not in Open Props).
+   Fallback value on ring-color ensures ring works even
+   without the semantic layer loaded.
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  --line-ring-width: 2px;
+  --line-ring-offset: 2px;
+  --line-ring-color: var(--line-ui-border, hsl(0 0% 83%));
+}

--- a/packages/theme/src/tokens/opacity.css
+++ b/packages/theme/src/tokens/opacity.css
@@ -1,0 +1,11 @@
+/* ═══════════════════════════════════════════════════════════
+   opacity.css — line://ui Opacity Tokens
+
+   3 semantic tokens — line:// extensions (not in Open Props).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  --line-opacity-disabled: 0.5;
+  --line-opacity-overlay: 0.75;
+  --line-opacity-placeholder: 0.6;
+}

--- a/packages/theme/src/tokens/shadows.css
+++ b/packages/theme/src/tokens/shadows.css
@@ -1,0 +1,83 @@
+/* ═══════════════════════════════════════════════════════════
+   shadows.css — line://ui Shadow / Elevation Tokens
+
+   Control variables (shadow-color, shadow-strength, 7
+   intermediate strengths), outer shadows (1..6), inner
+   shadows (0..4), inner-shadow-highlight.
+
+   Full 1:1 Open Props match (24 tokens + dark mode overrides).
+   Uses inline calc() for strength references per design guide.
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Light Mode (default) ── */
+
+:where(html) {
+  --line-shadow-color: 220 3% 15%;
+  --line-shadow-strength: 1%;
+
+  --line-inner-shadow-highlight: inset 0 -0.5px 0 0 #fff2, inset 0 0.5px 0 0 #0001;
+
+  --line-shadow-1: 0 1px 2px -1px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%));
+
+  --line-shadow-2:
+    0 3px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 7px 14px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%));
+
+  --line-shadow-3:
+    0 -1px 3px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
+    0 1px 2px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
+    0 2px 5px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
+    0 4px 12px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
+    0 12px 15px -5px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 7%));
+
+  --line-shadow-4:
+    0 -2px 5px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
+    0 1px 1px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 2px 2px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 5px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
+    0 9px 9px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
+    0 16px 16px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 6%));
+
+  --line-shadow-5:
+    0 -1px 2px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
+    0 2px 1px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 5px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 10px 10px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
+    0 20px 20px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
+    0 40px 40px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 7%));
+
+  --line-shadow-6:
+    0 -1px 2px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 2%)),
+    0 3px 2px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 7px 5px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 3%)),
+    0 12px 10px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 4%)),
+    0 22px 18px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 5%)),
+    0 41px 33px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 6%)),
+    0 100px 80px -2px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 7%));
+
+  --line-inner-shadow-0: inset 0 0 0 1px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%));
+
+  --line-inner-shadow-1:
+    inset 0 1px 2px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
+    var(--line-inner-shadow-highlight);
+
+  --line-inner-shadow-2:
+    inset 0 1px 4px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
+    var(--line-inner-shadow-highlight);
+
+  --line-inner-shadow-3:
+    inset 0 2px 8px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
+    var(--line-inner-shadow-highlight);
+
+  --line-inner-shadow-4:
+    inset 0 2px 14px 0 hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%)),
+    var(--line-inner-shadow-highlight);
+}
+
+/* ── Dark Mode Override ── */
+
+:where(html):is(.dark) {
+  --line-shadow-color: 220 40% 2%;
+  --line-shadow-strength: 25%;
+  --line-inner-shadow-highlight: inset 0 -0.5px 0 0 #fff1, inset 0 0.5px 0 0 #0007;
+}

--- a/packages/theme/src/tokens/shadows.css
+++ b/packages/theme/src/tokens/shadows.css
@@ -15,6 +15,9 @@
   --line-shadow-color: 220 3% 15%;
   --line-shadow-strength: 1%;
 
+  /* Deviation from OP: uses #fff2 (13% opacity) instead of OP's #fff (fully opaque).
+     Provides a subtler highlight that blends better with colored surfaces and
+     avoids harsh white lines on non-white backgrounds. */
   --line-inner-shadow-highlight: inset 0 -0.5px 0 0 #fff2, inset 0 0.5px 0 0 #0001;
 
   --line-shadow-1: 0 1px 2px -1px hsl(var(--line-shadow-color) / calc(var(--line-shadow-strength) + 9%));

--- a/packages/theme/src/tokens/sizing.css
+++ b/packages/theme/src/tokens/sizing.css
@@ -1,0 +1,118 @@
+/* ═══════════════════════════════════════════════════════════
+   sizing.css — line://ui Sizing & Spacing Tokens
+
+   Rem sizes (16), px sizes (16), fluid sizes (10),
+   content widths (3), header widths (3), breakpoints (7),
+   relative/ch-based sizes (18).
+
+   Full 1:1 Open Props match (74 tokens).
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Rem Sizes (OP 16) ── */
+
+:where(html) {
+  --line-size-000: -0.5rem;
+  --line-size-00: -0.25rem;
+  --line-size-1: 0.25rem;
+  --line-size-2: 0.5rem;
+  --line-size-3: 1rem;
+  --line-size-4: 1.25rem;
+  --line-size-5: 1.5rem;
+  --line-size-6: 1.75rem;
+  --line-size-7: 2rem;
+  --line-size-8: 3rem;
+  --line-size-9: 4rem;
+  --line-size-10: 5rem;
+  --line-size-11: 7.5rem;
+  --line-size-12: 10rem;
+  --line-size-13: 15rem;
+  --line-size-14: 20rem;
+  --line-size-15: 30rem;
+}
+
+/* ── Px Sizes (OP 16) ── */
+
+:where(html) {
+  --line-size-px-000: -8px;
+  --line-size-px-00: -4px;
+  --line-size-px-1: 4px;
+  --line-size-px-2: 8px;
+  --line-size-px-3: 16px;
+  --line-size-px-4: 20px;
+  --line-size-px-5: 24px;
+  --line-size-px-6: 28px;
+  --line-size-px-7: 32px;
+  --line-size-px-8: 48px;
+  --line-size-px-9: 64px;
+  --line-size-px-10: 80px;
+  --line-size-px-11: 120px;
+  --line-size-px-12: 160px;
+  --line-size-px-13: 240px;
+  --line-size-px-14: 320px;
+  --line-size-px-15: 480px;
+}
+
+/* ── Fluid Sizes (OP 10) ── */
+
+:where(html) {
+  --line-size-fluid-1: clamp(0.5rem, 1vw, 1rem);
+  --line-size-fluid-2: clamp(1rem, 2vw, 1.5rem);
+  --line-size-fluid-3: clamp(1.5rem, 3vw, 2rem);
+  --line-size-fluid-4: clamp(2rem, 4vw, 3rem);
+  --line-size-fluid-5: clamp(4rem, 5vw, 5rem);
+  --line-size-fluid-6: clamp(5rem, 7vw, 7.5rem);
+  --line-size-fluid-7: clamp(7.5rem, 10vw, 10rem);
+  --line-size-fluid-8: clamp(10rem, 20vw, 15rem);
+  --line-size-fluid-9: clamp(15rem, 30vw, 20rem);
+  --line-size-fluid-10: clamp(20rem, 40vw, 30rem);
+}
+
+/* ── Content Widths (OP 3) ── */
+
+:where(html) {
+  --line-size-content-1: 20ch;
+  --line-size-content-2: 45ch;
+  --line-size-content-3: 60ch;
+}
+
+/* ── Header Widths (OP 3) ── */
+
+:where(html) {
+  --line-size-header-1: 20ch;
+  --line-size-header-2: 25ch;
+  --line-size-header-3: 35ch;
+}
+
+/* ── Breakpoints (OP 7) ── */
+
+:where(html) {
+  --line-size-xxs: 240px;
+  --line-size-xs: 360px;
+  --line-size-sm: 480px;
+  --line-size-md: 768px;
+  --line-size-lg: 1024px;
+  --line-size-xl: 1440px;
+  --line-size-xxl: 1920px;
+}
+
+/* ── Relative / ch-based (OP 18) ── */
+
+:where(html) {
+  --line-size-relative-000: -0.5ch;
+  --line-size-relative-00: -0.25ch;
+  --line-size-relative-1: 0.25ch;
+  --line-size-relative-2: 0.5ch;
+  --line-size-relative-3: 1ch;
+  --line-size-relative-4: 1.25ch;
+  --line-size-relative-5: 1.5ch;
+  --line-size-relative-6: 1.75ch;
+  --line-size-relative-7: 2ch;
+  --line-size-relative-8: 3ch;
+  --line-size-relative-9: 4ch;
+  --line-size-relative-10: 5ch;
+  --line-size-relative-11: 7.5ch;
+  --line-size-relative-12: 10ch;
+  --line-size-relative-13: 15ch;
+  --line-size-relative-14: 20ch;
+  --line-size-relative-15: 30ch;
+}

--- a/packages/theme/src/tokens/typography.css
+++ b/packages/theme/src/tokens/typography.css
@@ -32,7 +32,7 @@
   --line-font-didone: Didot, Bodoni MT, Noto Serif Display, URW Palladio L, P052, Sylfaen, serif;
   --line-font-handwritten: Segoe Print, Bradley Hand, Chilanka, TSCu_Comic, casual, cursive;
 
-  /* Aliases — line:// uses custom stacks for sans/serif/mono */
+  /* Custom stacks — line:// defines its own sans/serif/mono (not OP aliases) */
   --line-font-sans: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
   --line-font-serif: ui-serif, serif;
   --line-font-mono:

--- a/packages/theme/src/tokens/typography.css
+++ b/packages/theme/src/tokens/typography.css
@@ -1,0 +1,111 @@
+/* ═══════════════════════════════════════════════════════════
+   typography.css — line://ui Typography Tokens
+
+   Font families, weights, line-heights, letter-spacings,
+   and font-sizes (static + fluid).
+
+   Open Props 1:1 mapping (19 families, 9 weights, 7 line-heights,
+   8 letter-spacings, 10 static + 4 fluid font-sizes)
+   plus line:// extensions (3 extra line-heights, 2 extra
+   letter-spacings, renumbered font-size scale to 10 steps).
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Font Families (OP 19) ── */
+
+:where(html) {
+  --line-font-system-ui: system-ui, sans-serif;
+  --line-font-transitional: Charter, Bitstream Charter, Sitka Text, Cambria, serif;
+  --line-font-old-style: Iowan Old Style, Palatino Linotype, URW Palladio L, P052, serif;
+  --line-font-humanist: Seravek, Gill Sans Nova, Ubuntu, Calibri, DejaVu Sans, source-sans-pro, sans-serif;
+  --line-font-geometric-humanist: Avenir, Montserrat, Corbel, URW Gothic, source-sans-pro, sans-serif;
+  --line-font-classical-humanist: Optima, Candara, Noto Sans, source-sans-pro, sans-serif;
+  --line-font-neo-grotesque: Inter, Roboto, Helvetica Neue, Arial Nova, Nimbus Sans, Arial, sans-serif;
+  --line-font-monospace-slab-serif: Nimbus Mono PS, Courier New, monospace;
+  --line-font-monospace-code:
+    Dank Mono, Operator Mono, Inconsolata, Fira Mono, ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro, Cascadia Code, Menlo, Consolas, DejaVu Sans Mono, monospace;
+  --line-font-industrial:
+    Bahnschrift, DIN Alternate, Franklin Gothic Medium, Nimbus Sans Narrow, sans-serif-condensed, sans-serif;
+  --line-font-rounded-sans:
+    ui-rounded, Hiragino Maru Gothic ProN, Quicksand, Comfortaa, Manjari, Arial Rounded MT, Arial Rounded MT Bold, Calibri, source-sans-pro, sans-serif;
+  --line-font-slab-serif: Rockwell, Rockwell Nova, Roboto Slab, DejaVu Serif, Sitka Small, serif;
+  --line-font-antique: Superclarendon, Bookman Old Style, URW Bookman, URW Bookman L, Georgia Pro, Georgia, serif;
+  --line-font-didone: Didot, Bodoni MT, Noto Serif Display, URW Palladio L, P052, Sylfaen, serif;
+  --line-font-handwritten: Segoe Print, Bradley Hand, Chilanka, TSCu_Comic, casual, cursive;
+
+  /* Aliases — line:// uses custom stacks for sans/serif/mono */
+  --line-font-sans: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  --line-font-serif: ui-serif, serif;
+  --line-font-mono:
+    Dank Mono, Operator Mono, Inconsolata, Fira Mono, ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro,
+    monospace;
+}
+
+/* ── Font Weights (OP 9) ── */
+
+:where(html) {
+  --line-font-weight-1: 100;
+  --line-font-weight-2: 200;
+  --line-font-weight-3: 300;
+  --line-font-weight-4: 400;
+  --line-font-weight-5: 500;
+  --line-font-weight-6: 600;
+  --line-font-weight-7: 700;
+  --line-font-weight-8: 800;
+  --line-font-weight-9: 900;
+}
+
+/* ── Line Height (OP 7 + 3 line:// extensions = 10) ──
+   OP --font-lineheight-00..5 mapped to --line-font-lineheight-0..6.
+   Extensions: 7 (2.25), 8 (2.5), 9 (3). */
+
+:where(html) {
+  --line-font-lineheight-0: 0.95;
+  --line-font-lineheight-1: 1.1;
+  --line-font-lineheight-2: 1.25;
+  --line-font-lineheight-3: 1.375;
+  --line-font-lineheight-4: 1.5;
+  --line-font-lineheight-5: 1.75;
+  --line-font-lineheight-6: 2;
+  --line-font-lineheight-7: 2.25;
+  --line-font-lineheight-8: 2.5;
+  --line-font-lineheight-9: 3;
+}
+
+/* ── Letter Spacing (OP 8 + 2 line:// extensions = 10) ── */
+
+:where(html) {
+  --line-font-letterspacing-0: -0.05em;
+  --line-font-letterspacing-1: 0.025em;
+  --line-font-letterspacing-2: 0.05em;
+  --line-font-letterspacing-3: 0.075em;
+  --line-font-letterspacing-4: 0.15em;
+  --line-font-letterspacing-5: 0.5em;
+  --line-font-letterspacing-6: 0.75em;
+  --line-font-letterspacing-7: 1em;
+  --line-font-letterspacing-8: 1.5em;
+  --line-font-letterspacing-9: 2em;
+}
+
+/* ── Font Size — Static (OP 10 renumbered to 0..9) ── */
+
+:where(html) {
+  --line-font-size-0: 0.5rem;
+  --line-font-size-1: 0.75rem;
+  --line-font-size-2: 1rem;
+  --line-font-size-3: 1.1rem;
+  --line-font-size-4: 1.25rem;
+  --line-font-size-5: 1.5rem;
+  --line-font-size-6: 2rem;
+  --line-font-size-7: 2.5rem;
+  --line-font-size-8: 3rem;
+  --line-font-size-9: 3.5rem;
+}
+
+/* ── Font Size — Fluid (OP 4) ── */
+
+:where(html) {
+  --line-font-size-fluid-0: clamp(0.75rem, 2vw, 1rem);
+  --line-font-size-fluid-1: clamp(1rem, 4vw, 1.5rem);
+  --line-font-size-fluid-2: clamp(1.5rem, 6vw, 2.5rem);
+  --line-font-size-fluid-3: clamp(2rem, 9vw, 3.5rem);
+}

--- a/packages/theme/src/tokens/zindex.css
+++ b/packages/theme/src/tokens/zindex.css
@@ -1,0 +1,29 @@
+/* ═══════════════════════════════════════════════════════════
+   zindex.css — line://ui Z-Index / Layer Tokens
+
+   Open Props layers (6) + line:// semantic extensions (8).
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── OP Layer Tokens (6) ── */
+
+:where(html) {
+  --line-layer-1: 1;
+  --line-layer-2: 2;
+  --line-layer-3: 3;
+  --line-layer-4: 4;
+  --line-layer-5: 5;
+  --line-layer-important: 2147483647;
+}
+
+/* ── Semantic Z-Index Extensions (8) ── */
+
+:where(html) {
+  --line-z-dropdown: 50;
+  --line-z-sticky: 100;
+  --line-z-fixed: 200;
+  --line-z-overlay: 300;
+  --line-z-modal: 400;
+  --line-z-popover: 500;
+  --line-z-toast: 600;
+  --line-z-tooltip: 700;
+}


### PR DESCRIPTION
Create per-family CSS token files under packages/theme/src/tokens/ with
hardcoded values from Open Props source, plus line:// semantic extensions.

Token families: typography (61), sizing (74), borders (29), shadows (17+3
dark overrides), easing (81), zindex (14), aspects (6), durations (12),
opacity (3), focus (3), colors-absolute (2+color-scheme). Total ~302 tokens.

Barrel file at src/tokens.css imports all family files. All selectors use
:where(html) for zero specificity. No runtime Open Props dependency.

Update DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md to reflect the new tokens/
directory architecture replacing the single-file approach.

Ref: BEAD line-ui-zpy.1