### PR TITLE
chore(theme): fix header comment token count in gradients.css (43 → 41)

### DIFF
--- a/packages/theme/src/tokens/gradients.css
+++ b/packages/theme/src/tokens/gradients.css
@@ -4,7 +4,7 @@
    Gradient space (1), gradients (1..30), noise textures (1..5),
    noise filters (1..5).
 
-   Full 1:1 Open Props match (43 tokens + @supports upgrade).
+   Full 1:1 Open Props match (41 tokens + @supports upgrade).
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {


### PR DESCRIPTION
The file header claimed 43 tokens but only 41 unique custom properties are defined: 1 gradient-space + 30 gradients + 5 noises + 5 noise-filters.