### PR TITLE
fix(theme): add missing --line-light/--line-dark tokens to 27 schema …

### DIFF
--- a/packages/theme/src/schemas/blue.css
+++ b/packages/theme/src/schemas/blue.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-blue-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-blue-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-blue-1); /* High-contrast text (-12) */
+  --line-light: var(--line-blue-12); /* Light text */
+  --line-dark: var(--line-blue-1); /* Dark text */
   --line-solid-text: var(--line-blue-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/bronze.css
+++ b/packages/theme/src/schemas/bronze.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-bronze-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-bronze-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-bronze-1); /* High-contrast text (-12) */
+  --line-light: var(--line-bronze-12); /* Light text */
+  --line-dark: var(--line-bronze-1); /* Dark text */
   --line-solid-text: var(--line-bronze-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/brown.css
+++ b/packages/theme/src/schemas/brown.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-brown-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-brown-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-brown-1); /* High-contrast text (-12) */
+  --line-light: var(--line-brown-12); /* Light text */
+  --line-dark: var(--line-brown-1); /* Dark text */
   --line-solid-text: var(--line-brown-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/crimson.css
+++ b/packages/theme/src/schemas/crimson.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-crimson-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-crimson-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-crimson-1); /* High-contrast text (-12) */
+  --line-light: var(--line-crimson-12); /* Light text */
+  --line-dark: var(--line-crimson-1); /* Dark text */
   --line-solid-text: var(--line-crimson-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/cyan.css
+++ b/packages/theme/src/schemas/cyan.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-cyan-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-cyan-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-cyan-1); /* High-contrast text (-12) */
+  --line-light: var(--line-cyan-12); /* Light text */
+  --line-dark: var(--line-cyan-1); /* Dark text */
   --line-solid-text: var(--line-cyan-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/gold.css
+++ b/packages/theme/src/schemas/gold.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-gold-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-gold-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-gold-1); /* High-contrast text (-12) */
+  --line-light: var(--line-gold-12); /* Light text */
+  --line-dark: var(--line-gold-1); /* Dark text */
   --line-solid-text: var(--line-gold-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/grass.css
+++ b/packages/theme/src/schemas/grass.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-grass-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-grass-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-grass-1); /* High-contrast text (-12) */
+  --line-light: var(--line-grass-12); /* Light text */
+  --line-dark: var(--line-grass-1); /* Dark text */
   --line-solid-text: var(--line-grass-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/gray.css
+++ b/packages/theme/src/schemas/gray.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-gray-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-gray-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-gray-1); /* High-contrast text (-12) */
+  --line-light: var(--line-gray-12); /* Light text */
+  --line-dark: var(--line-gray-1); /* Dark text */
   --line-solid-text: var(--line-gray-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/green.css
+++ b/packages/theme/src/schemas/green.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-green-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-green-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-green-1); /* High-contrast text (-12) */
+  --line-light: var(--line-green-12); /* Light text */
+  --line-dark: var(--line-green-1); /* Dark text */
   --line-solid-text: var(--line-green-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/indigo.css
+++ b/packages/theme/src/schemas/indigo.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-indigo-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-indigo-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-indigo-1); /* High-contrast text (-12) */
+  --line-light: var(--line-indigo-12); /* Light text */
+  --line-dark: var(--line-indigo-1); /* Dark text */
   --line-solid-text: var(--line-indigo-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/lime.css
+++ b/packages/theme/src/schemas/lime.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-lime-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-lime-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-lime-1); /* High-contrast text (-12) */
+  --line-light: var(--line-lime-12); /* Light text */
+  --line-dark: var(--line-lime-1); /* Dark text */
   --line-solid-text: var(--line-lime-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/mauve.css
+++ b/packages/theme/src/schemas/mauve.css
@@ -29,6 +29,8 @@
   --line-solid-hover: var(--line-mauve-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-mauve-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-mauve-1); /* High-contrast text (-12) */
+  --line-light: var(--line-mauve-12); /* Light text */
+  --line-dark: var(--line-mauve-1); /* Dark text */
   --line-solid-text: var(--line-mauve-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/mint.css
+++ b/packages/theme/src/schemas/mint.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-mint-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-mint-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-mint-1); /* High-contrast text (-12) */
+  --line-light: var(--line-mint-12); /* Light text */
+  --line-dark: var(--line-mint-1); /* Dark text */
   --line-solid-text: var(--line-mint-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/olive.css
+++ b/packages/theme/src/schemas/olive.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-olive-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-olive-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-olive-1); /* High-contrast text (-12) */
+  --line-light: var(--line-olive-12); /* Light text */
+  --line-dark: var(--line-olive-1); /* Dark text */
   --line-solid-text: var(--line-olive-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/orange.css
+++ b/packages/theme/src/schemas/orange.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-orange-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-orange-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-orange-1); /* High-contrast text (-12) */
+  --line-light: var(--line-orange-12); /* Light text */
+  --line-dark: var(--line-orange-1); /* Dark text */
   --line-solid-text: var(--line-orange-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/pink.css
+++ b/packages/theme/src/schemas/pink.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-pink-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-pink-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-pink-1); /* High-contrast text (-12) */
+  --line-light: var(--line-pink-12); /* Light text */
+  --line-dark: var(--line-pink-1); /* Dark text */
   --line-solid-text: var(--line-pink-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/plum.css
+++ b/packages/theme/src/schemas/plum.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-plum-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-plum-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-plum-1); /* High-contrast text (-12) */
+  --line-light: var(--line-plum-12); /* Light text */
+  --line-dark: var(--line-plum-1); /* Dark text */
   --line-solid-text: var(--line-plum-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/purple.css
+++ b/packages/theme/src/schemas/purple.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-purple-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-purple-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-purple-1); /* High-contrast text (-12) */
+  --line-light: var(--line-purple-12); /* Light text */
+  --line-dark: var(--line-purple-1); /* Dark text */
   --line-solid-text: var(--line-purple-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/red.css
+++ b/packages/theme/src/schemas/red.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-red-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-red-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-red-1); /* High-contrast text (-12) */
+  --line-light: var(--line-red-12); /* Light text */
+  --line-dark: var(--line-red-1); /* Dark text */
   --line-solid-text: var(--line-red-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/sage.css
+++ b/packages/theme/src/schemas/sage.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-sage-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-sage-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-sage-1); /* High-contrast text (-12) */
+  --line-light: var(--line-sage-12); /* Light text */
+  --line-dark: var(--line-sage-1); /* Dark text */
   --line-solid-text: var(--line-sage-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/sand.css
+++ b/packages/theme/src/schemas/sand.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-sand-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-sand-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-sand-1); /* High-contrast text (-12) */
+  --line-light: var(--line-sand-12); /* Light text */
+  --line-dark: var(--line-sand-1); /* Dark text */
   --line-solid-text: var(--line-sand-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/sky.css
+++ b/packages/theme/src/schemas/sky.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-sky-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-sky-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-sky-1); /* High-contrast text (-12) */
+  --line-light: var(--line-sky-12); /* Light text */
+  --line-dark: var(--line-sky-1); /* Dark text */
   --line-solid-text: var(--line-sky-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/slate.css
+++ b/packages/theme/src/schemas/slate.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-slate-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-slate-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-slate-1); /* High-contrast text (-12) */
+  --line-light: var(--line-slate-12); /* Light text */
+  --line-dark: var(--line-slate-1); /* Dark text */
   --line-solid-text: var(--line-slate-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/teal.css
+++ b/packages/theme/src/schemas/teal.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-teal-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-teal-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-teal-1); /* High-contrast text (-12) */
+  --line-light: var(--line-teal-12); /* Light text */
+  --line-dark: var(--line-teal-1); /* Dark text */
   --line-solid-text: var(--line-teal-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/tomato.css
+++ b/packages/theme/src/schemas/tomato.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-tomato-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-tomato-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-tomato-1); /* High-contrast text (-12) */
+  --line-light: var(--line-tomato-12); /* Light text */
+  --line-dark: var(--line-tomato-1); /* Dark text */
   --line-solid-text: var(--line-tomato-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/violet.css
+++ b/packages/theme/src/schemas/violet.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-violet-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-violet-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-violet-1); /* High-contrast text (-12) */
+  --line-light: var(--line-violet-12); /* Light text */
+  --line-dark: var(--line-violet-1); /* Dark text */
   --line-solid-text: var(--line-violet-contrast); /* Solid background text */
 }
 

--- a/packages/theme/src/schemas/yellow.css
+++ b/packages/theme/src/schemas/yellow.css
@@ -31,6 +31,8 @@
   --line-solid-hover: var(--line-yellow-3); /* Hovered solid backgrounds (-10) */
   --line-low-contrast: var(--line-yellow-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-yellow-1); /* High-contrast text (-12) */
+  --line-light: var(--line-yellow-12); /* Light text */
+  --line-dark: var(--line-yellow-1); /* Dark text */
   --line-solid-text: var(--line-yellow-contrast); /* Solid background text */
 }
 


### PR DESCRIPTION
…dark blocks

Only amber.css had --line-light and --line-dark in its dark mode block. The remaining 27 palettes were missing these tokens, causing dark mode consumers to inherit the light-mode values (palette-1 for --line-light instead of the correct palette-12).

Dark mode mapping (inverted from light):
  --line-light: var(--line-{palette}-12)
  --line-dark: var(--line-{palette}-1)

All 28 dark blocks now have 15 consistent properties.