### PR TITLE
feat(theme): add optional consumer-side reset.css with zero-specifici…

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -4,6 +4,13 @@
   "description": "Base theme for line://ui",
   "type": "module",
   "style": "dist/line.min.css",
+  "exports": {
+    ".": "./dist/line.min.css",
+    "./reset": "./dist/reset.min.css",
+    "./tokens": "./dist/tokens.min.css",
+    "./semantic-defaults": "./dist/semantic-defaults.min.css",
+    "./aliases": "./dist/aliases.min.css"
+  },
   "scripts": {
     "dev": "vite",
     "build": "rm -rf dist && bun run src/build.ts",

--- a/packages/theme/src/build.ts
+++ b/packages/theme/src/build.ts
@@ -114,13 +114,7 @@ async function discoverEntries(): Promise<EntryPoint[]> {
   const entries: EntryPoint[] = [];
 
   // Directory-based entries
-  const dirPatterns = [
-    'colors/*.css',
-    'schemas/*.css',
-    'themes/*-theme.css',
-    'custom/*-custom.css',
-    'utils/*.css',
-  ];
+  const dirPatterns = ['colors/*.css', 'schemas/*.css', 'themes/*-theme.css', 'custom/*-custom.css', 'utils/*.css'];
 
   for (const pattern of dirPatterns) {
     const glob = new Glob(pattern);
@@ -133,12 +127,7 @@ async function discoverEntries(): Promise<EntryPoint[]> {
   }
 
   // Root-level entry files (only if they exist)
-  const rootEntries = [
-    'tokens.css',
-    'semantic-defaults.css',
-    'aliases.css',
-    'line.css',
-  ];
+  const rootEntries = ['tokens.css', 'semantic-defaults.css', 'aliases.css', 'reset.css', 'line.css'];
 
   for (const file of rootEntries) {
     const srcPath = join(SRC, file);
@@ -160,14 +149,11 @@ async function discoverEntries(): Promise<EntryPoint[]> {
 /**
  * Process a single CSS entry point through PostCSS.
  */
-async function processEntry(
-  processor: postcss.Processor,
-  entry: EntryPoint,
-): Promise<void> {
+async function processEntry(processor: postcss.Processor, entry: EntryPoint): Promise<void> {
   const css = readFileSync(entry.src, 'utf-8');
   const result = await processor.process(css, {
     from: entry.src,
-    to: join(DIST, entry.outFile),
+    to: join(DIST, entry.outFile)
   });
 
   const outPath = join(DIST, entry.outFile);
@@ -179,6 +165,7 @@ async function processEntry(
 
   // Log warnings
   for (const warning of result.warnings()) {
+    // biome-ignore lint/suspicious/noConsole: Build script needs console output
     console.warn(`  [warn] ${entry.outFile}: ${warning.text}`);
   }
 }
@@ -190,10 +177,7 @@ async function processEntry(
  * Each worker reads and increments `index` synchronously before the `await`,
  * so no two workers can claim the same task index.
  */
-async function runWithConcurrency<T>(
-  tasks: (() => Promise<T>)[],
-  limit: number,
-): Promise<T[]> {
+async function runWithConcurrency<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[]> {
   const results: T[] = [];
   let index = 0;
 
@@ -204,9 +188,7 @@ async function runWithConcurrency<T>(
     }
   }
 
-  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () =>
-    worker(),
-  );
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker());
   await Promise.all(workers);
   return results;
 }
@@ -262,18 +244,14 @@ async function main(): Promise<void> {
     } catch (err) {
       failed++;
       console.error(`  FAILED: ${entry.outFile}`);
-      console.error(
-        `    ${err instanceof Error ? err.message : String(err)}`,
-      );
+      console.error(`    ${err instanceof Error ? err.message : String(err)}`);
     }
   });
 
   await runWithConcurrency(tasks, CONCURRENCY);
 
   const elapsed = ((performance.now() - startTime) / 1000).toFixed(2);
-  console.info(
-    `\n${entries.length - failed}/${entries.length} entries built in ${elapsed}s`,
-  );
+  console.info(`\n${entries.length - failed}/${entries.length} entries built in ${elapsed}s`);
 
   if (failed > 0) {
     console.error(`${failed} entry(ies) failed.`);

--- a/packages/theme/src/reset.css
+++ b/packages/theme/src/reset.css
@@ -1,0 +1,168 @@
+/**
+ * Consumer-side reset for slotted / light-DOM content inside line-* components.
+ *
+ * This file is OPTIONAL — consumers must explicitly import it.
+ * All selectors use :where() for zero specificity, so consumer styles
+ * always win without needing to increase specificity.
+ *
+ * Usage:
+ *   @import '@websublime/line-theme/reset';
+ *
+ * Or load the built file directly:
+ *   <link rel="stylesheet" href="@websublime/line-theme/dist/reset.min.css">
+ */
+
+/* ---------------------------------------------------------------------------
+ * 1. Global slotted content resets
+ *
+ * Targets common light-DOM elements when they appear inside any line-*
+ * custom element. Resets spacing, font inheritance, and box model so
+ * that component-level styles have a clean baseline.
+ * --------------------------------------------------------------------------- */
+
+:where([class*="line-"]) :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote, figure, pre, hr) {
+  margin: 0;
+  padding: 0;
+}
+
+:where([class*="line-"]) :where(h1, h2, h3, h4, h5, h6, p, span, label, a, small, strong, em) {
+  font: inherit;
+}
+
+:where([class*="line-"]) :where(ul, ol) {
+  list-style: none;
+  padding-inline-start: 0;
+}
+
+:where([class*="line-"]) :where(img, svg, video) {
+  display: block;
+  max-inline-size: 100%;
+  block-size: auto;
+}
+
+/* ---------------------------------------------------------------------------
+ * 2. Field component — labels, hints, errors
+ *
+ * Spec reference: ARCHITECTURE.md §14.10
+ * --------------------------------------------------------------------------- */
+
+:where(line-field) :where(label) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+:where(line-field) :where(span[slot="hint"]),
+:where(line-field) :where(span[slot="error"]) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+/* ---------------------------------------------------------------------------
+ * 3. Form-adjacent components — input wrappers, select, textarea
+ *
+ * Reset native form elements when slotted into line-* form components.
+ * --------------------------------------------------------------------------- */
+
+:where(line-input, line-textarea, line-select, line-number-field, line-combobox, line-pin-input) :where(label) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+:where(line-input, line-textarea, line-select, line-number-field, line-combobox, line-pin-input)
+  :where(span[slot="hint"]),
+:where(line-input, line-textarea, line-select, line-number-field, line-combobox, line-pin-input)
+  :where(span[slot="error"]),
+:where(line-input, line-textarea, line-select, line-number-field, line-combobox, line-pin-input)
+  :where(span[slot="description"]) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+/* ---------------------------------------------------------------------------
+ * 4. Content containers — card, dialog, alert, drawer, popover, tooltip
+ *
+ * These components accept arbitrary slotted content. Reset spacing
+ * and font inheritance for common elements that appear inside them.
+ * --------------------------------------------------------------------------- */
+
+:where(line-card, line-dialog, line-alert, line-drawer, line-popover, line-tooltip, line-callout, line-banner)
+  :where(h1, h2, h3, h4, h5, h6) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+:where(line-card, line-dialog, line-alert, line-drawer, line-popover, line-tooltip, line-callout, line-banner)
+  :where(p) {
+  margin: 0;
+  padding: 0;
+}
+
+:where(line-card, line-dialog, line-alert, line-drawer, line-popover, line-tooltip, line-callout, line-banner)
+  :where(ul, ol) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  padding-inline-start: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * 5. Navigation components — tabs, breadcrumb, menu, pagination
+ *
+ * Reset list and link styling for items slotted into navigation patterns.
+ * --------------------------------------------------------------------------- */
+
+:where(line-tabs, line-breadcrumb, line-menu, line-pagination, line-navigation-menu) :where(a) {
+  text-decoration: none;
+  color: inherit;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+}
+
+:where(line-tabs, line-breadcrumb, line-menu, line-pagination, line-navigation-menu) :where(ul, ol, li) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * 6. Button resets for slotted buttons
+ *
+ * When native <button> elements are slotted into line-* components,
+ * strip the default browser button chrome.
+ * --------------------------------------------------------------------------- */
+
+:where(line-dialog, line-alert, line-drawer, line-toolbar, line-card) :where(button:not([class])) {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+/* ---------------------------------------------------------------------------
+ * 7. Table resets for slotted tables
+ *
+ * When <table> is slotted into line-* components, collapse borders
+ * and remove spacing for a clean baseline.
+ * --------------------------------------------------------------------------- */
+
+:where(line-card, line-dialog, line-drawer) :where(table) {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+:where(line-card, line-dialog, line-drawer) :where(th, td) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  text-align: start;
+}


### PR DESCRIPTION
…ty selectors

Add reset.css for slotted/light-DOM content inside line-* components. All selectors use :where() for zero specificity so consumer styles always win. Covers field labels/hints/errors, form inputs, content containers (card, dialog, alert, drawer), navigation components, slotted buttons, and tables. File is opt-in only (not in line.css). Register in build.ts root entries and add package.json exports field. Also fixes pre-existing Biome formatting in build.ts.