### PR TITLE
fix(theme): add missing --line-white/--line-black tokens to all 28 sc…

### DIFF
--- a/packages/theme/src/schemas/amber.css
+++ b/packages/theme/src/schemas/amber.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-amber-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-amber-12); /* High-contrast text (-12) */
   --line-light: var(--line-amber-1); /* Light text */
+  --line-white: var(--line-amber-1); /* White text */
+  --line-black: var(--line-amber-12); /* Black text */
   --line-dark: var(--line-amber-12); /* Dark text */
   --line-solid-text: var(--line-amber-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-amber-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-amber-1); /* High-contrast text (-12) */
   --line-light: var(--line-amber-12); /* Light text */
+  --line-white: var(--line-amber-1); /* White text */
+  --line-black: var(--line-amber-12); /* Black text */
   --line-dark: var(--line-amber-1); /* Dark text */
   --line-solid-text: var(--line-amber-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/blue.css
+++ b/packages/theme/src/schemas/blue.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-blue-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-blue-12); /* High-contrast text (-12) */
   --line-light: var(--line-blue-1); /* Light text */
+  --line-white: var(--line-blue-1); /* White text */
+  --line-black: var(--line-blue-12); /* Black text */
   --line-dark: var(--line-blue-12); /* Dark text */
   --line-solid-text: var(--line-blue-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-blue-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-blue-1); /* High-contrast text (-12) */
   --line-light: var(--line-blue-12); /* Light text */
+  --line-white: var(--line-blue-1); /* White text */
+  --line-black: var(--line-blue-12); /* Black text */
   --line-dark: var(--line-blue-1); /* Dark text */
   --line-solid-text: var(--line-blue-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/bronze.css
+++ b/packages/theme/src/schemas/bronze.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-bronze-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-bronze-12); /* High-contrast text (-12) */
   --line-light: var(--line-bronze-1); /* Light text */
+  --line-white: var(--line-bronze-1); /* White text */
+  --line-black: var(--line-bronze-12); /* Black text */
   --line-dark: var(--line-bronze-12); /* Dark text */
   --line-solid-text: var(--line-bronze-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-bronze-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-bronze-1); /* High-contrast text (-12) */
   --line-light: var(--line-bronze-12); /* Light text */
+  --line-white: var(--line-bronze-1); /* White text */
+  --line-black: var(--line-bronze-12); /* Black text */
   --line-dark: var(--line-bronze-1); /* Dark text */
   --line-solid-text: var(--line-bronze-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/brown.css
+++ b/packages/theme/src/schemas/brown.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-brown-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-brown-12); /* High-contrast text (-12) */
   --line-light: var(--line-brown-1); /* Light text */
+  --line-white: var(--line-brown-1); /* White text */
+  --line-black: var(--line-brown-12); /* Black text */
   --line-dark: var(--line-brown-12); /* Dark text */
   --line-solid-text: var(--line-brown-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-brown-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-brown-1); /* High-contrast text (-12) */
   --line-light: var(--line-brown-12); /* Light text */
+  --line-white: var(--line-brown-1); /* White text */
+  --line-black: var(--line-brown-12); /* Black text */
   --line-dark: var(--line-brown-1); /* Dark text */
   --line-solid-text: var(--line-brown-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/crimson.css
+++ b/packages/theme/src/schemas/crimson.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-crimson-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-crimson-12); /* High-contrast text (-12) */
   --line-light: var(--line-crimson-1); /* Light text */
+  --line-white: var(--line-crimson-1); /* White text */
+  --line-black: var(--line-crimson-12); /* Black text */
   --line-dark: var(--line-crimson-12); /* Dark text */
   --line-solid-text: var(--line-crimson-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-crimson-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-crimson-1); /* High-contrast text (-12) */
   --line-light: var(--line-crimson-12); /* Light text */
+  --line-white: var(--line-crimson-1); /* White text */
+  --line-black: var(--line-crimson-12); /* Black text */
   --line-dark: var(--line-crimson-1); /* Dark text */
   --line-solid-text: var(--line-crimson-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/cyan.css
+++ b/packages/theme/src/schemas/cyan.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-cyan-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-cyan-12); /* High-contrast text (-12) */
   --line-light: var(--line-cyan-1); /* Light text */
