### PR TITLE
feat(showcase): scaffold apps/showcase/ package with Vite + Lit + router

### DIFF
--- a/apps/showcase/index.html
+++ b/apps/showcase/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>line://ui — Design System Showcase</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/src/styles/showcase.css" />
+    <script type="module" src="/src/app.ts"></script>
+  </head>
+  <body>
+    <sc-app></sc-app>
+  </body>
+</html>

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@websublime/showcase",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@lit-labs/router": "^0.1.3",
+    "@websublime/line-theme": "workspace:*",
+    "culori": "^4.0.1",
+    "lit": "^3.2.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^7.0.0"
+  }
+}

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -1,0 +1,59 @@
+import { Router } from '@lit-labs/router';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+// Validate theme imports resolve correctly
+import '@websublime/line-theme';
+import '@websublime/line-theme/tokens';
+import '@websublime/line-theme/colors/blue';
+import '@websublime/line-theme/schemas/blue';
+import '@websublime/line-theme/aliases';
+
+// Page imports (lazy stubs for now)
+import './pages/home.js';
+
+@customElement('sc-app')
+export class ScApp extends LitElement {
+  private router = new Router(this, [
+    { path: '/', render: () => html`<sc-page-home></sc-page-home>` },
+    { path: '/tokens/colors', render: () => html`<sc-page-placeholder data-page="colors"></sc-page-placeholder>` },
+    {
+      path: '/tokens/typography',
+      render: () => html`<sc-page-placeholder data-page="typography"></sc-page-placeholder>`
+    },
+    { path: '/tokens/spacing', render: () => html`<sc-page-placeholder data-page="spacing"></sc-page-placeholder>` },
+    { path: '/tokens/motion', render: () => html`<sc-page-placeholder data-page="motion"></sc-page-placeholder>` },
+    { path: '/tokens/surfaces', render: () => html`<sc-page-placeholder data-page="surfaces"></sc-page-placeholder>` },
+    {
+      path: '/tokens/decorative',
+      render: () => html`<sc-page-placeholder data-page="decorative"></sc-page-placeholder>`
+    },
+    { path: '/semantic', render: () => html`<sc-page-placeholder data-page="semantic"></sc-page-placeholder>` },
+    { path: '/elements', render: () => html`<sc-page-placeholder data-page="elements"></sc-page-placeholder>` },
+    { path: '/themes', render: () => html`<sc-page-placeholder data-page="themes"></sc-page-placeholder>` },
+    { path: '/generator', render: () => html`<sc-page-placeholder data-page="generator"></sc-page-placeholder>` }
+  ]);
+
+  static override styles = css`
+    :host {
+      display: block;
+      min-height: 100dvh;
+    }
+
+    main {
+      padding: 1rem;
+    }
+  `;
+
+  override render() {
+    return html`
+      <main>${this.router.outlet()}</main>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-app': ScApp;
+  }
+}

--- a/apps/showcase/src/components/sc-code-block.ts
+++ b/apps/showcase/src/components/sc-code-block.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-code-block')
+export class ScCodeBlock extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<pre><code><slot></slot></code></pre>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-code-block': ScCodeBlock;
+  }
+}

--- a/apps/showcase/src/components/sc-color-picker.ts
+++ b/apps/showcase/src/components/sc-color-picker.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-color-picker')
+export class ScColorPicker extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<div class="color-picker"><!-- HSL/OKLCH color picker --></div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-color-picker': ScColorPicker;
+  }
+}

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-nav')
+export class ScNav extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<nav><!-- Sidebar navigation --></nav>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-nav': ScNav;
+  }
+}

--- a/apps/showcase/src/components/sc-section.ts
+++ b/apps/showcase/src/components/sc-section.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-section')
+export class ScSection extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<section><slot></slot></section>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-section': ScSection;
+  }
+}

--- a/apps/showcase/src/components/sc-swatch.ts
+++ b/apps/showcase/src/components/sc-swatch.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-swatch')
+export class ScSwatch extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<div class="swatch"><slot></slot></div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-swatch': ScSwatch;
+  }
+}

--- a/apps/showcase/src/components/sc-token-card.ts
+++ b/apps/showcase/src/components/sc-token-card.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-token-card')
+export class ScTokenCard extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<div class="token-card"><slot></slot></div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-token-card': ScTokenCard;
+  }
+}

--- a/apps/showcase/src/pages/colors.ts
+++ b/apps/showcase/src/pages/colors.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-colors')
+export class ScPageColors extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Colors</h2><p>L0: 28 palettes x 12 levels</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-colors': ScPageColors;
+  }
+}

--- a/apps/showcase/src/pages/decorative.ts
+++ b/apps/showcase/src/pages/decorative.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-decorative')
+export class ScPageDecorative extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Decorative</h2><p>41 gradients/noise, 34 masks, 3 highlights</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-decorative': ScPageDecorative;
+  }
+}

--- a/apps/showcase/src/pages/elements.ts
+++ b/apps/showcase/src/pages/elements.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-elements')
+export class ScPageElements extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Elements</h2><p>Normalize/reset: all native HTML elements</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-elements': ScPageElements;
+  }
+}

--- a/apps/showcase/src/pages/generator.ts
+++ b/apps/showcase/src/pages/generator.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-generator')
+export class ScPageGenerator extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Palette Generator</h2><p>Pick a base color and generate a full 12-level palette</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-generator': ScPageGenerator;
+  }
+}

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -1,0 +1,37 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-home')
+export class ScPageHome extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    h1 {
+      font-size: 2rem;
+      margin-block-end: 0.5rem;
+    }
+
+    .accent {
+      color: var(--line-blue-9, #3b82f6);
+    }
+
+    p {
+      color: var(--line-gray-11, #6b7280);
+    }
+  `;
+
+  override render() {
+    return html`
+      <h1>line<span class="accent">://</span>ui</h1>
+      <p>Design System Showcase</p>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-home': ScPageHome;
+  }
+}

--- a/apps/showcase/src/pages/motion.ts
+++ b/apps/showcase/src/pages/motion.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-motion')
+export class ScPageMotion extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Motion</h2><p>81 easings, 12 durations, 23 animations</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-motion': ScPageMotion;
+  }
+}

--- a/apps/showcase/src/pages/semantic.ts
+++ b/apps/showcase/src/pages/semantic.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-semantic')
+export class ScPageSemantic extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Semantic</h2><p>L2 semantic defaults + L3 aliases</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-semantic': ScPageSemantic;
+  }
+}

--- a/apps/showcase/src/pages/spacing.ts
+++ b/apps/showcase/src/pages/spacing.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-spacing')
+export class ScPageSpacing extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Spacing</h2><p>74 spacing tokens</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-spacing': ScPageSpacing;
+  }
+}

--- a/apps/showcase/src/pages/surfaces.ts
+++ b/apps/showcase/src/pages/surfaces.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-surfaces')
+export class ScPageSurfaces extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Surfaces</h2><p>24 shadows, 29 borders/radii, 3 opacity, 3 focus ring, 6 aspects</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-surfaces': ScPageSurfaces;
+  }
+}

--- a/apps/showcase/src/pages/themes.ts
+++ b/apps/showcase/src/pages/themes.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-themes')
+export class ScPageThemes extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Themes</h2><p>28 pre-built theme bundles</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-themes': ScPageThemes;
+  }
+}

--- a/apps/showcase/src/pages/typography.ts
+++ b/apps/showcase/src/pages/typography.ts
@@ -1,0 +1,19 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sc-page-typography')
+export class ScPageTypography extends LitElement {
+  static override styles = css`
+    :host { display: block; }
+  `;
+
+  override render() {
+    return html`<h2>Typography</h2><p>62 typography tokens</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-page-typography': ScPageTypography;
+  }
+}

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -1,0 +1,17 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: "JetBrains Mono", monospace;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100dvh;
+}

