### PR TITLE
feat(theme): add highlight and SVG squircle tokens (6 tokens)

### DIFF
--- a/packages/theme/src/tokens.css
+++ b/packages/theme/src/tokens.css
@@ -22,4 +22,6 @@
 @import "./tokens/gradients.css";
 @import "./tokens/masks.css";
 @import "./tokens/layouts.css";
+@import "./tokens/highlights.css";
+@import "./tokens/svg.css";
 @import "./tokens/colors-absolute.css";

--- a/packages/theme/src/tokens/highlights.css
+++ b/packages/theme/src/tokens/highlights.css
@@ -1,0 +1,20 @@
+/* ═══════════════════════════════════════════════════════════
+   highlights.css — line://ui Highlight Tokens
+
+   Highlight tokens (2) + composite (1).
+
+   Full 1:1 Open Props match (3 tokens).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  /* ── Highlight ── */
+
+  --line-highlight-size: 10px;
+  --line-highlight-color: hsl(0 0% 0% / 20%);
+
+  --line-highlight: 0 0 0 var(--line-highlight-size) var(--line-highlight-color);
+
+  @media (--OSdark) {
+    --line-highlight-color: hsl(0 0% 100% / 20%);
+  }
+}

--- a/packages/theme/src/tokens/svg.css
+++ b/packages/theme/src/tokens/svg.css
@@ -1,0 +1,15 @@
+/* ═══════════════════════════════════════════════════════════
+   svg.css — line://ui SVG Squircle Tokens
+
+   SVG squircle tokens (3).
+
+   Full 1:1 Open Props match (3 tokens).
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  /* ── Squircle ── */
+
+  --line-squircle-1: url("data:image/svg+xml,%3Csvg viewbox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d=' M 0, 75 C 0, 18.75 18.75, 0 75, 0 S 150, 18.75 150, 75 131.25, 150 75, 150 0, 131.25 0, 75 ' fill='%23FADB5F' transform='rotate( 0, 100, 100 ) translate( 25 25 )'%3E%3C/path%3E%3C/svg%3E");
+  --line-squircle-2: url("data:image/svg+xml,%3Csvg viewbox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d=' M 0, 75 C 0, 13.500000000000004 13.500000000000004, 0 75, 0 S 150, 13.500000000000004 150, 75 136.5, 150 75, 150 0, 136.5 0, 75 ' fill='%23FADB5F' transform='rotate( 0, 100, 100 ) translate( 25 25 )'%3E%3C/path%3E%3C/svg%3E");
+  --line-squircle-3: url("data:image/svg+xml,%3Csvg viewbox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d=' M 0, 75 C 0, 5.999999999999997 5.999999999999997, 0 75, 0 S 150, 5.999999999999997 150, 75 144, 150 75, 150 0, 144 0, 75 ' fill='%23FADB5F' transform='rotate( 0, 100, 100 ) translate( 25 25 )'%3E%3C/path%3E%3C/svg%3E");
+}


### PR DESCRIPTION
Create tokens/highlights.css with 3 highlight tokens (size, color, composite) including dark mode override, and tokens/svg.css with 3 squircle data-URI tokens. Full 1:1 Open Props match.