### PR TITLE
fix(theme): remove open-props and postcss-jit-props, prefix shadow vars

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,11 +46,9 @@
       "version": "0.6.0",
       "devDependencies": {
         "cssnano": "^6.0.1",
-        "open-props": "^1.6.5",
         "postcss": "^8.4.31",
         "postcss-custom-media": "^10.0.2",
         "postcss-import": "^15.1.0",
-        "postcss-jit-props": "^1.0.13",
         "postcss-mixins": "^9.0.4",
         "postcss-nested": "^6.0.1",
         "postcss-preset-env": "^9.2.0",
@@ -497,11 +495,7 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "globalyzer": ["globalyzer@0.1.0", "", {}, "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="],
-
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
-
-    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -585,8 +579,6 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
-    "open-props": ["open-props@1.7.23", "", {}, "sha512-+xyrJmxV9QUBFbSwPROYhOg/FLXry+uuPr4R+B5EaE4556Oc18/8ZC/fL5A+/lbRSwNvA0Alh+C0KpyFWLmLZg=="],
-
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
@@ -666,8 +658,6 @@
     "postcss-image-set-function": ["postcss-image-set-function@6.0.3", "", { "dependencies": { "@csstools/utilities": "^1.0.0", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.4" } }, "sha512-i2bXrBYzfbRzFnm+pVuxVePSTCRiNmlfssGI4H0tJQvDue+yywXwUxe68VyzXs7cGtMaH6MCLY6IbCShrSroCw=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
-
-    "postcss-jit-props": ["postcss-jit-props@1.0.16", "", { "dependencies": { "tiny-glob": "^0.2.9" }, "peerDependencies": { "postcss": "^8.2.8" } }, "sha512-EXHA65umJ3+BiMnd6kOCargYe+QXS72hGrkW9nqaCdt6aeOp4fT3Nme6qn6yIDBmzv19mx3zeVU0PdiqJBCwoA=="],
 
     "postcss-js": ["postcss-js@4.1.0", "", { "dependencies": { "camelcase-css": "^2.0.1" }, "peerDependencies": { "postcss": "^8.4.21" } }, "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw=="],
 
@@ -820,8 +810,6 @@
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
     "thenby": ["thenby@1.3.4", "", {}, "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="],
-
-    "tiny-glob": ["tiny-glob@0.2.9", "", { "dependencies": { "globalyzer": "0.1.0", "globrex": "^0.1.2" } }, "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -26,11 +26,9 @@
   },
   "devDependencies": {
     "cssnano": "^6.0.1",
-    "open-props": "^1.6.5",
     "postcss": "^8.4.31",
     "postcss-custom-media": "^10.0.2",
     "postcss-import": "^15.1.0",
-    "postcss-jit-props": "^1.0.13",
     "postcss-mixins": "^9.0.4",
     "postcss-nested": "^6.0.1",
     "postcss-preset-env": "^9.2.0",

--- a/packages/theme/src/custom/amber-custom.css
+++ b/packages/theme/src/custom/amber-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-amber-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-amber-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-amber-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-amber-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-amber-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-amber-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-amber-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-amber-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-amber-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-amber-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-amber-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-amber-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/blue-custom.css
+++ b/packages/theme/src/custom/blue-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-blue-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-blue-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-blue-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-blue-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-blue-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-blue-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-blue-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-blue-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-blue-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-blue-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-blue-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-blue-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/bronze-custom.css
+++ b/packages/theme/src/custom/bronze-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-bronze-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-bronze-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-bronze-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-bronze-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-bronze-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-bronze-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-bronze-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-bronze-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-bronze-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-bronze-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-bronze-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-bronze-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/brown-custom.css
+++ b/packages/theme/src/custom/brown-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-brown-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-brown-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-brown-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-brown-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-brown-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-brown-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-brown-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-brown-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-brown-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-brown-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-brown-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-brown-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/crimson-custom.css
+++ b/packages/theme/src/custom/crimson-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-crimson-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-crimson-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-crimson-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-crimson-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-crimson-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-crimson-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-crimson-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-crimson-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-crimson-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-crimson-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-crimson-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-crimson-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/cyan-custom.css
+++ b/packages/theme/src/custom/cyan-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-cyan-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-cyan-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-cyan-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-cyan-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-cyan-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-cyan-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-cyan-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-cyan-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-cyan-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-cyan-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-cyan-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-cyan-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/gold-custom.css
+++ b/packages/theme/src/custom/gold-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-gold-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-gold-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-gold-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-gold-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-gold-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-gold-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-gold-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-gold-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-gold-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-gold-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-gold-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-gold-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/grass-custom.css
+++ b/packages/theme/src/custom/grass-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-grass-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-grass-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-grass-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-grass-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-grass-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-grass-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-grass-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-grass-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-grass-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-grass-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-grass-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-grass-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/gray-custom.css
+++ b/packages/theme/src/custom/gray-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-gray-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-gray-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-gray-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-gray-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-gray-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-gray-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-gray-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-gray-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-gray-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-gray-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-gray-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-gray-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/green-custom.css
+++ b/packages/theme/src/custom/green-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-green-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-green-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-green-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-green-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-green-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-green-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-green-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-green-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-green-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-green-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-green-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-green-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/indigo-custom.css
+++ b/packages/theme/src/custom/indigo-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-indigo-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-indigo-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-indigo-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-indigo-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-indigo-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-indigo-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-indigo-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-indigo-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-indigo-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-indigo-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-indigo-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-indigo-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/lime-custom.css
+++ b/packages/theme/src/custom/lime-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-lime-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-lime-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-lime-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-lime-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-lime-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-lime-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-lime-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-lime-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-lime-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-lime-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-lime-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-lime-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/mauve-custom.css
+++ b/packages/theme/src/custom/mauve-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-mauve-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-mauve-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-mauve-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-mauve-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-mauve-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-mauve-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-mauve-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-mauve-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-mauve-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-mauve-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-mauve-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-mauve-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/mint-custom.css
+++ b/packages/theme/src/custom/mint-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-mint-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-mint-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-mint-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-mint-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-mint-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-mint-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-mint-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-mint-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-mint-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-mint-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-mint-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-mint-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/olive-custom.css
+++ b/packages/theme/src/custom/olive-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-olive-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-olive-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-olive-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-olive-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-olive-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-olive-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-olive-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-olive-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-olive-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-olive-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-olive-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-olive-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/orange-custom.css
+++ b/packages/theme/src/custom/orange-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-orange-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-orange-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-orange-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-orange-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-orange-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-orange-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-orange-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-orange-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-orange-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-orange-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-orange-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-orange-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/pink-custom.css
+++ b/packages/theme/src/custom/pink-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-pink-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-pink-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-pink-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-pink-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-pink-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-pink-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-pink-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-pink-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-pink-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-pink-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-pink-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-pink-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/plum-custom.css
+++ b/packages/theme/src/custom/plum-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-plum-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-plum-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-plum-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-plum-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-plum-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-plum-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-plum-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-plum-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-plum-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-plum-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-plum-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-plum-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/purple-custom.css
+++ b/packages/theme/src/custom/purple-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-purple-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-purple-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-purple-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-purple-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-purple-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-purple-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-purple-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-purple-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-purple-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-purple-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-purple-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-purple-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/red-custom.css
+++ b/packages/theme/src/custom/red-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-red-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-red-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-red-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-red-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-red-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-red-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-red-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-red-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-red-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-red-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-red-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-red-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/sage-custom.css
+++ b/packages/theme/src/custom/sage-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-sage-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-sage-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-sage-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-sage-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-sage-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-sage-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-sage-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-sage-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-sage-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-sage-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-sage-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-sage-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/sand-custom.css
+++ b/packages/theme/src/custom/sand-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-sand-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-sand-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-sand-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-sand-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-sand-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-sand-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-sand-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-sand-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-sand-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-sand-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-sand-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-sand-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/sky-custom.css
+++ b/packages/theme/src/custom/sky-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-sky-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-sky-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-sky-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-sky-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-sky-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-sky-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-sky-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-sky-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-sky-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-sky-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-sky-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-sky-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/slate-custom.css
+++ b/packages/theme/src/custom/slate-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-slate-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-slate-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-slate-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-slate-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-slate-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-slate-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-slate-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-slate-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-slate-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-slate-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-slate-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-slate-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/teal-custom.css
+++ b/packages/theme/src/custom/teal-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-teal-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-teal-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-teal-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-teal-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-teal-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-teal-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-teal-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-teal-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-teal-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-teal-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-teal-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-teal-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/tomato-custom.css
+++ b/packages/theme/src/custom/tomato-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-tomato-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-tomato-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-tomato-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-tomato-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-tomato-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-tomato-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-tomato-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-tomato-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-tomato-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-tomato-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-tomato-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-tomato-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/violet-custom.css
+++ b/packages/theme/src/custom/violet-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-violet-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-violet-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-violet-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-violet-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-violet-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-violet-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-violet-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-violet-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-violet-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-violet-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-violet-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-violet-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/custom/yellow-custom.css
+++ b/packages/theme/src/custom/yellow-custom.css
@@ -6,61 +6,61 @@
 
   :nth-child(2) {
     background: var(--line-yellow-1);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(3) {
     background: var(--line-yellow-2);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(4) {
     background: var(--line-yellow-3);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(5) {
     background: var(--line-yellow-4);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(6) {
     background: var(--line-yellow-5);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(7) {
     background: var(--line-yellow-6);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(8) {
     background: var(--line-yellow-7);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(9) {
     background: var(--line-yellow-8);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(10) {
     background: var(--line-yellow-9);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(11) {
     background: var(--line-yellow-10);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(12) {
     background: var(--line-yellow-11);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 
   :nth-child(13) {
     background: var(--line-yellow-12);
-    box-shadow: var(--shadow-3);
+    box-shadow: var(--line-shadow-3);
   }
 }

--- a/packages/theme/src/postcss-pipeline.ts
+++ b/packages/theme/src/postcss-pipeline.ts
@@ -12,10 +12,6 @@
 
 import type { AcceptedPlugin } from 'postcss';
 
-// TODO(line-ui-c5q.1): Add postcss-jit-props plugin for Open Props utility token
-// injection with --line-* prefix rewrite. The dependency is already installed; it needs
-// to be activated in this pipeline. See PRD 9.3 and Decision T3.
-
 /**
  * Lazily load and configure the full PostCSS plugin chain.
  *


### PR DESCRIPTION
Remove open-props and postcss-jit-props from devDependencies since all foundation tokens are now explicitly defined in src/tokens/ with --line-* prefix. Remove the obsolete TODO comment from postcss-pipeline.ts. Fix 336 occurrences of var(--shadow-3) to var(--line-shadow-3) across 28 custom CSS files that previously relied on jit-props resolution.

Resolves: line-ui-c5q.1