--- a/apps/showcase/tsconfig.json
+++ b/apps/showcase/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "useDefineForClassFields": false,
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "importHelpers": false,
+    "experimentalDecorators": true,
+    "rootDir": "./src",
+    "plugins": [
+      {
+        "name": "ts-lit-plugin",
+        "strict": true
+      }
+    ]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["dist"]
+}

--- a/apps/showcase/vite.config.ts
+++ b/apps/showcase/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  },
+  resolve: {
+    conditions: ['development', 'browser']
+  }
+});

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,20 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/showcase": {
+      "name": "@websublime/showcase",
+      "version": "0.0.0",
+      "dependencies": {
+        "@lit-labs/router": "^0.1.3",
+        "@websublime/line-theme": "workspace:*",
+        "culori": "^4.0.1",
+        "lit": "^3.2.1",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vite": "^7.0.0",
+      },
+    },
     "packages/core": {
       "name": "@websublime/line-core",
       "version": "0.2.0",
@@ -54,7 +68,6 @@
         "postcss-preset-env": "^9.2.0",
         "postcss-simple-vars": "^7.0.1",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5",
       },
     },
   },
@@ -251,6 +264,8 @@
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
+    "@lit-labs/router": ["@lit-labs/router@0.1.4", "", { "dependencies": { "lit": "^2.0.0 || ^3.0.0" } }, "sha512-xURH6fOPE0MYfXa1nyl+qTIhZRVWkFa2oggTRodKAI2q/HjA2Va7HEKe7fMm8DdnFE+zEI2aUGnStawKpVh3lQ=="],
+
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
     "@lit/reactive-element": ["@lit/reactive-element@2.1.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0" } }, "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A=="],
