### PR TITLE
chore(theme): normalize Open Props references in token file headers

### DIFF
--- a/packages/theme/src/tokens/aspects.css
+++ b/packages/theme/src/tokens/aspects.css
@@ -1,7 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    aspects.css — line://ui Aspect Ratio Tokens
 
-   Full 1:1 Open Props match — all 6 aspect ratio tokens.
+   6 aspect ratio tokens.
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/borders.css
+++ b/packages/theme/src/tokens/borders.css
@@ -1,13 +1,13 @@
 /* ═══════════════════════════════════════════════════════════
    borders.css — line://ui Border Tokens
 
-   Border sizes (OP 5), radii (OP 6), drawn radii (OP 6),
-   round (OP 1), blob radii (OP 5), conditional radii (OP 6).
+   29 border tokens: sizes (5), radii (6), drawn radii (6),
+   round (1), blob radii (5), conditional radii (6).
 
-   Full 1:1 Open Props match (29 tokens).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
-/* ── Border Sizes (OP 5) ── */
+/* ── Border Sizes (5) ── */
 
 :where(html) {
   --line-border-size-1: 1px;
@@ -17,7 +17,7 @@
   --line-border-size-5: 25px;
 }
 
-/* ── Border Radius (OP 6) ── */
+/* ── Border Radius (6) ── */
 
 :where(html) {
   --line-radius-1: 2px;
@@ -28,7 +28,7 @@
   --line-radius-6: 8rem;
 }
 
-/* ── Radius Drawn (OP 6) ── */
+/* ── Radius Drawn (6) ── */
 
 :where(html) {
   --line-radius-drawn-1: 255px 15px 225px 15px / 15px 225px 15px 255px;
@@ -39,13 +39,13 @@
   --line-radius-drawn-6: 28px 100px 20px 15px / 150px 30px 205px 225px;
 }
 
-/* ── Radius Round (OP 1) ── */
+/* ── Radius Round (1) ── */
 
 :where(html) {
   --line-radius-round: 1e5px;
 }
 
-/* ── Radius Blob (OP 5) ── */
+/* ── Radius Blob (5) ── */
 
 :where(html) {
   --line-radius-blob-1: 30% 70% 70% 30% / 53% 30% 70% 47%;
@@ -55,7 +55,7 @@
   --line-radius-blob-5: 49% 51% 48% 52% / 57% 44% 56% 43%;
 }
 