+  --line-white: var(--line-cyan-1); /* White text */
+  --line-black: var(--line-cyan-12); /* Black text */
   --line-dark: var(--line-cyan-12); /* Dark text */
   --line-solid-text: var(--line-cyan-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-cyan-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-cyan-1); /* High-contrast text (-12) */
   --line-light: var(--line-cyan-12); /* Light text */
+  --line-white: var(--line-cyan-1); /* White text */
+  --line-black: var(--line-cyan-12); /* Black text */
   --line-dark: var(--line-cyan-1); /* Dark text */
   --line-solid-text: var(--line-cyan-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/gold.css
+++ b/packages/theme/src/schemas/gold.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-gold-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-gold-12); /* High-contrast text (-12) */
   --line-light: var(--line-gold-1); /* Light text */
+  --line-white: var(--line-gold-1); /* White text */
+  --line-black: var(--line-gold-12); /* Black text */
   --line-dark: var(--line-gold-12); /* Dark text */
   --line-solid-text: var(--line-gold-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-gold-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-gold-1); /* High-contrast text (-12) */
   --line-light: var(--line-gold-12); /* Light text */
+  --line-white: var(--line-gold-1); /* White text */
+  --line-black: var(--line-gold-12); /* Black text */
   --line-dark: var(--line-gold-1); /* Dark text */
   --line-solid-text: var(--line-gold-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/grass.css
+++ b/packages/theme/src/schemas/grass.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-grass-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-grass-12); /* High-contrast text (-12) */
   --line-light: var(--line-grass-1); /* Light text */
+  --line-white: var(--line-grass-1); /* White text */
+  --line-black: var(--line-grass-12); /* Black text */
   --line-dark: var(--line-grass-12); /* Dark text */
   --line-solid-text: var(--line-grass-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-grass-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-grass-1); /* High-contrast text (-12) */
   --line-light: var(--line-grass-12); /* Light text */
+  --line-white: var(--line-grass-1); /* White text */
+  --line-black: var(--line-grass-12); /* Black text */
   --line-dark: var(--line-grass-1); /* Dark text */
   --line-solid-text: var(--line-grass-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/gray.css
+++ b/packages/theme/src/schemas/gray.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-gray-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-gray-12); /* High-contrast text (-12) */
   --line-light: var(--line-gray-1); /* Light text */
+  --line-white: var(--line-gray-1); /* White text */
+  --line-black: var(--line-gray-12); /* Black text */
   --line-dark: var(--line-gray-12); /* Dark text */
   --line-solid-text: var(--line-gray-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-gray-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-gray-1); /* High-contrast text (-12) */
   --line-light: var(--line-gray-12); /* Light text */
+  --line-white: var(--line-gray-1); /* White text */
+  --line-black: var(--line-gray-12); /* Black text */
   --line-dark: var(--line-gray-1); /* Dark text */
   --line-solid-text: var(--line-gray-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/green.css
+++ b/packages/theme/src/schemas/green.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-green-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-green-12); /* High-contrast text (-12) */
   --line-light: var(--line-green-1); /* Light text */
+  --line-white: var(--line-green-1); /* White text */
+  --line-black: var(--line-green-12); /* Black text */
   --line-dark: var(--line-green-12); /* Dark text */
   --line-solid-text: var(--line-green-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-green-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-green-1); /* High-contrast text (-12) */
   --line-light: var(--line-green-12); /* Light text */
+  --line-white: var(--line-green-1); /* White text */
+  --line-black: var(--line-green-12); /* Black text */
   --line-dark: var(--line-green-1); /* Dark text */
   --line-solid-text: var(--line-green-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/indigo.css
+++ b/packages/theme/src/schemas/indigo.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-indigo-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-indigo-12); /* High-contrast text (-12) */
   --line-light: var(--line-indigo-1); /* Light text */
+  --line-white: var(--line-indigo-1); /* White text */
+  --line-black: var(--line-indigo-12); /* Black text */
   --line-dark: var(--line-indigo-12); /* Dark text */
   --line-solid-text: var(--line-indigo-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-indigo-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-indigo-1); /* High-contrast text (-12) */
   --line-light: var(--line-indigo-12); /* Light text */
+  --line-white: var(--line-indigo-1); /* White text */
+  --line-black: var(--line-indigo-12); /* Black text */
   --line-dark: var(--line-indigo-1); /* Dark text */
   --line-solid-text: var(--line-indigo-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/lime.css
+++ b/packages/theme/src/schemas/lime.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-lime-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-lime-12); /* High-contrast text (-12) */
   --line-light: var(--line-lime-1); /* Light text */