@@ -347,6 +362,8 @@
 
     "@websublime/line-theme": ["@websublime/line-theme@workspace:packages/theme"],
 
+    "@websublime/showcase": ["@websublime/showcase@workspace:apps/showcase"],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
@@ -430,6 +447,8 @@
     "cssnano-utils": ["cssnano-utils@4.0.2", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "culori": ["culori@4.0.2", "", {}, "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw=="],
 
     "dataloader": ["dataloader@1.4.0", "", {}, "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="],
 
@@ -863,8 +882,6 @@
 
     "@rushstack/node-core-library/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
 
-    "@websublime/line-theme/vite": ["vite@4.5.14", "", { "dependencies": { "esbuild": "^0.18.10", "postcss": "^8.4.27", "rollup": "^3.27.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@types/node": ">= 14", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g=="],
-
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
@@ -891,58 +908,10 @@
 
     "@rushstack/node-core-library/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
-    "@websublime/line-theme/vite/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@websublime/line-theme/vite/rollup": ["rollup@3.30.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA=="],
-
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "postcss-cli/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "postcss-cli/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
-
-    "@websublime/line-theme/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   ],
   "license": "ISC",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "apps/*"
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",


### PR DESCRIPTION
Create the apps/showcase/ directory and wire up the full scaffold as defined in SHOWCASE-APP-SPEC section 2:

- package.json (@websublime/showcase, private, dev/build/preview scripts)
- vite.config.ts (Vite 7+)
- tsconfig.json (extends tsconfig.base.json, strict)
- index.html (entry point with JetBrains Mono font)
- src/app.ts (app shell with @lit-labs/router and all 11 routes)
- src/pages/ (stub pages for all routes: home, colors, typography, spacing, motion, surfaces, decorative, semantic, elements, themes, generator)
- src/components/ (stub components: sc-nav, sc-token-card, sc-code-block, sc-color-picker, sc-swatch, sc-section)
- src/styles/showcase.css (app-level styles)

Dependencies: lit@^3, @lit-labs/router, @websublime/line-theme (workspace), culori (for palette generator).

All five theme import paths validated at build time:
  import '@websublime/line-theme'
  import '@websublime/line-theme/tokens'
  import '@websublime/line-theme/colors/blue'
  import '@websublime/line-theme/schemas/blue'
  import '@websublime/line-theme/aliases'

Root package.json workspaces updated to include apps/*.