### PR TITLE
fix(theme): align --invertedColors whitespace with Open Props convention

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -46,7 +46,8 @@
             "allow": ["error", "info", "group"]
           }
         },
-        "noExplicitAny": "warn"
+        "noExplicitAny": "warn",
+        "noUnknownAtRules": "off"
       },
       "performance": {
         "noBarrelFile": "warn"

--- a/packages/theme/src/utils/media.css
+++ b/packages/theme/src/utils/media.css
@@ -11,7 +11,7 @@
 @custom-media --highContrast  (prefers-contrast: more);
 @custom-media --lowContrast   (prefers-contrast: less);
 
-@custom-media --invertedColors (inverted-colors: inverted);
+@custom-media --invertedColors  (inverted-colors: inverted);
 @custom-media --forcedColors  (forced-colors: active);
 
 @custom-media --portrait      (orientation: portrait);


### PR DESCRIPTION
Add second space before opening paren on media.css line 14 to match the Open Props source formatting (2-space minimum gap for the longest custom media name).

Also disable noUnknownAtRules in biome.json since @custom-media is a valid PostCSS at-rule processed by postcss-custom-media plugin.