### PR TITLE
feat(theme): add gradient and noise tokens with 1:1 Open Props match

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,7 +27,8 @@
         "noUnusedImports": "error",
         "noUnusedVariables": "error",
         "noUnknownMediaFeatureName": "off",
-        "noUnknownPseudoClass": "off"
+        "noUnknownPseudoClass": "off",
+        "noInvalidDirectionInLinearGradient": "off"
       },
       "style": {
         "noParameterAssign": "error",

--- a/packages/theme/src/tokens.css
+++ b/packages/theme/src/tokens.css
@@ -19,4 +19,5 @@
 @import "./tokens/opacity.css";
 @import "./tokens/focus.css";
 @import "./tokens/animations.css";
+@import "./tokens/gradients.css";
 @import "./tokens/colors-absolute.css";

--- a/packages/theme/src/tokens/gradients.css
+++ b/packages/theme/src/tokens/gradients.css
@@ -1,0 +1,156 @@
+/* ═══════════════════════════════════════════════════════════
+   gradients.css — line://ui Gradient & Noise Tokens
+
+   Gradient space (1), gradients (1..30), noise textures (1..5),
+   noise filters (1..5).
+
+   Full 1:1 Open Props match (43 tokens + @supports upgrade).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  --line-gradient-space: ;
+
+  --line-gradient-1: linear-gradient(
+    to bottom right var(--line-gradient-space),
+    #1f005c,
+    #5b0060,
+    #870160,
+    #ac255e,
+    #ca485c,
+    #e16b5c,
+    #f39060,
+    #ffb56b
+  );
+  --line-gradient-2: linear-gradient(to bottom right var(--line-gradient-space), #48005c, #8300e2, #a269ff);
+  --line-gradient-3:
+    radial-gradient(circle at top right var(--line-gradient-space), hsl(180 100% 50%), hsl(180 100% 50% / 0%)),
+    radial-gradient(circle at bottom left var(--line-gradient-space), hsl(328 100% 54%), hsl(328 100% 54% / 0%));
+  --line-gradient-4: linear-gradient(to bottom right var(--line-gradient-space), #00f5a0, #00d9f5);
+  --line-gradient-5: conic-gradient(from -270deg at 75% 110% var(--line-gradient-space), fuchsia, floralwhite);
+  --line-gradient-6: conic-gradient(from -90deg at top left var(--line-gradient-space), black, white);
+  --line-gradient-7: linear-gradient(to bottom right var(--line-gradient-space), #72c6ef, #004e8f);
+  --line-gradient-8: conic-gradient(from 90deg at 50% 0% var(--line-gradient-space), #111, 50%, #222, #111);
+  --line-gradient-9: conic-gradient(from 0.5turn at bottom center var(--line-gradient-space), lightblue, white);
+  --line-gradient-10: conic-gradient(
+    from 90deg at 40% -25% var(--line-gradient-space),
+    #ffd700,
+    #f79d03,
+    #ee6907,
+    #e6390a,
+    #de0d0d,
+    #d61039,
+    #cf1261,
+    #c71585,
+    #cf1261,
+    #d61039,
+    #de0d0d,
+    #ee6907,
+    #f79d03,
+    #ffd700,
+    #ffd700,
+    #ffd700
+  );
+  --line-gradient-11: conic-gradient(at bottom left var(--line-gradient-space), deeppink, cyan);
+  --line-gradient-12: conic-gradient(
+    from 90deg at 25% -10% var(--line-gradient-space),
+    #ff4500,
+    #d3f340,
+    #7bee85,
+    #afeeee,
+    #7bee85
+  );
+  --line-gradient-13: radial-gradient(
+    circle at 50% 200% var(--line-gradient-space),
+    #000142,
+    #3b0083,
+    #b300c3,
+    #ff059f,
+    #ff4661,
+    #ffad86,
+    #fff3c7
+  );
+  --line-gradient-14: conic-gradient(at top right var(--line-gradient-space), lime, cyan);
+  --line-gradient-15: linear-gradient(to bottom right var(--line-gradient-space), #c7d2fe, #fecaca, #fef3c7);
+  --line-gradient-16: radial-gradient(circle at 50% -250% var(--line-gradient-space), #374151, #111827, #000);
+  --line-gradient-17: conic-gradient(from -90deg at 50% -25% var(--line-gradient-space), blue, blueviolet);
+  --line-gradient-18:
+    linear-gradient(0deg var(--line-gradient-space), hsla(0 100% 50% / 80%), hsla(0 100% 50% / 0) 75%),
+    linear-gradient(60deg var(--line-gradient-space), hsla(60 100% 50% / 80%), hsla(60 100% 50% / 0) 75%),
+    linear-gradient(120deg var(--line-gradient-space), hsla(120 100% 50% / 80%), hsla(120 100% 50% / 0) 75%),
+    linear-gradient(180deg var(--line-gradient-space), hsla(180 100% 50% / 80%), hsla(180 100% 50% / 0) 75%),
+    linear-gradient(240deg var(--line-gradient-space), hsla(240 100% 50% / 80%), hsla(240 100% 50% / 0) 75%),
+    linear-gradient(300deg var(--line-gradient-space), hsla(300 100% 50% / 80%), hsla(300 100% 50% / 0) 75%);
+  --line-gradient-19: linear-gradient(to bottom right var(--line-gradient-space), #ffe259, #ffa751);
+  --line-gradient-20: conic-gradient(
+    from -135deg at -10% center var(--line-gradient-space),
+    #ffa500,
+    #ff7715,
+    #ff522a,
+    #ff3f47,
+    #ff5482,
+    #ff69b4
+  );
+  --line-gradient-21: conic-gradient(
+    from -90deg at 25% 115% var(--line-gradient-space),
+    #ff0000,
+    #ff0066,
+    #ff00cc,
+    #cc00ff,
+    #6600ff,
+    #0000ff,
+    #0000ff,
+    #0000ff,
+    #0000ff
+  );
+  --line-gradient-22: linear-gradient(to bottom right var(--line-gradient-space), #acb6e5, #86fde8);
+  --line-gradient-23: linear-gradient(to bottom right var(--line-gradient-space), #536976, #292e49);
+  --line-gradient-24: conic-gradient(
+    from 0.5turn at 0% 0% var(--line-gradient-space),
+    #00c476,
+    10%,
+    #82b0ff,
+    90%,
+    #00c476
+  );
+  --line-gradient-25: conic-gradient(
+    at 125% 50% var(--line-gradient-space),
+    #b78cf7,
+    #ff7c94,
+    #ffcf0d,
+    #ff7c94,
+    #b78cf7
+  );
+  --line-gradient-26: linear-gradient(to bottom right var(--line-gradient-space), #9796f0, #fbc7d4);
+  --line-gradient-27: conic-gradient(from 0.5turn at bottom left var(--line-gradient-space), deeppink, rebeccapurple);
+  --line-gradient-28: conic-gradient(from -90deg at 50% 105% var(--line-gradient-space), white, orchid);
+  --line-gradient-29:
+    radial-gradient(circle at top right var(--line-gradient-space), hsl(250 100% 85%), hsl(250 100% 85% / 0%)),
+    radial-gradient(circle at bottom left var(--line-gradient-space), hsl(220 90% 75%), hsl(220 90% 75% / 0%));
+  --line-gradient-30:
+    radial-gradient(circle at top right var(--line-gradient-space), hsl(150 100% 50%), hsl(150 100% 50% / 0%)),
+    radial-gradient(circle at bottom left var(--line-gradient-space), hsl(150 100% 84%), hsl(150 100% 84% / 0%));
+
+  /* ── Noise Textures (SVG data URIs) ── */
+
+  --line-noise-1: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.005' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+  --line-noise-2: url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.05' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+  --line-noise-3: url("data:image/svg+xml,%3Csvg viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.25' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+  --line-noise-4: url("data:image/svg+xml,%3Csvg viewBox='0 0 2056 2056' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.5' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+  --line-noise-5: url("data:image/svg+xml,%3Csvg viewBox='0 0 2056 2056' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+
+  /* ── Noise Filters ── */
+
+  --line-noise-filter-1: contrast(300%) brightness(100%);
+  --line-noise-filter-2: contrast(200%) brightness(150%);
+  --line-noise-filter-3: contrast(200%) brightness(250%);
+  --line-noise-filter-4: contrast(200%) brightness(500%);
+  --line-noise-filter-5: contrast(200%) brightness(1000%);
+}
+
+/* ── Progressive Enhancement: oklab interpolation ── */
+
+@supports (background: linear-gradient(to right in oklab, #000, #fff)) {
+  :where(html) {
+    --line-gradient-space: in oklab;
+  }
+}


### PR DESCRIPTION
Create tokens/gradients.css with all 41 Open Props gradient tokens:
- 1 gradient-space control variable (empty default, oklab via @supports)
- 30 gradient presets (linear, radial, conic)
- 5 noise SVG textures
- 5 noise filter presets

Barrel tokens.css updated to include gradients.css. Biome noInvalidDirectionInLinearGradient rule disabled (false positive on var(--line-gradient-space) injection pattern used by Open Props).