### PR TITLE
feat(theme): add mask tokens with 1:1 Open Props match (34 tokens)

### DIFF
--- a/packages/theme/src/tokens.css
+++ b/packages/theme/src/tokens.css
@@ -20,4 +20,5 @@
 @import "./tokens/focus.css";
 @import "./tokens/animations.css";
 @import "./tokens/gradients.css";
+@import "./tokens/masks.css";
 @import "./tokens/colors-absolute.css";

--- a/packages/theme/src/tokens/masks.css
+++ b/packages/theme/src/tokens/masks.css
@@ -1,0 +1,105 @@
+/* ═══════════════════════════════════════════════════════════
+   masks.css — line://ui Mask Tokens
+
+   Edge masks (25), corner-cut masks (9).
+
+   Full 1:1 Open Props match (34 tokens).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  /* ── Edge Masks: Scoop ── */
+
+  --line-mask-edge-scoop-bottom: radial-gradient(20px at 50% 100%, #0000 97%, #000) 50% / calc(1.9 * 20px) 100%;
+  --line-mask-edge-scoop-top: radial-gradient(20px at 50% 0, #0000 97%, #000) 50% / calc(1.9 * 20px) 100%;
+  --line-mask-edge-scoop-vertical: radial-gradient(20px at 50% 20px, #0000 97%, #000) 50% -20px / calc(1.9 * 20px) 100%;
+  --line-mask-edge-scoop-left: radial-gradient(20px at 0 50%, #0000 97%, #000) 50% / 100% calc(1.9 * 20px);
+  --line-mask-edge-scoop-right: radial-gradient(20px at 100% 50%, #0000 97%, #000) 50% / 100% calc(1.9 * 20px);
+  --line-mask-edge-scoop-horizontal: radial-gradient(20px at 20px 50%, #0000 97%, #000) -20px / 100% calc(1.9 * 20px);
+
+  /* ── Edge Masks: Scalloped ── */
+
+  --line-mask-edge-scalloped:
+    radial-gradient(farthest-side, #000 97%, #0000) 0 0 / 20px 20px round,
+    linear-gradient(#000 0 0) 50% / calc(100% - 20px) calc(100% - 20px) no-repeat;
+  --line-mask-edge-scalloped-bottom:
+    linear-gradient(to top, #0000 20px, #000 0),
+    radial-gradient(20px at top, #000 97%, #0000) bottom / calc(1.9 * 20px) 20px;
+  --line-mask-edge-scalloped-top:
+    linear-gradient(to bottom, #0000 20px, #000 0),
+    radial-gradient(20px at bottom, #000 97%, #0000) top / calc(1.9 * 20px) 20px;
+  --line-mask-edge-scalloped-vertical:
+    linear-gradient(0deg, #0000 calc(2 * 20px), #000 0) 0 20px,
+    radial-gradient(20px, #000 97%, #0000) 50% / calc(1.9 * 20px) calc(2 * 20px) repeat space;
+  --line-mask-edge-scalloped-left:
+    linear-gradient(to right, #0000 20px, #000 0),
+    radial-gradient(20px at right, #000 97%, #0000) left / 20px calc(1.9 * 20px);
+  --line-mask-edge-scalloped-right:
+    linear-gradient(to left, #0000 20px, #000 0),
+    radial-gradient(20px at left, #000 97%, #0000) right / 20px calc(1.9 * 20px);
+  --line-mask-edge-scalloped-horizontal:
+    linear-gradient(-90deg, #0000 calc(2 * 20px), #000 0) 20px,
+    radial-gradient(20px, #000 97%, #0000) 50% / calc(2 * 20px) calc(1.9 * 20px) space repeat;
+
+  /* ── Edge Masks: Drip ── */
+
+  --line-mask-edge-drip-bottom:
+    radial-gradient(20px at bottom, #0000 97%, #000) 50% calc(100% - 20px) / calc(2 * 20px) 100% repeat-x,
+    radial-gradient(20px at 25% 50%, #000 97%, #0000) calc(50% - 20px) 99% / calc(4 * 20px) calc(2 * 20px) repeat-x;
+  --line-mask-edge-drip-top:
+    radial-gradient(20px at top, #0000 97%, #000) 50% 20px / calc(2 * 20px) 100% repeat-x,
+    radial-gradient(20px at 25% 50%, #000 97%, #0000) calc(50% - 20px) 1% / calc(4 * 20px) calc(2 * 20px) repeat-x;
+  --line-mask-edge-drip-vertical:
+    radial-gradient(20px at top, #0000 97%, #000) 50% 20px / calc(2 * 20px) 51% repeat-x,
+    radial-gradient(20px at bottom, #0000 97%, #000) 50% calc(100% - 20px) / calc(2 * 20px) 51% repeat-x,
+    radial-gradient(20px at 25% 50%, #000 97%, #0000) calc(50% - 20px) 1% / calc(4 * 20px) calc(2 * 20px) repeat-x,
+    radial-gradient(20px at 25% 50%, #000 97%, #0000) calc(50% - 3 * 20px) 99% / calc(4 * 20px) calc(2 * 20px) repeat-x;
+  --line-mask-edge-drip-left:
+    radial-gradient(20px at left, #0000 97%, #000) 20px 50% / 100% calc(2 * 20px) repeat-y,
+    radial-gradient(20px at 50% 25%, #000 97%, #0000) 1% calc(50% - 20px) / calc(2 * 20px) calc(4 * 20px) repeat-y;
+  --line-mask-edge-drip-right:
+    radial-gradient(20px at right, #0000 97%, #000) calc(100% - 20px) 50% / 100% calc(2 * 20px) repeat-y,
+    radial-gradient(20px at 50% 25%, #000 97%, #0000) 99% calc(50% - 20px) / calc(2 * 20px) calc(4 * 20px) repeat-y;
+  --line-mask-edge-drip-horizontal:
+    radial-gradient(20px at left, #0000 97%, #000) 20px 50% / 51% calc(2 * 20px) repeat-y,
+    radial-gradient(20px at right, #0000 97%, #000) calc(100% - 20px) 50% / 51% calc(2 * 20px) repeat-y,
+    radial-gradient(20px at 50% 25%, #000 97%, #0000) 1% calc(50% - 20px) / calc(2 * 20px) calc(4 * 20px) repeat-y,
+    radial-gradient(20px at 50% 25%, #000 97%, #0000) 99% calc(50% - 3 * 20px) / calc(2 * 20px) calc(4 * 20px) repeat-y;
+
+  /* ── Edge Masks: Zig-Zag ── */
+
+  --line-mask-edge-zig-zag-top: conic-gradient(from 135deg at top, #0000, #000 1deg 90deg, #0000 91deg) 50% / 40px 100%;
+  --line-mask-edge-zig-zag-bottom:
+    conic-gradient(from -45deg at bottom, #0000, #000 1deg 90deg, #0000 91deg) 50% / 40px 100%;
+  --line-mask-edge-zig-zag-left:
+    conic-gradient(from 45deg at left, #0000, #000 1deg 90deg, #0000 91deg) 50% / 100% 40px;
+  --line-mask-edge-zig-zag-right:
+    conic-gradient(from -135deg at right, #0000, #000 1deg 90deg, #0000 91deg) 50% / 100% 40px;
+  --line-mask-edge-zig-zag-horizontal:
+    repeating-conic-gradient(from 45deg at 20px 50%, #0000, #000 1deg 90deg, #0000 91deg 180deg) -20px 50% / 100% 40px;
+  --line-mask-edge-zig-zag-vertical:
+    repeating-conic-gradient(from 135deg at 50% 20px, #0000, #000 1deg 90deg, #0000 91deg 180deg) 50% -20px / 40px 100%;
+
+  /* ── Corner-Cut Masks: Circles ── */
+
+  --line-mask-corner-cut-circles-1: radial-gradient(1rem at 1rem 1rem, #0000 99%, #000) -1rem -1rem;
+  --line-mask-corner-cut-circles-2: radial-gradient(2rem at 2rem 2rem, #0000 99%, #000) -2rem -2rem;
+  --line-mask-corner-cut-circles-3: radial-gradient(4rem at 4rem 4rem, #0000 99%, #000) -4rem -4rem;
+
+  /* ── Corner-Cut Masks: Squares ── */
+
+  --line-mask-corner-cut-squares-1: conic-gradient(at calc(2 * 1rem) calc(2 * 1rem), #000 75%, #0000 0) -1rem -1rem;
+  --line-mask-corner-cut-squares-2: conic-gradient(at calc(2 * 2rem) calc(2 * 2rem), #000 75%, #0000 0) -2rem -2rem;
+  --line-mask-corner-cut-squares-3: conic-gradient(at calc(2 * 4rem) calc(2 * 4rem), #000 75%, #0000 0) -4rem -4rem;
+
+  /* ── Corner-Cut Masks: Angles ── */
+
+  --line-mask-corner-cut-angles-1:
+    conic-gradient(from -45deg at 1rem 1rem, #0000 25%, #000 0) -1rem 0 / 100% 51% repeat-x,
+    conic-gradient(from 135deg at 1rem calc(100% - 1rem), #0000 25%, #000 0) -1rem 100% / 100% 51% repeat-x;
+  --line-mask-corner-cut-angles-2:
+    conic-gradient(from -45deg at 2rem 2rem, #0000 25%, #000 0) -2rem 0 / 100% 51% repeat-x,
+    conic-gradient(from 135deg at 2rem calc(100% - 2rem), #0000 25%, #000 0) -2rem 100% / 100% 51% repeat-x;
+  --line-mask-corner-cut-angles-3:
+    conic-gradient(from -45deg at 4rem 4rem, #0000 25%, #000 0) -4rem 0 / 100% 51% repeat-x,
+    conic-gradient(from 135deg at 4rem calc(100% - 4rem), #0000 25%, #000 0) -4rem 100% / 100% 51% repeat-x;
+}


### PR DESCRIPTION
Create tokens/masks.css with all 34 mask custom properties:
- 25 edge masks (scoop, scalloped, drip, zig-zag variants)
- 9 corner-cut masks (circles, squares, angles at 3 sizes)

All values copied verbatim from Open Props, prefixed as --line-mask-*. File is independently importable with no cross-dependencies. Registered in tokens.css barrel after gradients.css.