### PR TITLE
chore(theme): add sub-category counts to masks.css header comment

### DIFF
--- a/packages/theme/src/tokens/masks.css
+++ b/packages/theme/src/tokens/masks.css
@@ -2,6 +2,8 @@
    masks.css — line://ui Mask Tokens
 
    34 mask tokens: edge masks (25), corner-cut masks (9).
+     Edge: scoop (6), scalloped (7), drip (6), zig-zag (6).
+     Corner-cut: circles (3), squares (3), angles (3).
 
    Explicitly defined within the line://ui token system.
    ═══════════════════════════════════════════════════════════ */


### PR DESCRIPTION
List per-sub-category token counts (scoop 6, scalloped 7, drip 6, zig-zag 6, circles 3, squares 3, angles 3) for quick scanning.

Ref: line-ui-p3v.16