### PR TITLE
chore(theme): rename export key from ./semantic-defaults to ./semantic

### DIFF
--- a/.claude/agents/theme-supervisor.md
+++ b/.claude/agents/theme-supervisor.md
@@ -149,12 +149,12 @@ packages/theme/
       normalize.css       # Modern CSS reset
       mixins.css          # PostCSS mixins
     tokens.css            # L1: Foundation tokens (typography, sizing, shadows, motion, etc.)
-    semantic-defaults.css # L2: Gray-based prefers-color-scheme defaults
+    semantic.css          # L2: Gray-based prefers-color-scheme defaults
     aliases.css           # L3: 6 aliases × 9 intent tokens = 54 variables
     line.css              # Main bundle that imports all of the above
   dist/                   # Built output — minified CSS files
     tokens.min.css
-    semantic-defaults.min.css
+    semantic.min.css
     normalize.min.css
     utilities.min.css
     aliases.min.css
@@ -170,7 +170,7 @@ packages/theme/
 
 **You handle:**
 - Foundation tokens in `tokens.css` (156 tokens, no external dependencies)
-- Semantic defaults in `semantic-defaults.css`
+- Semantic defaults in `semantic.css`
 - Aliases in `aliases.css`
 - Colour palette files in `src/colors/` (including `--line-{palette}-contrast` tokens)
 - Schema files in `src/schemas/` (including `--line-solid-text` semantic token)

--- a/docs/DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md
+++ b/docs/DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md
@@ -45,7 +45,7 @@
 │  L3 — Semantic Aliases         (aliases.css)                │
 │  Intent: --line-primary, --line-danger, --line-success       │
 ├─────────────────────────────────────────────────────────────┤
-│  L2 — Semantic Roles           (semantic-defaults + schemas) │
+│  L2 — Semantic Roles           (semantic + schemas)           │
 │  Context: --line-background, --line-solid-background         │
 ├─────────────────────────────────────────────────────────────┤
 │  L1 — Foundation Tokens        (tokens.css)                 │
@@ -87,7 +87,7 @@ Each layer is independently consumable. A consumer can stop at any layer:
 ```
 packages/theme/src/
 ├── utils/
-│   ├── rules.css            → SPLIT INTO tokens.css + semantic-defaults.css
+│   ├── rules.css            → SPLIT INTO tokens.css + semantic.css
 │   ├── normalize.css        → KEEP (fix token references)
 │   ├── general.css          → RENAME TO utilities.css (fix + wrap :where())
 │   ├── mixins.css           → KEEP (fix token references)
@@ -104,7 +104,7 @@ packages/theme/src/
 ├── custom/                  → DELETE (demo files, not for production)
 ├── aliases.css              → NEW
 ├── tokens.css               → NEW (extracted from rules.css)
-├── semantic-defaults.css    → NEW (extracted from rules.css)
+├── semantic.css             → NEW (extracted from rules.css)
 └── line.css                 → REWRITE (new import order, no custom/*)
 ```
 
@@ -113,7 +113,7 @@ packages/theme/src/
 ```
 packages/theme/dist/
 ├── tokens.min.css                ← L1: foundation only
-├── semantic-defaults.min.css     ← L2: gray prefers-color-scheme
+├── semantic.min.css              ← L2: gray prefers-color-scheme
 ├── normalize.min.css             ← Document reset
 ├── utilities.min.css             ← Utility classes
 ├── aliases.min.css               ← L3: primary/danger/success/warning/info
@@ -393,7 +393,7 @@ Each family file can be imported independently via package.json exports
 
 ### Step 1.2 — Delete the old `rules.css`
 
-After extracting `tokens/` and `semantic-defaults.css` (next phase), delete
+After extracting `tokens/` and `semantic.css` (next phase), delete
 `src/utils/rules.css`. All its content will live in the new token files and
 the semantic defaults layer.
 
@@ -401,16 +401,16 @@ the semantic defaults layer.
 
 ## 5. Phase 2 — Semantic Defaults Layer (L2)
 
-> **Goal:** Create `semantic-defaults.css` — gray-based default semantic roles.
+> **Goal:** Create `semantic.css` — gray-based default semantic roles.
 
-### Step 2.1 — Create `src/semantic-defaults.css`
+### Step 2.1 — Create `src/semantic.css`
 
 This file contains only the `prefers-color-scheme` blocks that map gray
 values to semantic role tokens. It is independent from any palette.
 
 ```css
 /* ═══════════════════════════════════════════════════════════
-   semantic-defaults.css — line://ui Semantic Role Defaults (L2)
+   semantic.css — line://ui Semantic Role Defaults (L2)
 
    Maps the neutral gray scale to semantic role tokens.
    Schemas (.line-schema-*) override these when active.
@@ -815,7 +815,7 @@ these are demo code, not design system utilities.
 @import "./tokens.css";
 
 /* L2 — Semantic defaults (gray, prefers-color-scheme) */