+  --line-white: var(--line-lime-1); /* White text */
+  --line-black: var(--line-lime-12); /* Black text */
   --line-dark: var(--line-lime-12); /* Dark text */
   --line-solid-text: var(--line-lime-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-lime-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-lime-1); /* High-contrast text (-12) */
   --line-light: var(--line-lime-12); /* Light text */
+  --line-white: var(--line-lime-1); /* White text */
+  --line-black: var(--line-lime-12); /* Black text */
   --line-dark: var(--line-lime-1); /* Dark text */
   --line-solid-text: var(--line-lime-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/mauve.css
+++ b/packages/theme/src/schemas/mauve.css
@@ -12,6 +12,8 @@
   --line-low-contrast: var(--line-mauve-11); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-mauve-12); /* High-contrast text (-12) */
   --line-light: var(--line-mauve-1); /* Light text */
+  --line-white: var(--line-mauve-1); /* White text */
+  --line-black: var(--line-mauve-12); /* Black text */
   --line-dark: var(--line-mauve-12); /* Dark text */
   --line-solid-text: var(--line-mauve-contrast); /* Solid background text */
 }
@@ -30,6 +32,8 @@
   --line-low-contrast: var(--line-mauve-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-mauve-1); /* High-contrast text (-12) */
   --line-light: var(--line-mauve-12); /* Light text */
+  --line-white: var(--line-mauve-1); /* White text */
+  --line-black: var(--line-mauve-12); /* Black text */
   --line-dark: var(--line-mauve-1); /* Dark text */
   --line-solid-text: var(--line-mauve-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/mint.css
+++ b/packages/theme/src/schemas/mint.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-mint-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-mint-1); /* High-contrast text (-12) */
   --line-light: var(--line-mint-12); /* Light text */
+  --line-white: var(--line-mint-1); /* White text */
+  --line-black: var(--line-mint-12); /* Black text */
   --line-dark: var(--line-mint-1); /* Dark text */
   --line-solid-text: var(--line-mint-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/olive.css
+++ b/packages/theme/src/schemas/olive.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-olive-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-olive-1); /* High-contrast text (-12) */
   --line-light: var(--line-olive-12); /* Light text */
+  --line-white: var(--line-olive-1); /* White text */
+  --line-black: var(--line-olive-12); /* Black text */
   --line-dark: var(--line-olive-1); /* Dark text */
   --line-solid-text: var(--line-olive-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/orange.css
+++ b/packages/theme/src/schemas/orange.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-orange-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-orange-1); /* High-contrast text (-12) */
   --line-light: var(--line-orange-12); /* Light text */
+  --line-white: var(--line-orange-1); /* White text */
+  --line-black: var(--line-orange-12); /* Black text */
   --line-dark: var(--line-orange-1); /* Dark text */
   --line-solid-text: var(--line-orange-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/pink.css
+++ b/packages/theme/src/schemas/pink.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-pink-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-pink-1); /* High-contrast text (-12) */
   --line-light: var(--line-pink-12); /* Light text */
+  --line-white: var(--line-pink-1); /* White text */
+  --line-black: var(--line-pink-12); /* Black text */
   --line-dark: var(--line-pink-1); /* Dark text */
   --line-solid-text: var(--line-pink-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/plum.css
+++ b/packages/theme/src/schemas/plum.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-plum-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-plum-1); /* High-contrast text (-12) */
   --line-light: var(--line-plum-12); /* Light text */
+  --line-white: var(--line-plum-1); /* White text */
+  --line-black: var(--line-plum-12); /* Black text */
   --line-dark: var(--line-plum-1); /* Dark text */
   --line-solid-text: var(--line-plum-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/purple.css
+++ b/packages/theme/src/schemas/purple.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-purple-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-purple-1); /* High-contrast text (-12) */
   --line-light: var(--line-purple-12); /* Light text */
+  --line-white: var(--line-purple-1); /* White text */
+  --line-black: var(--line-purple-12); /* Black text */
   --line-dark: var(--line-purple-1); /* Dark text */
   --line-solid-text: var(--line-purple-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/red.css
+++ b/packages/theme/src/schemas/red.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-red-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-red-1); /* High-contrast text (-12) */
   --line-light: var(--line-red-12); /* Light text */
