### PR TITLE
chore(presets): remove leading ./ prefix from files array entries

### DIFF
--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -44,7 +44,7 @@
   },
   "files": [
     "dist/",
-    "./LICENSE.md",
-    "./README.md"
+    "LICENSE.md",
+    "README.md"
   ]
 }


### PR DESCRIPTION
Normalize LICENSE.md and README.md entries in the files array to omit the unnecessary ./ prefix, consistent with npm conventions.