-@import "./semantic-defaults.css";
+@import "./semantic.css";
 
 /* Normalize (document reset) */
 @import "./utils/normalize.css";
@@ -888,7 +888,7 @@ Add new scripts for the new entry points:
 
     "css:all": "postcss src/line.css -o ./dist/line.min.css",
     "css:tokens": "postcss src/tokens.css -o ./dist/tokens.min.css",
-    "css:semantic": "postcss src/semantic-defaults.css -o ./dist/semantic-defaults.min.css",
+    "css:semantic": "postcss src/semantic.css -o ./dist/semantic.min.css",
     "css:normalize": "postcss src/utils/normalize.css -o ./dist/normalize.min.css",
     "css:utilities": "postcss src/utils/utilities.css -o ./dist/utilities.min.css",
     "css:aliases": "postcss src/aliases.css -o ./dist/aliases.min.css",
@@ -924,7 +924,7 @@ dist/theme-amber.min.css       →    dist/themes/amber.min.css
   "exports": {
     ".": "./dist/line.min.css",
     "./tokens": "./dist/tokens.min.css",
-    "./semantic": "./dist/semantic-defaults.min.css",
+    "./semantic": "./dist/semantic.min.css",
     "./normalize": "./dist/normalize.min.css",
     "./utilities": "./dist/utilities.min.css",
     "./aliases": "./dist/aliases.min.css",
@@ -1412,7 +1412,7 @@ yields ≥ 4.5:1 against the level-9 background. Run as part of CI.
 ```bash
 # Verify all expected files exist
 ls dist/tokens.min.css
-ls dist/semantic-defaults.min.css
+ls dist/semantic.min.css
 ls dist/normalize.min.css
 ls dist/utilities.min.css
 ls dist/aliases.min.css

--- a/docs/PRODUCT-PLAN.md
+++ b/docs/PRODUCT-PLAN.md
@@ -54,7 +54,7 @@ This epic must complete before all other Phase 0 work. Everything downstream dep
 
 | Task ID | Title | Description | Dependencies | Supervisor | Complexity | Reference |
 |---------|-------|-------------|--------------|------------|------------|-----------|
-| P0-E2-T1 | Define foundation tokens explicitly | Create `src/tokens.css` with all foundation token scales (typography, sizing, shadows, z-index, opacity, motion, radius, border-width, focus-ring, aspect-ratio). Create `src/semantic-defaults.css` extracted from `rules.css`. Remove `postcss-jit-props` and `open-props` from devDependencies. Add contrast tokens (`--line-{palette}-contrast`) to all 28 colour files. Update all 28 schemas to use contrast token. Reference: `docs/DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md` Phases 1-3. | P0-E1-T3 | Violet | L | PRD 9.3, 9.15 |
+| P0-E2-T1 | Define foundation tokens explicitly | Create `src/tokens.css` with all foundation token scales (typography, sizing, shadows, z-index, opacity, motion, radius, border-width, focus-ring, aspect-ratio). Create `src/semantic.css` extracted from `rules.css`. Remove `postcss-jit-props` and `open-props` from devDependencies. Add contrast tokens (`--line-{palette}-contrast`) to all 28 colour files. Update all 28 schemas to use contrast token. Reference: `docs/DESIGN-SYSTEM-IMPLEMENTATION-GUIDE.md` Phases 1-3. | P0-E1-T3 | Violet | L | PRD 9.3, 9.15 |
 | P0-E2-T2 | Add postcss-custom-media to pipeline | Ensure `postcss-custom-media` is active in the pipeline so that custom media queries from `media.css` are resolved. Verify breakpoint and preference queries work. | P0-E1-T3 | Violet | S | PRD 9.8 |
 | P0-E2-T3 | Remove demo files from production bundle | Exclude `custom/*-custom.css` demo swatch files from all build outputs. Move them to a location suitable for Storybook consumption only. | P0-E1-T1 | Violet | S | PRD 9.12, Decision T5 |
 | P0-E2-T4 | Configure Vite 7+ with Rolldown | Verify or update Vite to 7+ with Rolldown for library mode builds. Ensure both core and theme packages build correctly with the new bundler. | P0-E1-T5, P0-E1-T1 | Luna | M | PRD 2 |
@@ -182,11 +182,11 @@ All of the following must be true:
 
 - [ ] All packages use `line-*` naming (npm names, CSS variables, CSS classes, tag prefix, base class)
 - [x] Foundation tokens defined in `tokens/` directory (~299 core tokens across 11 family files, all `--line-*` prefixed) — E8 T1 complete
-- [ ] Semantic defaults defined in `semantic-defaults.css` (split from rules.css)
+- [ ] Semantic defaults defined in `semantic.css` (split from rules.css)
 - [ ] Contrast token `--line-{palette}-contrast` added to all 28 colour files
 - [ ] All 28 schemas updated to use contrast token (`--line-solid-text`)
 - [ ] `postcss-jit-props` and `open-props` removed from devDependencies
-- [ ] Build outputs restructured: dist/tokens.min.css, dist/semantic-defaults.min.css, dist/aliases.min.css, dist/colors/, dist/schemas/, dist/themes/
+- [ ] Build outputs restructured: dist/tokens.min.css, dist/semantic.min.css, dist/aliases.min.css, dist/colors/, dist/schemas/, dist/themes/
 - [ ] Demo/swatch files are excluded from production CSS outputs
 - [ ] Monorepo has 6 packages: core, components, theme, icons, site, storybook
 - [ ] `bun install` and `bun run build` work from root across all packages

--- a/docs/PRODUCT-REQUIREMENTS-SPECIFICATION.md
+++ b/docs/PRODUCT-REQUIREMENTS-SPECIFICATION.md
@@ -1096,7 +1096,7 @@ Dark mode values are **not** simply inverted — each level has independently cr
 | Token Category | Namespace | Examples | Defined In |
 |----------------|-----------|----------|------------|
 | Palette colours | `--line-{color}-{level}` | `--line-blue-1`, `--line-gray-12`, `--line-crimson-9` | `src/colors/*.css` |
-| Semantic roles | `--line-{role}` | `--line-background`, `--line-solid-hover`, `--line-high-contrast` | `src/schemas/*.css`, `src/utils/semantic-defaults.css` |
+| Semantic roles | `--line-{role}` | `--line-background`, `--line-solid-hover`, `--line-high-contrast` | `src/schemas/*.css`, `src/semantic.css` |
 | Foundation tokens | `--line-{token}` | `--line-size-3`, `--line-font-size-2`, `--line-shadow-3` | `src/tokens.css` |
 | Semantic aliases | `--line-{alias}[-{intent}]` | `--line-primary`, `--line-primary-hover`, `--line-danger-text` | `src/aliases.css` (Phase 1) |
 | Component tokens | `--line-{component}-{prop}` | `--line-button-radius`, `--line-input-bg` | Component `:host` styles |
@@ -1114,7 +1114,7 @@ Foundation tokens are defined explicitly in `src/tokens.css` with the `--line-*`
 |-------|------|------------|----------|
 | L0 | Primitives | `colors/*.css` | Raw palette values: `--line-blue-1..12`, `--line-blue-contrast` |
 | L1 | Foundation tokens | `tokens.css` | Named scales: typography, sizing, shadows, z-index, opacity, motion, radius, border-width, focus-ring, aspect-ratio |
-| L2 | Semantic roles | `semantic-defaults.css` + `schemas/*.css` | Context-mapped: `--line-background`, `--line-solid-background`, `--line-solid-text` |
+| L2 | Semantic roles | `semantic.css` + `schemas/*.css` | Context-mapped: `--line-background`, `--line-solid-background`, `--line-solid-text` |
 | L3 | Semantic aliases | `aliases.css` | Intent-mapped: `--line-primary`, `--line-danger`, etc. (6 aliases × 9 tokens = 54 variables) |
 | L4 | Component tokens | `@websublime/line-presets` | Scoped: `--line-button-radius`, `--line-input-height` |
 | L5 | Component styles | `@websublime/line-presets` | Visual opinions via `::part()` selectors |
@@ -1333,7 +1333,7 @@ A theme file imports a colour palette and its corresponding schema:
 ```
 line.css
 ├── tokens.css               ← L1: Foundation tokens (typography, sizing, shadows, motion, etc.)
-├── semantic-defaults.css     ← L2: Gray-based prefers-color-scheme defaults
+├── semantic.css              ← L2: Gray-based prefers-color-scheme defaults
 ├── utils/normalize.css       ← Modern CSS reset (imports media.css internally)
 ├── utils/utilities.css       ← Utility classes mapping to semantic tokens
 ├── themes/*-theme.css (x28)  ← All 28 palette + schema pairs
@@ -1361,7 +1361,7 @@ Two coexisting mechanisms control light/dark mode:
 
 **Mechanism 1: OS-level preference (automatic)**
 
-In `semantic-defaults.css`, `@media (prefers-color-scheme: light/dark)` sets root-level semantic tokens on `:root`:
+In `semantic.css`, `@media (prefers-color-scheme: light/dark)` sets root-level semantic tokens on `:root`:
 
 ```css
 @media (prefers-color-scheme: light) {
@@ -1404,7 +1404,7 @@ This class also triggers dark mode in:
 document.documentElement.classList.add('dark');
 ```
 
-**Interaction between mechanisms:** The `.dark` class on `<html>` overrides palette and schema tokens via higher specificity (`:is(.dark)` vs bare `:where(html)`). However, the `semantic-defaults.css` root semantic tokens are set via `@media (prefers-color-scheme)` and are **not** overridden by the `.dark` class — they require a schema class to take effect. This means:
+**Interaction between mechanisms:** The `.dark` class on `<html>` overrides palette and schema tokens via higher specificity (`:is(.dark)` vs bare `:where(html)`). However, the `semantic.css` root semantic tokens are set via `@media (prefers-color-scheme)` and are **not** overridden by the `.dark` class — they require a schema class to take effect. This means:
 
 - Without a schema class: root tokens follow OS preference only
 - With a schema class: schema tokens follow the `.dark` / `.light` class, overriding OS preference for that scope
@@ -1454,7 +1454,7 @@ This configuration ensures CSS custom properties are preserved in the output (no
 
 ### 9.9 CSS Utilities
 
-**`semantic-defaults.css`** — Foundation layer
+**`semantic.css`** — Foundation layer
 
 - Light/dark mode root semantic tokens via `@media (prefers-color-scheme)`
 - `color-scheme` declaration for `.dark` / `.light` classes
@@ -1614,7 +1614,7 @@ The design token system follows a three-tier cascade:
   "exports": {
     ".":           "./dist/line.min.css",
     "./tokens":    "./dist/tokens.min.css",
-    "./semantic":  "./dist/semantic-defaults.min.css",
+    "./semantic":  "./dist/semantic.min.css",
     "./normalize": "./dist/normalize.min.css",
     "./utilities": "./dist/utilities.min.css",
     "./aliases":   "./dist/aliases.min.css",
@@ -1631,7 +1631,7 @@ The design token system follows a three-tier cascade:
 |--------|-----------------|---------|----------|
 | `dist/line.min.css` | `.` | Full bundle: all layers + all 28 themes | Quick start |
 | `dist/tokens.min.css` | `./tokens` | L1: Foundation tokens (no colours) | Headless setup |
-| `dist/semantic-defaults.min.css` | `./semantic` | L2: Gray prefers-color-scheme defaults | Foundation + reset |
+| `dist/semantic.min.css` | `./semantic` | L2: Gray prefers-color-scheme defaults | Foundation + reset |
 | `dist/normalize.min.css` | `./normalize` | CSS reset | Document reset |
 | `dist/utilities.min.css` | `./utilities` | Semantic utility classes | Utility classes |
 | `dist/aliases.min.css` | `./aliases` | L3: 6 aliases × 9 intent tokens | Intent tokens |

--- a/docs/THEME-GAP-ANALYSIS.md
+++ b/docs/THEME-GAP-ANALYSIS.md
@@ -75,7 +75,7 @@ own the values and don't depend on Open Props defaults.
 
 ### Gap 2 — Utility tokens UNPREFIXED ✅ RESOLVED (E8 T1)
 
-**Status:** All foundation tokens now live in `tokens/` directory with proper `--line-*` prefix (~299 core tokens across 11 family files). The unprefixed tokens in `rules.css` are now redundant and will be removed when E8 T2 (semantic-defaults.css) cleans up rules.css.
+**Status:** All foundation tokens now live in `tokens/` directory with proper `--line-*` prefix (~299 core tokens across 11 family files). The unprefixed tokens in `rules.css` are now redundant and will be removed when E8 T2 (semantic.css) cleans up rules.css.
 
 **Original issue:** `rules.css` (~160 occurrences) defined tokens without `--line-` prefix.
 
@@ -330,7 +330,7 @@ Schemas override these when active.
 
 ### Gap 16 — `rules.css` mixes foundation and semantic tokens — PARTIALLY RESOLVED (E8 T1)
 
-**Status:** Foundation tokens are now in `tokens/` directory (E8 T1 complete). Semantic defaults still need extraction from `rules.css` into `semantic-defaults.css` (tracked in E8 T2). Redundant unprefixed foundation tokens in rules.css lines 39-205 need removal as part of T2 cleanup.
+**Status:** Foundation tokens are now in `tokens/` directory (E8 T1 complete). Semantic defaults still need extraction from `rules.css` into `semantic.css` (tracked in E8 T2). Redundant unprefixed foundation tokens in rules.css lines 39-205 need removal as part of T2 cleanup.
 
 **Original impact:** `rules.css` contained both foundation tokens (`--font-sans`,
 `--size-3`, `--shadow-1`) and the semantic role map (`--line-background`,
@@ -343,7 +343,7 @@ Schemas override these when active.
 | File | Contents | Status |
 |------|----------|--------|
 | `tokens/` directory | Foundation: typography, sizing, borders, shadows, easing, z-index, aspects, durations, opacity, focus-ring, absolute colors | ✅ Done (E8 T1) |
-| `semantic-defaults.css` | The `prefers-color-scheme` light/dark blocks mapping gray scale to `--line-background`, `--line-solid-background`, etc. | Pending (E8 T2) |
+| `semantic.css` | The `prefers-color-scheme` light/dark blocks mapping gray scale to `--line-background`, `--line-solid-background`, etc. | Pending (E8 T2) |
 
 ### Gap 17 — No component-level token layer (NEW)
 
@@ -557,7 +557,7 @@ Single monolithic output: `line.css` imports everything including demos.
 @websublime/line-theme/
 ├── dist/
 │   ├── tokens.min.css              ← L1: foundation tokens only (no colors, no semantic)
-│   ├── semantic-defaults.min.css   ← L2: gray-based prefers-color-scheme defaults
+│   ├── semantic.min.css            ← L2: gray-based prefers-color-scheme defaults
 │   ├── normalize.min.css           ← Document reset (optional)
 │   ├── utilities.min.css           ← .line-is-* utility classes
 │   ├── aliases.min.css             ← L3: primary/danger/success/warning/info/neutral
@@ -587,7 +587,7 @@ Single monolithic output: `line.css` imports everything including demos.
   "exports": {
     ".":           "./dist/line.min.css",
     "./tokens":    "./dist/tokens.min.css",
-    "./semantic":  "./dist/semantic-defaults.min.css",
+    "./semantic":  "./dist/semantic.min.css",
     "./normalize": "./dist/normalize.min.css",
     "./utilities": "./dist/utilities.min.css",
     "./aliases":   "./dist/aliases.min.css",
@@ -858,7 +858,7 @@ P0-7. Remove custom/* imports from line.css (Gap 4)
 ### Phase 1 — Architecture
 
 ```
-P1-1. Split rules.css into tokens.css + semantic-defaults.css (Gap 16)
+P1-1. Split rules.css into tokens.css + semantic.css (Gap 16)
 P1-2. Add missing foundation scales (z-index, opacity, motion, focus-ring, aspect-ratio) (Gap 13)
 P1-3. Create aliases.css (Gap 6)
 P1-4. Wrap general.css utilities in :where() (Gap 5)

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -9,7 +9,7 @@
     "./reset": "./dist/reset.min.css",
     "./tokens": "./dist/tokens.min.css",
     "./tokens/*": "./dist/tokens/*.min.css",
-    "./semantic": "./dist/semantic-defaults.min.css",
+    "./semantic": "./dist/semantic.min.css",
     "./aliases": "./dist/aliases.min.css",
     "./normalize": "./dist/normalize.min.css",
     "./utilities": "./dist/utilities.min.css",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -9,7 +9,7 @@
     "./reset": "./dist/reset.min.css",
     "./tokens": "./dist/tokens.min.css",
     "./tokens/*": "./dist/tokens/*.min.css",
-    "./semantic-defaults": "./dist/semantic-defaults.min.css",
+    "./semantic": "./dist/semantic-defaults.min.css",
     "./aliases": "./dist/aliases.min.css",
     "./normalize": "./dist/normalize.min.css",
     "./utilities": "./dist/utilities.min.css",

--- a/packages/theme/src/build.ts
+++ b/packages/theme/src/build.ts
@@ -69,7 +69,7 @@ const EXCLUDED_BASENAMES = new Set(['mixins.css', 'style.css', 'rules.css']);
  *   src/utils/utilities.css       -> utilities.min.css       (promoted to root)
  *   src/utils/{name}.css          -> utils/{name}.min.css    (other utils)
  *   src/tokens.css                -> tokens.min.css
- *   src/semantic-defaults.css     -> semantic-defaults.min.css
+ *   src/semantic.css               -> semantic.min.css
  *   src/aliases.css               -> aliases.min.css
  *   src/line.css                  -> line.min.css
  */
@@ -143,7 +143,7 @@ async function discoverEntries(): Promise<EntryPoint[]> {
   }
 
   // Root-level entry files (only if they exist)
-  const rootEntries = ['tokens.css', 'semantic-defaults.css', 'aliases.css', 'reset.css', 'line.css'];
+  const rootEntries = ['tokens.css', 'semantic.css', 'aliases.css', 'reset.css', 'line.css'];
 
   for (const file of rootEntries) {
     const srcPath = join(SRC, file);

--- a/packages/theme/src/line.css
+++ b/packages/theme/src/line.css
@@ -1,5 +1,5 @@
 @import "./tokens.css";
-@import "./semantic-defaults.css";
+@import "./semantic.css";
 @import "./utils/normalize.css";
 @import "./utils/utilities.css";
 

--- a/packages/theme/src/semantic.css
+++ b/packages/theme/src/semantic.css
@@ -1,5 +1,5 @@
 /* ═══════════════════════════════════════════════════════════
-   semantic-defaults.css — line://ui Semantic Role Defaults (L2)
+   semantic.css — line://ui Semantic Role Defaults (L2)
 
    Maps the neutral gray scale to semantic role tokens.
    Schemas (.line-schema-*) override these when active.

--- a/packages/theme/src/style.css
+++ b/packages/theme/src/style.css
@@ -1,5 +1,5 @@
 @import "./tokens.css";
-@import "./semantic-defaults.css";
+@import "./semantic.css";
 @import "./utils/normalize.css";
 @import "./utils/utilities.css";
 


### PR DESCRIPTION
Aligns the package.json export key with the documented public API specified in the Design System Implementation Guide, PRD, and Theme Gap Analysis. The underlying file path (dist/semantic-defaults.min.css) remains unchanged.

Ref: line-ui-p3v.19