+  --line-white: var(--line-red-1); /* White text */
+  --line-black: var(--line-red-12); /* Black text */
   --line-dark: var(--line-red-1); /* Dark text */
   --line-solid-text: var(--line-red-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/sage.css
+++ b/packages/theme/src/schemas/sage.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-sage-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-sage-1); /* High-contrast text (-12) */
   --line-light: var(--line-sage-12); /* Light text */
+  --line-white: var(--line-sage-1); /* White text */
+  --line-black: var(--line-sage-12); /* Black text */
   --line-dark: var(--line-sage-1); /* Dark text */
   --line-solid-text: var(--line-sage-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/sand.css
+++ b/packages/theme/src/schemas/sand.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-sand-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-sand-1); /* High-contrast text (-12) */
   --line-light: var(--line-sand-12); /* Light text */
+  --line-white: var(--line-sand-1); /* White text */
+  --line-black: var(--line-sand-12); /* Black text */
   --line-dark: var(--line-sand-1); /* Dark text */
   --line-solid-text: var(--line-sand-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/sky.css
+++ b/packages/theme/src/schemas/sky.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-sky-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-sky-1); /* High-contrast text (-12) */
   --line-light: var(--line-sky-12); /* Light text */
+  --line-white: var(--line-sky-1); /* White text */
+  --line-black: var(--line-sky-12); /* Black text */
   --line-dark: var(--line-sky-1); /* Dark text */
   --line-solid-text: var(--line-sky-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/slate.css
+++ b/packages/theme/src/schemas/slate.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-slate-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-slate-1); /* High-contrast text (-12) */
   --line-light: var(--line-slate-12); /* Light text */
+  --line-white: var(--line-slate-1); /* White text */
+  --line-black: var(--line-slate-12); /* Black text */
   --line-dark: var(--line-slate-1); /* Dark text */
   --line-solid-text: var(--line-slate-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/teal.css
+++ b/packages/theme/src/schemas/teal.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-teal-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-teal-1); /* High-contrast text (-12) */
   --line-light: var(--line-teal-12); /* Light text */
+  --line-white: var(--line-teal-1); /* White text */
+  --line-black: var(--line-teal-12); /* Black text */
   --line-dark: var(--line-teal-1); /* Dark text */
   --line-solid-text: var(--line-teal-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/tomato.css
+++ b/packages/theme/src/schemas/tomato.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-tomato-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-tomato-1); /* High-contrast text (-12) */
   --line-light: var(--line-tomato-12); /* Light text */
+  --line-white: var(--line-tomato-1); /* White text */
+  --line-black: var(--line-tomato-12); /* Black text */
   --line-dark: var(--line-tomato-1); /* Dark text */
   --line-solid-text: var(--line-tomato-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/violet.css
+++ b/packages/theme/src/schemas/violet.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-violet-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-violet-1); /* High-contrast text (-12) */
   --line-light: var(--line-violet-12); /* Light text */
+  --line-white: var(--line-violet-1); /* White text */
+  --line-black: var(--line-violet-12); /* Black text */
   --line-dark: var(--line-violet-1); /* Dark text */
   --line-solid-text: var(--line-violet-contrast); /* Solid background text */
 }

--- a/packages/theme/src/schemas/yellow.css
+++ b/packages/theme/src/schemas/yellow.css
@@ -32,6 +32,8 @@
   --line-low-contrast: var(--line-yellow-2); /* Low-contrast text (-11) */
   --line-high-contrast: var(--line-yellow-1); /* High-contrast text (-12) */
   --line-light: var(--line-yellow-12); /* Light text */
+  --line-white: var(--line-yellow-1); /* White text */
+  --line-black: var(--line-yellow-12); /* Black text */
   --line-dark: var(--line-yellow-1); /* Dark text */
   --line-solid-text: var(--line-yellow-contrast); /* Solid background text */
 }


### PR DESCRIPTION
…hema palettes

- Add --line-white and --line-black to light blocks of 13 palettes that were missing them (amber, blue, bronze, brown, crimson, cyan, gold, grass, gray, green, indigo, lime, mauve)
- Add --line-white and --line-black to dark blocks of all 28 palettes (none had them previously)
- All 28 schemas now have 17 tokens in both light and dark blocks
- --line-white always references palette level 1 (lightest shade)
- --line-black always references palette level 12 (darkest shade)

Resolves: line-ui-p3v.3