### PR TITLE
chore(theme): deduplicate PostCSS plugin chain into shared postcss-pi…

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,7 +15,6 @@
     "cssnano": "^6.0.1",
     "open-props": "^1.6.5",
     "postcss": "^8.4.31",
-    "postcss-cli": "^10.1.0",
     "postcss-custom-media": "^10.0.2",
     "postcss-import": "^15.1.0",
     "postcss-jit-props": "^1.0.13",

--- a/packages/theme/postcss.config.mjs
+++ b/packages/theme/postcss.config.mjs
@@ -1,43 +1,7 @@
-import cssNano from 'cssnano';
-import customMedia from 'postcss-custom-media';
-import postcssImport from 'postcss-import';
-import postcssMixins from 'postcss-mixins';
-import postcssNested from 'postcss-nested';
-import postcssPresetEnv from 'postcss-preset-env';
-import postcssSimpleVars from 'postcss-simple-vars';
+// PostCSS config for Vite dev server (auto-discovered by convention).
+// Plugin chain is defined in src/postcss-pipeline.ts (single source of truth).
+import { createPlugins } from './src/postcss-pipeline.ts';
 
-// TODO(line-ui-c5q.1): Add postcss-jit-props plugin here for Open Props utility token
-// injection with --line-* prefix rewrite. The dependency is already installed; it needs
-// to be activated in this pipeline. See PRD 9.3 and Decision T3.
-//
-// NOTE: This plugin chain is duplicated in src/build.ts:createProcessor().
-// If you add/remove/reconfigure a plugin here, update build.ts to match.
 export default {
-  plugins: [
-    postcssImport(),
-    postcssMixins(),
-    postcssSimpleVars(),
-    postcssNested(),
-    postcssPresetEnv({
-      autoprefixer: false,
-      features: {
-        'color-functional-notation': false,
-        'custom-media-queries': { preserve: true },
-        'custom-properties': false,
-        'double-position-gradients': false,
-        'focus-visible-pseudo-class': false,
-        'focus-within-pseudo-class': false,
-        'gap-properties': false,
-        'logical-properties-and-values': false,
-        'not-pseudo-class': false,
-        'place-properties': false,
-        'prefers-color-scheme-query': false
-      },
-      stage: 0
-    }),
-    customMedia(),
-    cssNano({
-      preset: 'default'
-    })
-  ]
+  plugins: await createPlugins()
 };

--- a/packages/theme/src/build.ts
+++ b/packages/theme/src/build.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import { Glob } from 'bun';
 import postcss from 'postcss';
+import { createPlugins } from './postcss-pipeline';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -29,55 +30,11 @@ const DIST = join(ROOT, 'dist');
 const CONCURRENCY = 16;
 
 // ---------------------------------------------------------------------------
-// PostCSS plugin chain (mirrors postcss.config.mjs — keep both in sync)
+// PostCSS processor (plugin chain defined in postcss-pipeline.ts)
 // ---------------------------------------------------------------------------
 
 async function createProcessor(): Promise<postcss.Processor> {
-  const [
-    { default: postcssImport },
-    { default: postcssMixins },
-    { default: postcssSimpleVars },
-    { default: postcssNested },
-    { default: postcssPresetEnv },
-    { default: customMedia },
-    { default: cssNano },
-  ] = await Promise.all([
-    import('postcss-import'),
-    import('postcss-mixins'),
-    import('postcss-simple-vars'),
-    import('postcss-nested'),
-    import('postcss-preset-env'),
-    import('postcss-custom-media'),
-    import('cssnano'),
-  ]);
-
-  return postcss([
-    postcssImport(),
-    postcssMixins(),
-    postcssSimpleVars(),
-    postcssNested(),
-    (postcssPresetEnv as any)({
-      autoprefixer: false,
-      features: {
-        'color-functional-notation': false,
-        'custom-media-queries': { preserve: true },
-        'custom-properties': false,
-        'double-position-gradients': false,
-        'focus-visible-pseudo-class': false,
-        'focus-within-pseudo-class': false,
-        'gap-properties': false,
-        'logical-properties-and-values': false,
-        'not-pseudo-class': false,
-        'place-properties': false,
-        'prefers-color-scheme-query': false,
-      },
-      stage: 0,
-    }),
-    customMedia(),
-    (cssNano as any)({
-      preset: 'default',
-    }),
-  ]);
+  return postcss(await createPlugins());
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/theme/src/postcss-pipeline.ts
+++ b/packages/theme/src/postcss-pipeline.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared PostCSS plugin pipeline — single source of truth.
+ *
+ * Both `build.ts` (production build) and `postcss.config.mjs` (Vite dev server)
+ * import from this module so the plugin chain is defined exactly once.
+ *
+ * The factory uses dynamic imports to preserve lazy-loading: plugins are only
+ * loaded when `createPlugins()` is called, not at module evaluation time.
+ *
+ * @module postcss-pipeline
+ */
+
+import type { AcceptedPlugin } from 'postcss';
+
+// TODO(line-ui-c5q.1): Add postcss-jit-props plugin for Open Props utility token
+// injection with --line-* prefix rewrite. The dependency is already installed; it needs
+// to be activated in this pipeline. See PRD 9.3 and Decision T3.
+
+/**
+ * Lazily load and configure the full PostCSS plugin chain.
+ *
+ * @returns Array of PostCSS plugins, ready to pass to `postcss()` or a config object.
+ */
+export async function createPlugins(): Promise<AcceptedPlugin[]> {
+  const [
+    { default: postcssImport },
+    { default: postcssMixins },
+    { default: postcssSimpleVars },
+    { default: postcssNested },
+    { default: postcssPresetEnv },
+    { default: customMedia },
+    { default: cssNano }
+  ] = await Promise.all([
+    import('postcss-import'),
+    import('postcss-mixins'),
+    import('postcss-simple-vars'),
+    import('postcss-nested'),
+    import('postcss-preset-env'),
+    import('postcss-custom-media'),
+    import('cssnano')
+  ]);
+
+  return [
+    postcssImport(),
+    postcssMixins(),
+    postcssSimpleVars(),
+    postcssNested(),
+    (postcssPresetEnv as any)({
+      autoprefixer: false,
+      features: {
+        'color-functional-notation': false,
+        'custom-media-queries': { preserve: true },
+        'custom-properties': false,
+        'double-position-gradients': false,
+        'focus-visible-pseudo-class': false,
+        'focus-within-pseudo-class': false,
+        'gap-properties': false,
+        'logical-properties-and-values': false,
+        'not-pseudo-class': false,
+        'place-properties': false,
+        'prefers-color-scheme-query': false
+      },
+      stage: 0
+    }),
+    customMedia(),
+    (cssNano as any)({
+      preset: 'default'
+    })
+  ];
+}


### PR DESCRIPTION
…peline.ts

Extract the PostCSS plugin configuration from both build.ts:createProcessor() and postcss.config.mjs into a single shared factory in src/postcss-pipeline.ts.

Both consumers now import createPlugins() from the shared module, eliminating the byte-for-byte duplication of 7 plugins and their configuration. The lazy dynamic-import pattern is preserved for build startup performance.

Also removes unused postcss-cli devDependency (legacy from pre-build.ts era).

Resolves: line-ui-p3v.6