### PR TITLE
feat(theme): add aliases.css with 54 semantic intent tokens (L3 layer)

### DIFF
--- a/packages/theme/src/aliases.css
+++ b/packages/theme/src/aliases.css
@@ -1,0 +1,78 @@
+/* ═══════════════════════════════════════════════════════════
+   aliases.css — line://ui Semantic Aliases (L3)
+
+   Maps design intent (primary, danger, etc.) to palette tokens.
+   Consumer overrides these to rebrand.
+
+   Requires: at least one color palette + schema to be loaded.
+   Default mapping: blue=primary, red=danger, green=success,
+                    amber=warning, cyan=info, gray=neutral.
+   ═══════════════════════════════════════════════════════════ */
+
+:where(html) {
+  /* ── Primary ── */
+  --line-primary: var(--line-blue-9);
+  --line-primary-hover: var(--line-blue-10);
+  --line-primary-active: var(--line-blue-11);
+  --line-primary-text: var(--line-blue-contrast);
+  --line-primary-subtle: var(--line-blue-3);
+  --line-primary-subtle-hover: var(--line-blue-4);
+  --line-primary-outline: var(--line-blue-7);
+  --line-primary-outline-hover: var(--line-blue-8);
+  --line-primary-fg: var(--line-blue-11);
+
+  /* ── Danger ── */
+  --line-danger: var(--line-red-9);
+  --line-danger-hover: var(--line-red-10);
+  --line-danger-active: var(--line-red-11);
+  --line-danger-text: var(--line-red-contrast);
+  --line-danger-subtle: var(--line-red-3);
+  --line-danger-subtle-hover: var(--line-red-4);
+  --line-danger-outline: var(--line-red-7);
+  --line-danger-outline-hover: var(--line-red-8);
+  --line-danger-fg: var(--line-red-11);
+
+  /* ── Success ── */
+  --line-success: var(--line-green-9);
+  --line-success-hover: var(--line-green-10);
+  --line-success-active: var(--line-green-11);
+  --line-success-text: var(--line-green-contrast);
+  --line-success-subtle: var(--line-green-3);
+  --line-success-subtle-hover: var(--line-green-4);
+  --line-success-outline: var(--line-green-7);
+  --line-success-outline-hover: var(--line-green-8);
+  --line-success-fg: var(--line-green-11);
+
+  /* ── Warning ── */
+  --line-warning: var(--line-amber-9);
+  --line-warning-hover: var(--line-amber-10);
+  --line-warning-active: var(--line-amber-11);
+  --line-warning-text: var(--line-amber-contrast);
+  --line-warning-subtle: var(--line-amber-3);
+  --line-warning-subtle-hover: var(--line-amber-4);
+  --line-warning-outline: var(--line-amber-7);
+  --line-warning-outline-hover: var(--line-amber-8);
+  --line-warning-fg: var(--line-amber-11);
+
+  /* ── Info ── */
+  --line-info: var(--line-cyan-9);
+  --line-info-hover: var(--line-cyan-10);
+  --line-info-active: var(--line-cyan-11);
+  --line-info-text: var(--line-cyan-contrast);
+  --line-info-subtle: var(--line-cyan-3);
+  --line-info-subtle-hover: var(--line-cyan-4);
+  --line-info-outline: var(--line-cyan-7);
+  --line-info-outline-hover: var(--line-cyan-8);
+  --line-info-fg: var(--line-cyan-11);
+
+  /* ── Neutral ── */
+  --line-neutral: var(--line-gray-9);
+  --line-neutral-hover: var(--line-gray-10);
+  --line-neutral-active: var(--line-gray-11);
+  --line-neutral-text: var(--line-gray-contrast);
+  --line-neutral-subtle: var(--line-gray-3);
+  --line-neutral-subtle-hover: var(--line-gray-4);
+  --line-neutral-outline: var(--line-gray-7);
+  --line-neutral-outline-hover: var(--line-gray-8);
+  --line-neutral-fg: var(--line-gray-11);
+}

--- a/packages/theme/src/line.css
+++ b/packages/theme/src/line.css
@@ -32,6 +32,8 @@
 @import "./themes/amber-theme.css";
 @import "./themes/orange-theme.css";
 
+@import "./aliases.css";
+
 @import "./custom/gray-custom.css";
 @import "./custom/mauve-custom.css";
 @import "./custom/slate-custom.css";


### PR DESCRIPTION
Create 6 semantic aliases (primary, danger, success, warning, info, neutral) mapped to palettes (blue, red, green, amber, cyan, gray), each with 9 intent tokens (base, hover, active, text, subtle, subtle-hover, outline, outline-hover, fg) for a total of 54 CSS custom properties. Import aliases in line.css after themes and before custom overrides per the L3 layer ordering.