### PR TITLE
chore(core): align publishConfig.registry to GitHub Packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,7 +95,7 @@
     }
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change core's publishConfig.registry from https://registry.npmjs.org/ to https://npm.pkg.github.com to match theme and presets packages, consistent with the CI .npmrc action that routes @websublime scope to GitHub Packages.