### PR TITLE
chore(theme): remove dead Open Props fallback block and migrate to --…

### DIFF
--- a/packages/theme/src/style.css
+++ b/packages/theme/src/style.css
@@ -114,17 +114,6 @@
   }
 }
 
-/* --- Fallbacks for Open Props tokens not yet activated --- */
-:root {
-  --radius-2: 5px;
-  --radius-3: 8px;
-  --border-size-1: 1px;
-  --border-size-2: 2px;
-  --border-size-3: 5px;
-  --ease-2: cubic-bezier(0.25, 0, 0.5, 1);
-  --surface-4: hsl(210 11% 85%);
-}
-
 /* --- Body --- */
 body {
   color: var(--line-low-contrast);
@@ -191,7 +180,7 @@ html {
       color: var(--line-low-contrast);
       text-decoration: none;
       padding: 0.375rem 0.625rem;
-      border-radius: var(--radius-2, 5px);
+      border-radius: var(--line-radius-2);
       white-space: nowrap;
       transition:
         color 0.15s ease,
@@ -421,7 +410,7 @@ html.light .wordmark-for-light {
     padding: var(--size-2, 0.5rem);
     align-items: center;
     justify-content: center;
-    border-radius: var(--radius-2, 5px);
+    border-radius: var(--line-radius-2);
   }
 }
 
@@ -520,7 +509,7 @@ html.light .wordmark-for-light {
   justify-content: center;
   padding: 1rem 0.5rem;
   min-height: 5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   outline: 1px solid var(--line-subtle-border);
   font-size: 0.6875rem;
   font-family: var(--font-mono);
@@ -538,7 +527,7 @@ html.light .wordmark-for-light {
 
 .showcase-palette-util-card {
   padding: 0.75rem 0.5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   font-size: 0.625rem;
   font-family: var(--font-mono);
   text-align: center;
@@ -573,7 +562,7 @@ html.light .wordmark-for-light {
 
 .showcase-font-family {
   padding: 1.5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   background-color: var(--line-subtle-background);
   margin-bottom: 1rem;
 
@@ -636,7 +625,7 @@ html.light .wordmark-for-light {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-3, 8px);
+  border-radius: var(--line-radius-3);
   background-color: var(--line-subtle-background);
   font-size: 0.75rem;
   font-family: var(--font-mono);
@@ -652,7 +641,7 @@ html.light .wordmark-for-light {
 
 .showcase-interactive-btn {
   padding: 0.75rem 1.5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   font-size: 0.875rem;
   font-family: var(--font-mono);
   cursor: pointer;
@@ -668,7 +657,7 @@ html.light .wordmark-for-light {
 /* --- Click interaction demo --- */
 .showcase-click-card {
   padding: 1.25rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   cursor: pointer;
   user-select: none;
   text-align: center;
@@ -684,7 +673,7 @@ html.light .wordmark-for-light {
   position: relative;
   overflow: hidden;
   padding: 2rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   cursor: pointer;
   text-align: center;
   font-family: var(--font-mono);
@@ -713,7 +702,7 @@ html.light .wordmark-for-light {
   align-items: center;
   gap: 0.75rem;
   padding: 1.5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   background-color: var(--line-subtle-background);
 
   & .spinner-label {
@@ -770,7 +759,7 @@ html.light .wordmark-for-light {
 }
 
 .showcase-theme-panel {
-  border-radius: var(--radius-3, 8px);
+  border-radius: var(--line-radius-3);
   padding: 1.5rem;
   outline: 1px solid var(--line-subtle-border);
 
@@ -791,7 +780,7 @@ html.light .wordmark-for-light {
 
   & .theme-panel-btn {
     padding: 0.5rem 1rem;
-    border-radius: var(--radius-2, 5px);
+    border-radius: var(--line-radius-2);
     font-size: 0.75rem;
     font-family: var(--font-mono);
     cursor: pointer;
@@ -801,7 +790,7 @@ html.light .wordmark-for-light {
 /* --- Cross-palette combos --- */
 .showcase-combo-card {
   padding: 1.5rem;
-  border-radius: var(--radius-3, 8px);
+  border-radius: var(--line-radius-3);
   margin-bottom: 1rem;
   font-family: var(--font-mono);
   font-size: 0.8125rem;
@@ -815,7 +804,7 @@ html.light .wordmark-for-light {
 
 .showcase-normalize-block {
   padding: 1.5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   background-color: var(--line-subtle-background);
 
   & h4 {
@@ -880,12 +869,12 @@ html.light .wordmark-for-light {
     border: 1px solid var(--line-ui-border);
     background-color: var(--line-background);
     color: var(--line-high-contrast);
-    border-radius: var(--radius-2, 5px);
+    border-radius: var(--line-radius-2);
   }
 
   & button {
     padding: 0.5rem 1rem;
-    border-radius: var(--radius-2, 5px);
+    border-radius: var(--line-radius-2);
     font-family: var(--font-mono);
     cursor: pointer;
   }
@@ -933,7 +922,7 @@ html.light .wordmark-for-light {
 
 .showcase-misc-card {
   padding: 1.25rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   background-color: var(--line-subtle-background);
   text-align: center;
 
@@ -964,7 +953,7 @@ html.light .wordmark-for-light {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: var(--radius-2, 5px);
+    border-radius: var(--line-radius-2);
     font-size: 0.75rem;
     font-family: var(--font-mono);
   }
@@ -973,7 +962,7 @@ html.light .wordmark-for-light {
 /* --- Selection demo --- */
 .showcase-selection-demo {
   padding: 1.5rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   background-color: var(--line-subtle-background);
   color: var(--line-high-contrast);
   line-height: var(--font-lineheight-5, 1.75);
@@ -998,7 +987,7 @@ html.light .wordmark-for-light {
 
 .showcase-transition-card {
   padding: 1rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   text-align: center;
   font-family: var(--font-mono);
   font-size: 0.75rem;
@@ -1016,7 +1005,7 @@ html.light .wordmark-for-light {
 .showcase-focus-demo button,
 .showcase-focus-demo a[href] {
   padding: 0.5rem 1rem;
-  border-radius: var(--radius-2, 5px);
+  border-radius: var(--line-radius-2);
   border: 1px solid var(--line-ui-border);
   background-color: var(--line-ui-background);
   color: var(--line-high-contrast);


### PR DESCRIPTION
…line-* tokens in style.css

The :root fallback block declaring raw OP names (--radius-2, --radius-3, --border-size-1/2/3, --ease-2, --surface-4) was dead code after normalize.css was migrated to --line-* tokens. Removed the block and replaced all 24 unprefixed var(--radius-2, 5px) / var(--radius-3, 8px) references with var(--line-radius-2) / var(--line-radius-3).