### PR TITLE
chore(theme): prefix all unprefixed foundation tokens in normalize.cs…

### DIFF
--- a/packages/theme/src/utils/normalize.css
+++ b/packages/theme/src/utils/normalize.css
@@ -19,8 +19,8 @@
 
 :where(html) {
   block-size: 100%;
-  font-family: var(--font-sans);
-  line-height: var(--font-lineheight-3);
+  font-family: var(--line-font-sans);
+  line-height: var(--line-font-lineheight-3);
   -webkit-text-size-adjust: none; /* https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/ */
 
   @media (--motionOK) {
@@ -30,7 +30,7 @@
 
 @media (--motionOK) {
   :where(:focus-visible) {
-    transition: outline-offset 145ms var(--ease-2);
+    transition: outline-offset 145ms var(--line-ease-2);
   }
   :where(:not(:active):focus-visible) {
     transition-duration: 0.25s;
@@ -46,37 +46,37 @@
 }
 
 :where(h1, h2, h3, h4, h5, h6) {
-  line-height: var(--font-lineheight-1);
-  font-weight: var(--font-weight-9);
+  line-height: var(--line-font-lineheight-1);
+  font-weight: var(--line-font-weight-9);
   text-wrap: balance;
 }
 
 :where(h1) {
-  font-size: var(--font-size-8);
-  max-inline-size: var(--size-header-1);
+  font-size: var(--line-font-size-8);
+  max-inline-size: var(--line-size-header-1);
 }
 
 :where(h2) {
-  font-size: var(--font-size-6);
-  max-inline-size: var(--size-header-2);
+  font-size: var(--line-font-size-6);
+  max-inline-size: var(--line-size-header-2);
 }
 
 :where(h3) {
-  font-size: var(--font-size-5);
+  font-size: var(--line-font-size-5);
 }
 :where(h4) {
-  font-size: var(--font-size-4);
+  font-size: var(--line-font-size-4);
 }
 :where(h5) {
-  font-size: var(--font-size-3);
+  font-size: var(--line-font-size-3);
 }
 
 :where(h3, h4, h5, h6, dt) {
-  max-inline-size: var(--size-header-3);
+  max-inline-size: var(--line-size-header-3);
 }
 
 :where(p, ul, ol, dl, h6) {
-  font-size: var(--font-size-2);
+  font-size: var(--line-font-size-2);
 }
 
 :where(a, u, ins, abbr) {
@@ -106,10 +106,10 @@
 }
 
 :where(a) {
-  padding-inline: var(--size-1);
-  margin-inline: calc(var(--size-1) * -1);
-  padding-block: var(--size-1);
-  margin-block: calc(var(--size-1) * -1);
+  padding-inline: var(--line-size-1);
+  margin-inline: calc(var(--line-size-1) * -1);
+  padding-block: var(--line-size-1);
+  margin-block: calc(var(--line-size-1) * -1);
 
   &:where(:not(:hover)) {
     text-decoration: inherit;
@@ -139,17 +139,17 @@
 }
 
 :where(input:not([type="range"]), textarea) {
-  padding-inline: var(--size-2);
-  padding-block: var(--size-1);
+  padding-inline: var(--line-size-2);
+  padding-block: var(--line-size-1);
 }
 
 :where(select) {
-  padding-inline: var(--size-relative-4) 0;
+  padding-inline: var(--line-size-relative-4) 0;
   padding-block: 0.75ch;
 }
 
 :where(textarea, select, input:not([type="button"], [type="submit"], [type="reset"])) {
-  border-radius: var(--radius-2);
+  border-radius: var(--line-radius-2);
 }
 
 :where(textarea) {
@@ -157,16 +157,16 @@
 }
 
 :where(input[type="checkbox"], input[type="radio"]) {
-  block-size: var(--size-3);
-  inline-size: var(--size-3);
+  block-size: var(--line-size-3);
+  inline-size: var(--line-size-3);
 }
 
 :where(svg:not([width])) {
-  inline-size: var(--size-10);
+  inline-size: var(--line-size-10);
 }
 
 :where(code, kbd, samp, pre) {
-  font-family: var(--font-mono);
+  font-family: var(--line-font-mono);
 }
 :where(:not(pre) > code, kbd) {
   white-space: nowrap;
@@ -181,107 +181,107 @@
 }
 
 :where(:not(pre) > code) {
-  padding: var(--size-1) var(--size-2);
-  border-radius: var(--radius-2);
+  padding: var(--line-size-1) var(--line-size-2);
+  border-radius: var(--line-radius-2);
   writing-mode: lr;
 }
 
 :where(kbd, var) {
-  padding: var(--size-1) var(--size-2);
-  border-width: var(--border-size-1);
-  border-radius: var(--radius-2);
+  padding: var(--line-size-1) var(--line-size-2);
+  border-width: var(--line-border-size-1);
+  border-radius: var(--line-radius-2);
 }
 
 :where(mark) {
-  border-radius: var(--radius-2);
-  padding-inline: var(--size-1);
+  border-radius: var(--line-radius-2);
+  padding-inline: var(--line-size-1);
 }
 
 :where(ol, ul) {
-  padding-inline-start: var(--size-8);
+  padding-inline-start: var(--line-size-8);
 }
 :where(li) {
-  padding-inline-start: var(--size-2);
+  padding-inline-start: var(--line-size-2);
 }
 :where(li, dd, figcaption) {
-  max-inline-size: var(--size-content-2);
+  max-inline-size: var(--line-size-content-2);
 }
 :where(p) {
-  max-inline-size: var(--size-content-3);
+  max-inline-size: var(--line-size-content-3);
   text-wrap: pretty;
 }
 :where(dt, summary) {
-  font-weight: var(--font-weight-7);
+  font-weight: var(--line-font-weight-7);
 }
 
 :where(dt:not(:first-of-type)) {
-  margin-block-start: var(--size-5);
+  margin-block-start: var(--line-size-5);
 }
 
 :where(small) {
-  font-size: max(0.5em, var(--font-size-0));
-  max-inline-size: var(--size-content-1);
+  font-size: max(0.5em, var(--line-font-size-0));
+  max-inline-size: var(--line-size-content-1);
 }
 
 :where(hr) {
-  margin-block: var(--size-fluid-5);
-  height: var(--border-size-2);
+  margin-block: var(--line-size-fluid-5);
+  height: var(--line-border-size-2);
 }
 
 :where(figure) {
   display: grid;
-  gap: var(--size-2);
+  gap: var(--line-size-2);
   place-items: center;
 
   & > :where(figcaption) {
-    font-size: var(--font-size-1);
+    font-size: var(--line-font-size-1);
     text-wrap: balance;
   }
 }
 
 :where(blockquote, :not(blockquote) > cite) {
-  border-inline-start-width: var(--border-size-3);
+  border-inline-start-width: var(--line-border-size-3);
 }
 
 :where(blockquote) {
   display: grid;
-  gap: var(--size-3);
-  padding-block: var(--size-3);
-  padding-inline: var(--size-4);
-  max-inline-size: var(--size-content-2);
+  gap: var(--line-size-3);
+  padding-block: var(--line-size-3);
+  padding-inline: var(--line-size-4);
+  max-inline-size: var(--line-size-content-2);
 }
 
 :where(:not(blockquote) > cite) {
-  padding-inline-start: var(--size-2);
+  padding-inline-start: var(--line-size-2);
 }
 
 :where(summary) {
-  padding: var(--size-2) var(--size-3);
-  margin: calc(var(--size-2) * -1) calc(var(--size-3) * -1);
-  border-radius: var(--radius-2);
+  padding: var(--line-size-2) var(--line-size-3);
+  margin: calc(var(--line-size-2) * -1) calc(var(--line-size-3) * -1);
+  border-radius: var(--line-radius-2);
 }
 
 :where(details) {
-  padding-inline: var(--size-3);
-  padding-block: var(--size-2);
-  border-radius: var(--radius-2);
+  padding-inline: var(--line-size-3);
+  padding-block: var(--line-size-2);
+  border-radius: var(--line-radius-2);
 }
 
 :where(details[open] > summary) {
-  margin-bottom: var(--size-2);
+  margin-bottom: var(--line-size-2);
   border-end-start-radius: 0;
   border-end-end-radius: 0;
 }
 
 :where(fieldset) {
-  border-radius: var(--radius-2);
-  border: var(--border-size-1) solid var(--surface-4);
+  border-radius: var(--line-radius-2);
+  border: var(--line-border-size-1) solid var(--line-gray-5, hsl(210 11% 85%));
 }
 
 :where(dialog) {
   color: inherit;
-  border-radius: var(--radius-3);
-  box-shadow: var(--shadow-6);
+  border-radius: var(--line-radius-3);
+  box-shadow: var(--line-shadow-6);
 
   &::backdrop {
     backdrop-filter: blur(25px);
@@ -295,7 +295,7 @@
 :where(menu) {
   padding-inline-start: 0;
   display: flex;
-  gap: var(--size-3);
+  gap: var(--line-size-3);
 }
 
 :where(sup) {
@@ -304,9 +304,9 @@
 
 :where(table) {
   width: fit-content;
-  border-radius: var(--radius-3);
+  border-radius: var(--line-radius-3);
 
-  --nice-inner-radius: calc(var(--radius-3) - 2px);
+  --nice-inner-radius: calc(var(--line-radius-3) - 2px);
 }
 
 :where(table:not(:has(tfoot)) tr:last-child td:first-child) {
@@ -338,13 +338,13 @@
 }
 
 :where(td) {
-  max-inline-size: var(--size-content-2);
+  max-inline-size: var(--line-size-content-2);
   text-wrap: pretty;
 }
 
 :where(td, th) {
   text-align: left;
-  padding: var(--size-2);
+  padding: var(--line-size-2);
 }
 
 :where(:is(td, th):not([align])) {
@@ -356,10 +356,10 @@
 }
 
 :where(table > caption) {
-  margin: var(--size-3);
+  margin: var(--line-size-3);
 }
 
 :where(tfoot button) {
-  padding-block: var(--size-1);
-  padding-inline: var(--size-3);
+  padding-block: var(--line-size-1);
+  padding-inline: var(--line-size-3);
 }


### PR DESCRIPTION
…s to --line-*

Replace 65 occurrences of 20 distinct unprefixed Open Props custom property references with their --line-* equivalents as declared in packages/theme/src/tokens/.

Token mappings applied:
- --font-sans → --line-font-sans
- --font-lineheight-1/3 → --line-font-lineheight-1/3
- --font-weight-7/9 → --line-font-weight-7/9
- --font-size-0..8 → --line-font-size-0..8
- --font-mono → --line-font-mono
- --size-1..10 → --line-size-1..10
- --size-header-1/2/3 → --line-size-header-1/2/3
- --size-content-1/2/3 → --line-size-content-1/2/3
- --size-fluid-5 → --line-size-fluid-5
- --size-relative-4 → --line-size-relative-4
- --radius-2/3 → --line-radius-2/3
- --border-size-1/2/3 → --line-border-size-1/2/3
- --ease-2 → --line-ease-2
- --shadow-6 → --line-shadow-6
- --surface-4 → var(--line-gray-5, hsl(210 11% 85%)) (temporary; no --line-surface-* token exists)

Unchanged (correct as-is):
- --motionOK: PostCSS custom media query, not a CSS custom property
- --nice-inner-radius: local variable within table rule scope
- --line-gray-7: already correctly prefixed

Resolves line-ui-p3v.10