-/* ── Radius Conditional (OP 6) ──
+/* ── Radius Conditional (6) ──
    These reference --line-radius-* tokens above. */
 
 :where(html) {

--- a/packages/theme/src/tokens/colors-absolute.css
+++ b/packages/theme/src/tokens/colors-absolute.css
@@ -1,8 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    colors-absolute.css — line://ui Absolute Color & Color Scheme Tokens
 
-   2 absolute colors + color-scheme declarations.
-   line:// extensions (not in Open Props core token system).
+   2 absolute color tokens + color-scheme declarations.
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/durations.css
+++ b/packages/theme/src/tokens/durations.css
@@ -1,11 +1,13 @@
 /* ═══════════════════════════════════════════════════════════
    durations.css — line://ui Duration / Timing Tokens
 
-   Open Props practical durations (7) + line:// semantic
-   extensions (5).
+   12 duration / timing tokens: practical durations (7),
+   semantic extensions (5).
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
-/* ── OP Practical Durations (7) ── */
+/* ── Practical Durations (7) ── */
 
 :where(html) {
   --line-duration-instant: 0ms;

--- a/packages/theme/src/tokens/easing.css
+++ b/packages/theme/src/tokens/easing.css
@@ -1,12 +1,13 @@
 /* ═══════════════════════════════════════════════════════════
    easing.css — line://ui Easing Tokens
 
-   Full 1:1 Open Props match — all 81 easing tokens:
-   Standard (5), ease-in (5), ease-out (5), ease-in-out (5),
-   elastic-out (5), elastic-in (5), elastic-in-out (5),
-   step (5), elastic aliases (5), squish aliases (5),
-   spring (5, linear()), bounce (5, linear()),
+   81 easing tokens: standard (5), ease-in (5), ease-out (5),
+   ease-in-out (5), elastic-out (5), elastic-in (5),
+   elastic-in-out (5), step (5), elastic aliases (5),
+   squish aliases (5), spring (5, linear()), bounce (5, linear()),
    named curves (21: circ, cubic, expo, quad, quart, quint, sine).
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/focus.css
+++ b/packages/theme/src/tokens/focus.css
@@ -1,9 +1,11 @@
 /* ═══════════════════════════════════════════════════════════
    focus.css — line://ui Focus Ring Tokens
 
-   3 tokens — line:// extensions (not in Open Props).
+   3 focus ring tokens (width, offset, color).
    Fallback value on ring-color ensures ring works even
    without the semantic layer loaded.
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/gradients.css
+++ b/packages/theme/src/tokens/gradients.css
@@ -1,10 +1,11 @@
 /* ═══════════════════════════════════════════════════════════
    gradients.css — line://ui Gradient & Noise Tokens
 
-   Gradient space (1), gradients (1..30), noise textures (1..5),
+   41 gradient and noise tokens (+ @supports upgrade):
+   gradient space (1), gradients (1..30), noise textures (1..5),
    noise filters (1..5).
 
-   Full 1:1 Open Props match (41 tokens + @supports upgrade).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/highlights.css
+++ b/packages/theme/src/tokens/highlights.css
@@ -1,9 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    highlights.css — line://ui Highlight Tokens
 
-   Highlight tokens (2) + composite (1).
+   3 highlight tokens: base (2) + composite (1).
 
-   Full 1:1 Open Props match (3 tokens).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/layouts.css
+++ b/packages/theme/src/tokens/layouts.css
@@ -1,9 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    layouts.css — line://ui Layout Tokens
 
-   Grid cell (2), RAM (1), Holy Grail (1).
+   4 layout tokens: grid cell (2), RAM (1), Holy Grail (1).
 
-   Full 1:1 Open Props match (4 tokens).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/masks.css
+++ b/packages/theme/src/tokens/masks.css
@@ -1,9 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    masks.css — line://ui Mask Tokens
 
-   Edge masks (25), corner-cut masks (9).
+   34 mask tokens: edge masks (25), corner-cut masks (9).
 
-   Full 1:1 Open Props match (34 tokens).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/opacity.css
+++ b/packages/theme/src/tokens/opacity.css
@@ -1,7 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    opacity.css — line://ui Opacity Tokens
 
-   3 semantic tokens — line:// extensions (not in Open Props).
+   3 opacity tokens (disabled, overlay, placeholder).
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/shadows.css
+++ b/packages/theme/src/tokens/shadows.css
@@ -1,12 +1,13 @@
 /* ═══════════════════════════════════════════════════════════
    shadows.css — line://ui Shadow / Elevation Tokens
 
-   Control variables (shadow-color, shadow-strength, 7
+   24 shadow / elevation tokens (+ dark mode overrides):
+   control variables (shadow-color, shadow-strength, 7
    intermediate strengths), outer shadows (1..6), inner
    shadows (0..4), inner-shadow-highlight.
 
-   Full 1:1 Open Props match (24 tokens + dark mode overrides).
    Uses inline calc() for strength references per design guide.
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 /* ── Light Mode (default) ── */
@@ -15,7 +16,7 @@
   --line-shadow-color: 220 3% 15%;
   --line-shadow-strength: 1%;
 
-  /* Deviation from OP: uses #fff2 (13% opacity) instead of OP's #fff (fully opaque).
+  /* Design choice: uses #fff2 (13% opacity) instead of fully opaque #fff.
      Provides a subtler highlight that blends better with colored surfaces and
      avoids harsh white lines on non-white backgrounds. */
   --line-inner-shadow-highlight: inset 0 -0.5px 0 0 #fff2, inset 0 0.5px 0 0 #0001;

--- a/packages/theme/src/tokens/sizing.css
+++ b/packages/theme/src/tokens/sizing.css
@@ -1,14 +1,14 @@
 /* ═══════════════════════════════════════════════════════════
    sizing.css — line://ui Sizing & Spacing Tokens
 
-   Rem sizes (16), px sizes (16), fluid sizes (10),
-   content widths (3), header widths (3), breakpoints (7),
-   relative/ch-based sizes (18).
+   74 sizing and spacing tokens: rem sizes (16), px sizes (16),
+   fluid sizes (10), content widths (3), header widths (3),
+   breakpoints (7), relative/ch-based sizes (18).
 
-   Full 1:1 Open Props match (74 tokens).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
-/* ── Rem Sizes (OP 16) ── */
+/* ── Rem Sizes (16) ── */
 
 :where(html) {
   --line-size-000: -0.5rem;
@@ -30,7 +30,7 @@
   --line-size-15: 30rem;
 }
 
-/* ── Px Sizes (OP 16) ── */
+/* ── Px Sizes (16) ── */
 
 :where(html) {
   --line-size-px-000: -8px;
@@ -52,7 +52,7 @@
   --line-size-px-15: 480px;
 }
 
-/* ── Fluid Sizes (OP 10) ── */
+/* ── Fluid Sizes (10) ── */
 
 :where(html) {
   --line-size-fluid-1: clamp(0.5rem, 1vw, 1rem);
@@ -67,7 +67,7 @@
   --line-size-fluid-10: clamp(20rem, 40vw, 30rem);
 }
 
-/* ── Content Widths (OP 3) ── */
+/* ── Content Widths (3) ── */
 
 :where(html) {
   --line-size-content-1: 20ch;
@@ -75,7 +75,7 @@
   --line-size-content-3: 60ch;
 }
 
-/* ── Header Widths (OP 3) ── */
+/* ── Header Widths (3) ── */
 
 :where(html) {
   --line-size-header-1: 20ch;
@@ -83,7 +83,7 @@
   --line-size-header-3: 35ch;
 }
 
-/* ── Breakpoints (OP 7) ── */
+/* ── Breakpoints (7) ── */
 
 :where(html) {
   --line-size-xxs: 240px;
@@ -95,7 +95,7 @@
   --line-size-xxl: 1920px;
 }
 
-/* ── Relative / ch-based (OP 18) ── */
+/* ── Relative / ch-based (18) ── */
 
 :where(html) {
   --line-size-relative-000: -0.5ch;

--- a/packages/theme/src/tokens/svg.css
+++ b/packages/theme/src/tokens/svg.css
@@ -1,9 +1,9 @@
 /* ═══════════════════════════════════════════════════════════
    svg.css — line://ui SVG Squircle Tokens
 
-   SVG squircle tokens (3).
+   3 SVG squircle tokens.
 
-   Full 1:1 Open Props match (3 tokens).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
 :where(html) {

--- a/packages/theme/src/tokens/typography.css
+++ b/packages/theme/src/tokens/typography.css
@@ -1,16 +1,14 @@
 /* ═══════════════════════════════════════════════════════════
    typography.css — line://ui Typography Tokens
 
-   Font families, weights, line-heights, letter-spacings,
-   and font-sizes (static + fluid).
+   62 typography tokens: 19 families, 9 weights,
+   10 line-heights, 10 letter-spacings,
+   10 static + 4 fluid font-sizes.
 
-   Open Props 1:1 mapping (19 families, 9 weights, 7 line-heights,
-   8 letter-spacings, 10 static + 4 fluid font-sizes)
-   plus line:// extensions (3 extra line-heights, 2 extra
-   letter-spacings, renumbered font-size scale to 10 steps).
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
-/* ── Font Families (OP 19) ── */
+/* ── Font Families (19) ── */
 
 :where(html) {
   --line-font-system-ui: system-ui, sans-serif;
@@ -32,7 +30,7 @@
   --line-font-didone: Didot, Bodoni MT, Noto Serif Display, URW Palladio L, P052, Sylfaen, serif;
   --line-font-handwritten: Segoe Print, Bradley Hand, Chilanka, TSCu_Comic, casual, cursive;
 
-  /* Custom stacks — line:// defines its own sans/serif/mono (not OP aliases) */
+  /* Custom stacks — line:// defines its own sans/serif/mono */
   --line-font-sans: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
   --line-font-serif: ui-serif, serif;
   --line-font-mono:
@@ -40,7 +38,7 @@
     monospace;
 }
 
-/* ── Font Weights (OP 9) ── */
+/* ── Font Weights (9) ── */
 
 :where(html) {
   --line-font-weight-1: 100;
@@ -54,9 +52,8 @@
   --line-font-weight-9: 900;
 }
 
-/* ── Line Height (OP 7 + 3 line:// extensions = 10) ──
-   OP --font-lineheight-00..5 mapped to --line-font-lineheight-0..6.
-   Extensions: 7 (2.25), 8 (2.5), 9 (3). */
+/* ── Line Height (10) ──
+   Base scale 0..6, extensions: 7 (2.25), 8 (2.5), 9 (3). */
 
 :where(html) {
   --line-font-lineheight-0: 0.95;
@@ -71,7 +68,7 @@
   --line-font-lineheight-9: 3;
 }
 
-/* ── Letter Spacing (OP 8 + 2 line:// extensions = 10) ── */
+/* ── Letter Spacing (10) ── */
 
 :where(html) {
   --line-font-letterspacing-0: -0.05em;
@@ -86,7 +83,7 @@
   --line-font-letterspacing-9: 2em;
 }
 
-/* ── Font Size — Static (OP 10 renumbered to 0..9) ── */
+/* ── Font Size — Static (10, numbered 0..9) ── */
 
 :where(html) {
   --line-font-size-0: 0.5rem;
@@ -101,7 +98,7 @@
   --line-font-size-9: 3.5rem;
 }
 
-/* ── Font Size — Fluid (OP 4) ── */
+/* ── Font Size — Fluid (4) ── */
 
 :where(html) {
   --line-font-size-fluid-0: clamp(0.75rem, 2vw, 1rem);

--- a/packages/theme/src/tokens/zindex.css
+++ b/packages/theme/src/tokens/zindex.css
@@ -1,10 +1,13 @@
 /* ═══════════════════════════════════════════════════════════
    zindex.css — line://ui Z-Index / Layer Tokens
 
-   Open Props layers (6) + line:// semantic extensions (8).
+   14 z-index / layer tokens: base layers (6),
+   semantic extensions (8).
+
+   Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */
 
-/* ── OP Layer Tokens (6) ── */
+/* ── Base Layer Tokens (6) ── */
 
 :where(html) {
   --line-layer-1: 1;


### PR DESCRIPTION
Replace 'Full 1:1 Open Props match' and 'OP' abbreviations in all 16 token file headers and section comments with neutral descriptions of token family content and count, consistent with the style adopted in animations.css (line-ui-p3v.24). All tokens are now presented as explicitly defined within the line://ui token system.