### PR TITLE
chore(theme): remove unnecessary ambient type declarations and elimin…

### DIFF
--- a/packages/theme/src/postcss-pipeline.ts
+++ b/packages/theme/src/postcss-pipeline.ts
@@ -45,8 +45,11 @@ export async function createPlugins(): Promise<AcceptedPlugin[]> {
     postcssMixins(),
     postcssSimpleVars(),
     postcssNested(),
-    (postcssPresetEnv as any)({
-      autoprefixer: false,
+    postcssPresetEnv({
+      // The shipped types for postcss-preset-env@9 only accept autoprefixer.Options,
+      // but the runtime also accepts `false` to disable autoprefixer entirely.
+      // Use a targeted assertion instead of casting the whole call to `any`.
+      autoprefixer: false as never,
       features: {
         'color-functional-notation': false,
         'custom-media-queries': { preserve: true },
@@ -63,7 +66,7 @@ export async function createPlugins(): Promise<AcceptedPlugin[]> {
       stage: 0
     }),
     customMedia(),
-    (cssNano as any)({
+    cssNano({
       preset: 'default'
     })
   ];

--- a/packages/theme/src/postcss-plugins.d.ts
+++ b/packages/theme/src/postcss-plugins.d.ts
@@ -1,5 +1,10 @@
 /**
- * Type declarations for PostCSS plugins that lack built-in types.
+ * Ambient type declarations for PostCSS plugins that lack built-in types.
+ *
+ * Only plugins without shipped .d.ts files need declarations here.
+ * Plugins with shipped types (postcss-preset-env, cssnano, postcss-nested,
+ * postcss-simple-vars, postcss-custom-media) are intentionally omitted so
+ * TypeScript resolves their real, narrowly-typed definitions.
  */
 declare module 'postcss-import' {
   import type { PluginCreator } from 'postcss';
@@ -8,36 +13,6 @@ declare module 'postcss-import' {
 }
 
 declare module 'postcss-mixins' {
-  import type { PluginCreator } from 'postcss';
-  const plugin: PluginCreator<Record<string, unknown>>;
-  export default plugin;
-}
-
-declare module 'postcss-simple-vars' {
-  import type { PluginCreator } from 'postcss';
-  const plugin: PluginCreator<Record<string, unknown>>;
-  export default plugin;
-}
-
-declare module 'postcss-nested' {
-  import type { PluginCreator } from 'postcss';
-  const plugin: PluginCreator<Record<string, unknown>>;
-  export default plugin;
-}
-
-declare module 'postcss-preset-env' {
-  import type { PluginCreator } from 'postcss';
-  const plugin: PluginCreator<Record<string, unknown>>;
-  export default plugin;
-}
-
-declare module 'postcss-custom-media' {
-  import type { PluginCreator } from 'postcss';
-  const plugin: PluginCreator<Record<string, unknown>>;
-  export default plugin;
-}
-
-declare module 'cssnano' {
   import type { PluginCreator } from 'postcss';
   const plugin: PluginCreator<Record<string, unknown>>;
   export default plugin;


### PR DESCRIPTION
…ate broad as-any casts

Remove ambient module declarations for 5 PostCSS plugins that ship their own .d.ts files (postcss-preset-env, cssnano, postcss-nested, postcss-simple-vars, postcss-custom-media). Keep declarations only for postcss-import and postcss-mixins which genuinely lack shipped types.

Remove the broad `as any` cast on the cssnano call site entirely. Replace the broad `as any` cast on postcss-preset-env with a targeted `false as never` on the autoprefixer field only (shipped types omit the `false` variant that the runtime accepts to disable autoprefixer).