### PR TITLE
 feat(showcase): implement app shell with nav sidebar, dark/light toggle, and schema picker

### DIFF
--- a/.spec/SHOWCASE-APP-SPEC.md
+++ b/.spec/SHOWCASE-APP-SPEC.md
@@ -2,7 +2,7 @@
 
 **Status:** APPROVED
 **Created:** 2026-03-18
-**Last updated:** 2026-03-18
+**Last updated:** 2026-03-19
 
 ---
 
@@ -41,25 +41,22 @@ Rationale: apps vs packages separation is standard monorepo convention. The show
 | Concern | Choice | Rationale |
 |---------|--------|-----------|
 | Component framework | Lit 3+ | Project standard, dogfooding |
-| Router | @lit-labs/router | Official Lit router, reactive controllers, URLPattern API, lightweight |
+| Navigation | Panel-based (PanelKey) | Simpler than URL routing; single-page tool, not a multi-page site. State persisted in localStorage. See §10 Decision D2 |
 | Color science | culori | 8KB, typed, OKLCH support for palette generation |
-| Theme | @websublime/line-theme | Consumed as package — validates exports |
+| Theme | @websublime/line-theme | Consumed as full bundle — validates exports |
 | Build | Vite 7+ | Project standard |
-| Fonts | JetBrains Mono (Google Fonts) | Monospace aesthetic from current showcase |
+| UI Font | Geist (Google Fonts) | Crisp sans-serif rendering across all browsers. See §10 Decision D3 |
+| Code Font | IBM Plex Mono (Google Fonts) | Monospace for token names, code blocks, and code snippets only |
 
 ### 2.3 Dependency on Theme Package
 
-The showcase imports the theme as a real consumer would:
+The showcase imports the theme as a single full bundle:
 
 ```ts
-import '@websublime/line-theme';              // Full bundle
-import '@websublime/line-theme/tokens';       // Just foundation tokens
-import '@websublime/line-theme/colors/blue';  // Individual palette
-import '@websublime/line-theme/schemas/blue'; // Schema mapping
-import '@websublime/line-theme/aliases';      // Semantic aliases
+import '@websublime/line-theme';  // Full bundle: all palettes, schemas, tokens, aliases, normalize
 ```
 
-This validates that `package.json` exports resolve correctly.
+This validates that the full bundle export resolves correctly and includes all necessary CSS. Individual sub-path exports (`/tokens`, `/colors/*`, `/schemas/*`, `/aliases`) remain available for consumer apps that want tree-shaking.
 
 ### 2.4 Directory Structure
 
@@ -70,7 +67,7 @@ apps/showcase/
 ├── vite.config.ts
 ├── tsconfig.json
 └── src/
-    ├── app.ts                  # App shell + router setup
+    ├── app.ts                  # App shell + panel-based rendering
     ├── styles/
     │   └── showcase.css        # App-level styles (not distributed)
     ├── pages/
@@ -86,7 +83,7 @@ apps/showcase/
     │   ├── themes.ts           # /themes
     │   └── generator.ts        # /generator
     └── components/
-        ├── sc-nav.ts           # Sidebar navigation
+        ├── sc-nav.ts           # Top bar navigation with inline pill nav + hamburger dropdown
         ├── sc-token-card.ts    # Reusable token display card
         ├── sc-code-block.ts    # Code snippet + copy-to-clipboard
         ├── sc-color-picker.ts  # HSL/OKLCH color picker for generator
@@ -98,41 +95,43 @@ Component prefix: `sc-` (showcase) to avoid collision with `line-` components.
 
 ---
 
-## 3. Routes
+## 3. Panels
 
-| Path | Page | Description |
-|------|------|-------------|
-| `/` | home | Overview with summary cards linking to each section |
-| `/tokens/colors` | colors | L0: 28 palettes × 12 levels, contrast tokens, color-mix demo |
-| `/tokens/typography` | typography | 62 tokens: font families, sizes, weights, line-heights, letter-spacings |
-| `/tokens/spacing` | spacing | 74 tokens: rem, px, fluid, breakpoints, content/header widths, ch-based |
-| `/tokens/motion` | motion | 81 easings, 12 durations, 23 animations with live keyframe demos |
-| `/tokens/surfaces` | surfaces | 24 shadows, 29 borders/radii, 3 opacity, 3 focus ring, 6 aspects |
-| `/tokens/decorative` | decorative | 41 gradients/noise, 34 masks, 3 highlights, 3 SVG squircles, 4 layouts |
-| `/semantic` | semantic | L2 semantic defaults (light/dark), L3 aliases, override demo |
-| `/elements` | elements | Normalize/reset: all native HTML elements with applied tokens |
-| `/themes` | themes | Pre-built theme previews (each palette as color + schema bundle) |
-| `/generator` | generator | Palette generator: color picker → 12-level palette → theme preview → CSS export |
+Navigation is panel-based (not URL-routed). The app shell tracks the active panel via a `PanelKey` type and renders the corresponding page component via a switch statement. Panel state is persisted in `localStorage('line-panel')`. See §10 Decision D2.
 
-### 3.1 Router Configuration
+| PanelKey | Page | Description |
+|----------|------|-------------|
+| `colors` | colors | L0: 28 palettes × 12 levels, contrast tokens, color-mix demo |
+| `typography` | typography | 62 tokens: font families, sizes, weights, line-heights, letter-spacings |
+| `spacing` | spacing | 74 tokens: rem, px, fluid, breakpoints, content/header widths, ch-based |
+| `motion` | motion | 81 easings, 12 durations, 23 animations with live keyframe demos |
+| `surfaces` | surfaces | 24 shadows, 29 borders/radii, 3 opacity, 3 focus ring, 6 aspects |
+| `decorative` | decorative | 41 gradients/noise, 34 masks, 3 highlights, 3 SVG squircles, 4 layouts |
+| `semantic` | semantic | L2 semantic defaults (light/dark), L3 aliases, override demo |
+| `elements` | elements | Normalize/reset: all native HTML elements with applied tokens |
+| `themes` | themes | Pre-built theme previews (each palette as color + schema bundle) |
+| `generator` | generator | Palette generator: color picker → 12-level palette → theme preview → CSS export |
+
+### 3.1 Panel Configuration
 
 ```ts
-import { Router } from '@lit-labs/router';
+export type PanelKey =
+  | 'colors' | 'typography' | 'spacing' | 'motion' | 'surfaces'
+  | 'decorative' | 'semantic' | 'elements' | 'themes' | 'generator';
 
-// In app shell
-private router = new Router(this, [
-  { path: '/',                   render: () => html`<sc-page-home></sc-page-home>` },
-  { path: '/tokens/colors',      render: () => html`<sc-page-colors></sc-page-colors>` },
-  { path: '/tokens/typography',  render: () => html`<sc-page-typography></sc-page-typography>` },
-  { path: '/tokens/spacing',     render: () => html`<sc-page-spacing></sc-page-spacing>` },
-  { path: '/tokens/motion',      render: () => html`<sc-page-motion></sc-page-motion>` },
-  { path: '/tokens/surfaces',    render: () => html`<sc-page-surfaces></sc-page-surfaces>` },
-  { path: '/tokens/decorative',  render: () => html`<sc-page-decorative></sc-page-decorative>` },
-  { path: '/semantic',           render: () => html`<sc-page-semantic></sc-page-semantic>` },
-  { path: '/elements',           render: () => html`<sc-page-elements></sc-page-elements>` },
-  { path: '/themes',             render: () => html`<sc-page-themes></sc-page-themes>` },
-  { path: '/generator',          render: () => html`<sc-page-generator></sc-page-generator>` },
-]);
+// In app shell — renders active panel via switch
+private _renderPanel() {
+  switch (this._panel) {
+    case 'colors':     return html`<sc-page-colors></sc-page-colors>`;
+    case 'typography': return html`<sc-page-typography></sc-page-typography>`;
+    // ... etc
+  }
+}
+
+// Navigation via custom events from sc-nav
+@sc-navigate=${this._handleNavigate}   // detail: { panel: PanelKey }
+@sc-schema-change=${this._handleSchemaChange}  // detail: { schema: string }
+@sc-mode-change=${this._handleModeChange}      // detail: { light: boolean }
 ```
 
 ---
@@ -324,13 +323,31 @@ Each element shown in a card with:
 
 ### 5.1 `sc-nav`
 
-Sidebar navigation present on all pages:
-- Logo/wordmark at top
-- Route links grouped by category (Tokens, Semantic, Elements, Themes, Tools)
-- Active route indicator
-- Dark/light mode toggle
-- Schema palette picker (compact)
-- Collapsible on mobile (hamburger)
+Horizontal top bar navigation, sticky at the top of the viewport:
+
+**Layout:** Logo left → inline pill nav (desktop) → controls right (schema chip, mode toggle, hamburger menu)
+
+**Properties:**
+- `panel: PanelKey` — active panel (highlights corresponding nav button)
+- `schema: string` — active schema name (displayed in chip)
+- `light: boolean` (reflect: true) — light mode flag; dark is default
+
+**Desktop (≥769px):** Inline horizontal nav buttons with animated pill/underline indicator that slides to the active item. Hamburger menu button also visible.
+
+**Mobile (<768px):** Inline nav hidden, hamburger menu visible.
+
+**Hamburger dropdown:** Visible on all screen sizes. Opens a panel below the top bar with a 5-column grid of nav buttons, "Current: {panel}" footer, and "tap to navigate" hint. Closes on outside click.
+
+**Events emitted:**
+- `sc-navigate` — `detail: { panel: PanelKey }` — user selected a panel
+- `sc-schema-change` — `detail: { schema: string }` — schema cycled
+- `sc-mode-change` — `detail: { light: boolean }` — mode toggled
+
+**Styling:**
+- Dark: frosted glass `rgba(8, 8, 8, 0.92)` with `backdrop-filter: blur(12px)`
+- Light: `rgba(250, 250, 250, 0.97)`
+- Uses semantic tokens for all colors (`--line-high-contrast`, `--line-low-contrast`, `--line-ui-border`, etc.)
+- Uses `:host([light])` selectors for light mode (cross-browser, no `:host-context()`)
 
 ### 5.2 `sc-token-card`
 
@@ -378,15 +395,22 @@ Page section wrapper:
 
 ### 6.1 Dark/Light Mode Toggle
 
-- Persists across routes (stored in `localStorage`)
-- Toggles `html.dark` / `html.light` class
-- Smooth transition on all themed elements
+- **Dark is the default.** The `light` boolean attribute toggles ON for light mode. See §10 Decision D4.
+- Persists in `localStorage('line-mode')` as `'dark'` or `'light'`
+- Toggles `html.dark` / `html.light` class on `document.documentElement`
+- `color-scheme: dark` by default on `<html>`, `color-scheme: light` on `html.light`
+- `<html class="dark">` set in `index.html` to prevent FOUC before JS hydrates
+- Uses `:host([light])` CSS selectors in components (cross-browser; `:host-context()` is NOT supported in Firefox/Safari)
+- Smooth transition via `--line-duration-moderate-1` and `--line-ease-2` tokens
 
 ### 6.2 Schema Palette Picker
 
-- Compact picker in the nav sidebar
-- Changes `body.line-schema-{palette}`
-- Persists across routes (`localStorage`)
+- Compact **cycling chip button** in the top bar controls (not a dropdown). See §10 Decision D5.
+- Shows a colored dot (using `--line-solid-background` accent) + current schema name
+- Clicking cycles to the next schema in the 28-palette list
+- Changes `body.line-schema-{palette}` class
+- Persists in `localStorage('line-schema')`
+- `<body class="line-schema-violet">` set in `index.html` to prevent FOUC
 - Affects all pages that use semantic tokens
 
 ### 6.3 Copy-to-Clipboard
@@ -401,28 +425,28 @@ Global token search (cmd+k) — deferred to post-launch iteration. Architecture 
 
 ## 7. Token Inventory Summary
 
-| Category | Tokens | Route |
+| Category | Tokens | Panel |
 |----------|--------|-------|
-| Color palettes | 364 (28×13) | /tokens/colors |
-| Typography | 62 | /tokens/typography |
-| Sizing & spacing | 74 | /tokens/spacing |
-| Easing | 81 | /tokens/motion |
-| Animations | 46 (23 tokens + 23 keyframes) | /tokens/motion |
-| Durations | 12 | /tokens/motion |
-| Gradients & noise | 41 | /tokens/decorative |
-| Masks | 34 | /tokens/decorative |
-| Borders & radii | 29 | /tokens/surfaces |
-| Shadows | 24 | /tokens/surfaces |
-| Z-index & layers | 14 | /tokens/surfaces |
-| Aspect ratios | 6 | /tokens/surfaces |
-| Focus ring | 3 | /tokens/surfaces |
-| Opacity | 3 | /tokens/surfaces |
-| Highlights | 3 | /tokens/decorative |
-| SVG squircles | 3 | /tokens/decorative |
-| Layouts | 4 | /tokens/decorative |
-| Colors absolute | 2 | /tokens/colors |
-| Semantic defaults | 14 | /semantic |
-| Aliases | 54 | /semantic |
+| Color palettes | 364 (28×13) | colors |
+| Typography | 62 | typography |
+| Sizing & spacing | 74 | spacing |
+| Easing | 81 | motion |
+| Animations | 46 (23 tokens + 23 keyframes) | motion |
+| Durations | 12 | motion |
+| Gradients & noise | 41 | decorative |
+| Masks | 34 | decorative |
+| Borders & radii | 29 | surfaces |
+| Shadows | 24 | surfaces |
+| Z-index & layers | 14 | surfaces |
+| Aspect ratios | 6 | surfaces |
+| Focus ring | 3 | surfaces |
+| Opacity | 3 | surfaces |
+| Highlights | 3 | decorative |
+| SVG squircles | 3 | decorative |
+| Layouts | 4 | decorative |
+| Colors absolute | 2 | colors |
+| Semantic defaults | 14 | semantic |
+| Aliases | 54 | semantic |
 | **Total** | **~873** | |
 
 ---
@@ -435,9 +459,9 @@ The previous `packages/theme/index.html` + `src/main.ts` + `src/style.css` showc
 
 ### 8.2 Phased Implementation
 
-**Phase A — Scaffold & Core:**
-1. Create `apps/showcase/` with Vite + Lit + @lit-labs/router
-2. App shell with `sc-nav` sidebar, route configuration, dark/light toggle, schema picker
+**Phase A — Scaffold & Core:** ✅
+1. ✅ Create `apps/showcase/` with Vite + Lit (panel-based, no router)
+2. ✅ App shell with `sc-nav` top bar, panel rendering, dark/light toggle, schema cycling chip
 3. Home page with navigation cards
 
 **Phase B — Token Pages:**
@@ -467,8 +491,8 @@ Build as needed during page implementation. `sc-token-card`, `sc-code-block`, an
 ## 9. Acceptance Criteria
 
 1. All ~873 tokens are visible and interactive somewhere in the app
-2. Dark/light mode toggle works globally across all routes
-3. Schema palette switching works globally
+2. Dark/light mode toggle works globally across all panels
+3. Schema palette cycling works globally
 4. Every token name is copyable to clipboard
 5. Color-mix demo uses native CSS `color-mix(in oklch)`
 6. All 23 animations have live demos
@@ -479,5 +503,57 @@ Build as needed during page implementation. `sc-token-card`, `sc-code-block`, an
 11. Generated palettes show WCAG AA contrast check
 12. App consumes `@websublime/line-theme` via package imports (dogfooding)
 13. Themes page shows all 28 theme bundles (color + schema) with light/dark comparison
-14. Routes load lazily (code splitting)
+14. Panel switching is instant (all pages imported upfront; code splitting deferred)
 15. App runs on Vite dev server with HMR
+
+---
+
+## 10. Decision Log
+
+### D1 — Top bar navigation instead of sidebar (2026-03-19)
+
+**Decision:** Replace the sidebar navigation with a horizontal top bar containing inline pill nav (desktop), hamburger dropdown (all sizes), and compact controls.
+
+**Why:** Mobile-first design, more content space, cleaner layout. The sidebar consumed 260px of horizontal space and required a different mobile layout. The top bar is consistent across breakpoints.
+
+**Supersedes:** Original spec §5.1 (sidebar navigation).
+
+### D2 — Panel-based rendering instead of URL router (2026-03-19)
+
+**Decision:** Remove `@lit-labs/router` dependency. Use a `PanelKey` union type and `switch` statement to render the active page component. Panel state persisted in `localStorage('line-panel')`.
+
+**Why:** The showcase is a single-page tool, not a multi-page site. URL routing added complexity (URLPattern polyfills, shadow DOM click interception, route configuration) without clear benefit. Panel switching is simpler and instant.
+
+**Supersedes:** Original spec §2.2 (router row), §3.1 (router configuration).
+
+### D3 — Geist + IBM Plex Mono instead of JetBrains Mono (2026-03-19)
+
+**Decision:** Use Geist (Vercel, sans-serif) for all UI text. Use IBM Plex Mono for token names, code blocks, and code snippets only.
+
+**Why:** JetBrains Mono caused blurry/soft rendering in Firefox, especially at smaller sizes and with `-webkit-font-smoothing: antialiased`. Geist provides crisp sans-serif rendering across all browsers. Separating UI font (sans) from code font (mono) follows standard design system practice.
+
+**Supersedes:** Original spec §2.2 (fonts row).
+
+### D4 — Dark as default mode (2026-03-19)
+
+**Decision:** Dark mode is the default. The `light` boolean property/attribute is toggled ON for light mode. Uses `:host([light])` CSS selectors.
+
+**Why:** (1) `:host-context()` has no Firefox/Safari support — a Chrome-only feature. `:host([light])` is cross-browser. (2) Design system showcases look best in dark mode. (3) `<html class="dark">` + `<body class="line-schema-violet">` set in index.html prevents FOUC before JS hydrates.
+
+**Supersedes:** Original spec §6.1 (toggle between html.dark/html.light).
+
+### D5 — Schema cycling chip instead of dropdown picker (2026-03-19)
+
+**Decision:** Schema selection is a compact chip button that cycles through all 28 schemas on click, showing a colored accent dot + schema name.
+
+**Why:** Simpler UX than a dropdown/select. Fits the compact top bar layout. 28 schemas are quickly cycleable. The accent dot provides immediate visual feedback of the active schema's color.
+
+**Supersedes:** Original spec §6.2 (compact picker in nav sidebar).
+
+### D6 — Semantic tokens for all UI colors (2026-03-19)
+
+**Decision:** All UI elements in the showcase use semantic tokens from schemas (`--line-high-contrast`, `--line-low-contrast`, `--line-background`, `--line-subtle-background`, `--line-ui-background`, `--line-ui-border`, `--line-subtle-border`, `--line-solid-background`). Raw palette stops (`--line-gray-N`) are NOT used for UI elements.
+
+**Why:** The gray palette scale is non-inverted — `--line-gray-1` is always light (~93-99%) and `--line-gray-12` is always dark (~9-12%) in both modes. Using raw stops like `--line-gray-8` (21.7% in dark mode) for text on a dark background produces ~2:1 contrast ratio — unreadable. Semantic tokens are designed to provide correct contrast in both modes.
+
+**Impact:** All pages and shared components must follow this rule. The showcase must be the exemplar of proper token usage.

--- a/apps/showcase/index.html
+++ b/apps/showcase/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/src/styles/showcase.css" />
     <script type="module" src="/src/app.ts"></script>
   </head>
-  <body>
+  <body class="line-schema-violet">
     <sc-app></sc-app>
   </body>
 </html>

--- a/apps/showcase/index.html
+++ b/apps/showcase/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="/src/styles/showcase.css" />

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -84,6 +84,16 @@ export class ScApp extends LitElement {
       margin: 0 auto;
       padding: var(--line-size-7, 2rem) var(--line-size-5, 1.5rem);
       box-sizing: border-box;
+      view-transition-name: panel-content;
+    }
+
+    /* Fallback fade-in for browsers without View Transitions API */
+    @keyframes panel-fade-in {
+      from { opacity: 0; transform: translateY(4px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    main.panel-enter {
+      animation: panel-fade-in var(--line-duration-moderate-2, 260ms) var(--line-ease-2) both;
     }
   `;
 
@@ -150,8 +160,28 @@ export class ScApp extends LitElement {
 
   private _handleNavigate(e: Event): void {
     const detail = (e as CustomEvent).detail as { panel: PanelKey };
-    this._panel = detail.panel;
-    localStorage.setItem('line-panel', this._panel);
+    const next = detail.panel;
+    if (next === this._panel) return;
+
+    localStorage.setItem('line-panel', next);
+
+    // View Transitions API (Chrome 111+, Safari 18+) — smooth crossfade
+    if (document.startViewTransition) {
+      document.startViewTransition(() => {
+        this._panel = next;
+        this.updateComplete;
+      });
+    } else {
+      // Fallback: CSS keyframe fade-in
+      this._panel = next;
+      const main = this.shadowRoot?.querySelector('main');
+      if (main) {
+        main.classList.remove('panel-enter');
+        // Force reflow to restart animation
+        void main.offsetWidth;
+        main.classList.add('panel-enter');
+      }
+    }
   }
 
   private _handleSchemaChange(e: Event): void {

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -1,6 +1,6 @@
 import { Router } from '@lit-labs/router';
 import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 
 // Validate theme imports resolve correctly
 import '@websublime/line-theme';
@@ -8,6 +8,7 @@ import '@websublime/line-theme/tokens';
 import '@websublime/line-theme/colors/blue';
 import '@websublime/line-theme/schemas/blue';
 import '@websublime/line-theme/aliases';
+import '@websublime/line-theme/normalize';
 
 // Navigation component
 import './components/sc-nav.js';
@@ -27,6 +28,8 @@ import './pages/generator.js';
 
 @customElement('sc-app')
 export class ScApp extends LitElement {
+  @state() private _darkMode = false;
+
   private router = new Router(this, [
     { path: '/', render: () => html`<sc-page-home></sc-page-home>` },
     {
@@ -79,25 +82,40 @@ export class ScApp extends LitElement {
     }
 
     main {
-      padding: 2rem;
+      padding: var(--line-size-7);
       overflow-y: auto;
       min-height: 100dvh;
     }
 
+    /* Breakpoint: --line-size-md (768px) */
     @media (max-width: 768px) {
       :host {
         grid-template-columns: 1fr;
       }
 
       main {
-        padding: 3.5rem 1rem 1rem;
+        padding: var(--line-size-8) var(--line-size-3) var(--line-size-3);
       }
     }
   `;
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    const storedMode = localStorage.getItem('line-mode');
+    this._darkMode = storedMode === 'dark';
+  }
+
+  private _handleModeChange(e: Event): void {
+    const detail = (e as CustomEvent).detail;
+    this._darkMode = detail.mode === 'dark';
+  }
+
   override render() {
     return html`
-      <sc-nav></sc-nav>
+      <sc-nav
+        ?dark=${this._darkMode}
+        @mode-change=${this._handleModeChange}
+      ></sc-nav>
       <main>${this.router.outlet()}</main>
     `;
   }

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -167,9 +167,9 @@ export class ScApp extends LitElement {
 
     // View Transitions API (Chrome 111+, Safari 18+) — smooth crossfade
     if (document.startViewTransition) {
-      document.startViewTransition(() => {
+      document.startViewTransition(async () => {
         this._panel = next;
-        this.updateComplete;
+        await this.updateComplete;
       });
     } else {
       // Fallback: CSS keyframe fade-in

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -5,10 +5,13 @@ import { customElement, state } from 'lit/decorators.js';
 // tokens, aliases, normalize, and utilities.
 import '@websublime/line-theme';
 
+import { isValidSchema } from './constants.js';
+
 // Navigation component
 import './components/sc-nav.js';
 
 // Page imports
+// TODO(line-ui-6zy.3): home page is imported but not rendered — wire into panel system when home page task is implemented
 import './pages/home.js';
 import './pages/colors.js';
 import './pages/typography.js';
@@ -32,37 +35,6 @@ export type PanelKey =
   | 'elements'
   | 'themes'
   | 'generator';
-
-const ALL_SCHEMAS = [
-  'amber',
-  'blue',
-  'bronze',
-  'brown',
-  'crimson',
-  'cyan',
-  'gold',
-  'grass',
-  'gray',
-  'green',
-  'indigo',
-  'lime',
-  'mauve',
-  'mint',
-  'olive',
-  'orange',
-  'pink',
-  'plum',
-  'purple',
-  'red',
-  'sage',
-  'sand',
-  'sky',
-  'slate',
-  'teal',
-  'tomato',
-  'violet',
-  'yellow'
-];
 
 @customElement('sc-app')
 export class ScApp extends LitElement {
@@ -110,7 +82,7 @@ export class ScApp extends LitElement {
 
     // Restore persisted schema
     const storedSchema = localStorage.getItem('line-schema');
-    if (storedSchema && ALL_SCHEMAS.includes(storedSchema)) {
+    if (storedSchema && isValidSchema(storedSchema)) {
       this._schema = storedSchema;
     }
     this._applySchema();

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -44,6 +44,7 @@ export class ScApp extends LitElement {
 
   static override styles = css`
     :host {
+      --_max-w: 1400px;
       display: flex;
       flex-direction: column;
       min-height: 100dvh;
@@ -51,7 +52,7 @@ export class ScApp extends LitElement {
 
     main {
       flex: 1;
-      max-width: 1400px;
+      max-width: var(--_max-w);
       width: 100%;
       margin: 0 auto;
       padding: var(--line-size-7, 2rem) var(--line-size-5, 1.5rem);

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -9,44 +9,95 @@ import '@websublime/line-theme/colors/blue';
 import '@websublime/line-theme/schemas/blue';
 import '@websublime/line-theme/aliases';
 
-// Page imports (lazy stubs for now)
+// Navigation component
+import './components/sc-nav.js';
+
+// Page imports
 import './pages/home.js';
+import './pages/colors.js';
+import './pages/typography.js';
+import './pages/spacing.js';
+import './pages/motion.js';
+import './pages/surfaces.js';
+import './pages/decorative.js';
+import './pages/semantic.js';
+import './pages/elements.js';
+import './pages/themes.js';
+import './pages/generator.js';
 
 @customElement('sc-app')
 export class ScApp extends LitElement {
   private router = new Router(this, [
     { path: '/', render: () => html`<sc-page-home></sc-page-home>` },
-    { path: '/tokens/colors', render: () => html`<sc-page-placeholder data-page="colors"></sc-page-placeholder>` },
+    {
+      path: '/tokens/colors',
+      render: () => html`<sc-page-colors></sc-page-colors>`
+    },
     {
       path: '/tokens/typography',
-      render: () => html`<sc-page-placeholder data-page="typography"></sc-page-placeholder>`
+      render: () => html`<sc-page-typography></sc-page-typography>`
     },
-    { path: '/tokens/spacing', render: () => html`<sc-page-placeholder data-page="spacing"></sc-page-placeholder>` },
-    { path: '/tokens/motion', render: () => html`<sc-page-placeholder data-page="motion"></sc-page-placeholder>` },
-    { path: '/tokens/surfaces', render: () => html`<sc-page-placeholder data-page="surfaces"></sc-page-placeholder>` },
+    {
+      path: '/tokens/spacing',
+      render: () => html`<sc-page-spacing></sc-page-spacing>`
+    },
+    {
+      path: '/tokens/motion',
+      render: () => html`<sc-page-motion></sc-page-motion>`
+    },
+    {
+      path: '/tokens/surfaces',
+      render: () => html`<sc-page-surfaces></sc-page-surfaces>`
+    },
     {
       path: '/tokens/decorative',
-      render: () => html`<sc-page-placeholder data-page="decorative"></sc-page-placeholder>`
+      render: () => html`<sc-page-decorative></sc-page-decorative>`
     },
-    { path: '/semantic', render: () => html`<sc-page-placeholder data-page="semantic"></sc-page-placeholder>` },
-    { path: '/elements', render: () => html`<sc-page-placeholder data-page="elements"></sc-page-placeholder>` },
-    { path: '/themes', render: () => html`<sc-page-placeholder data-page="themes"></sc-page-placeholder>` },
-    { path: '/generator', render: () => html`<sc-page-placeholder data-page="generator"></sc-page-placeholder>` }
+    {
+      path: '/semantic',
+      render: () => html`<sc-page-semantic></sc-page-semantic>`
+    },
+    {
+      path: '/elements',
+      render: () => html`<sc-page-elements></sc-page-elements>`
+    },
+    {
+      path: '/themes',
+      render: () => html`<sc-page-themes></sc-page-themes>`
+    },
+    {
+      path: '/generator',
+      render: () => html`<sc-page-generator></sc-page-generator>`
+    }
   ]);
 
   static override styles = css`
     :host {
-      display: block;
+      display: grid;
+      grid-template-columns: var(--sc-sidebar-width, 260px) 1fr;
       min-height: 100dvh;
     }
 
     main {
-      padding: 1rem;
+      padding: 2rem;
+      overflow-y: auto;
+      min-height: 100dvh;
+    }
+
+    @media (max-width: 768px) {
+      :host {
+        grid-template-columns: 1fr;
+      }
+
+      main {
+        padding: 3.5rem 1rem 1rem;
+      }
     }
   `;
 
   override render() {
     return html`
+      <sc-nav></sc-nav>
       <main>${this.router.outlet()}</main>
     `;
   }

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -1,5 +1,4 @@
-import { Router } from '@lit-labs/router';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 // Validate theme imports resolve correctly
@@ -26,97 +25,191 @@ import './pages/elements.js';
 import './pages/themes.js';
 import './pages/generator.js';
 
+export type PanelKey =
+  | 'colors'
+  | 'typography'
+  | 'spacing'
+  | 'motion'
+  | 'surfaces'
+  | 'decorative'
+  | 'semantic'
+  | 'elements'
+  | 'themes'
+  | 'generator';
+
+const ALL_SCHEMAS = [
+  'amber',
+  'blue',
+  'bronze',
+  'brown',
+  'crimson',
+  'cyan',
+  'gold',
+  'grass',
+  'gray',
+  'green',
+  'indigo',
+  'lime',
+  'mauve',
+  'mint',
+  'olive',
+  'orange',
+  'pink',
+  'plum',
+  'purple',
+  'red',
+  'sage',
+  'sand',
+  'sky',
+  'slate',
+  'teal',
+  'tomato',
+  'violet',
+  'yellow'
+];
+
 @customElement('sc-app')
 export class ScApp extends LitElement {
-  @state() private _darkMode = false;
-
-  private router = new Router(this, [
-    { path: '/', render: () => html`<sc-page-home></sc-page-home>` },
-    {
-      path: '/tokens/colors',
-      render: () => html`<sc-page-colors></sc-page-colors>`
-    },
-    {
-      path: '/tokens/typography',
-      render: () => html`<sc-page-typography></sc-page-typography>`
-    },
-    {
-      path: '/tokens/spacing',
-      render: () => html`<sc-page-spacing></sc-page-spacing>`
-    },
-    {
-      path: '/tokens/motion',
-      render: () => html`<sc-page-motion></sc-page-motion>`
-    },
-    {
-      path: '/tokens/surfaces',
-      render: () => html`<sc-page-surfaces></sc-page-surfaces>`
-    },
-    {
-      path: '/tokens/decorative',
-      render: () => html`<sc-page-decorative></sc-page-decorative>`
-    },
-    {
-      path: '/semantic',
-      render: () => html`<sc-page-semantic></sc-page-semantic>`
-    },
-    {
-      path: '/elements',
-      render: () => html`<sc-page-elements></sc-page-elements>`
-    },
-    {
-      path: '/themes',
-      render: () => html`<sc-page-themes></sc-page-themes>`
-    },
-    {
-      path: '/generator',
-      render: () => html`<sc-page-generator></sc-page-generator>`
-    }
-  ]);
+  @state() private _panel: PanelKey = 'colors';
+  @state() private _schema = 'violet';
+  @state() private _light = false;
 
   static override styles = css`
     :host {
-      display: grid;
-      grid-template-columns: var(--sc-sidebar-width, 260px) 1fr;
+      display: flex;
+      flex-direction: column;
       min-height: 100dvh;
     }
 
     main {
-      padding: var(--line-size-7);
-      overflow-y: auto;
-      min-height: 100dvh;
-    }
-
-    /* Breakpoint: --line-size-md (768px) */
-    @media (max-width: 768px) {
-      :host {
-        grid-template-columns: 1fr;
-      }
-
-      main {
-        padding: var(--line-size-8) var(--line-size-3) var(--line-size-3);
-      }
+      flex: 1;
+      max-width: 1400px;
+      width: 100%;
+      margin: 0 auto;
+      padding: var(--line-size-7, 2rem) var(--line-size-5, 1.5rem);
+      box-sizing: border-box;
     }
   `;
 
   override connectedCallback(): void {
     super.connectedCallback();
+
+    // Restore persisted mode
     const storedMode = localStorage.getItem('line-mode');
-    this._darkMode = storedMode === 'dark';
+    if (storedMode === 'light') {
+      this._light = true;
+    }
+    // Default is dark (light = false)
+    this._applyMode();
+
+    // Restore persisted schema
+    const storedSchema = localStorage.getItem('line-schema');
+    if (storedSchema && ALL_SCHEMAS.includes(storedSchema)) {
+      this._schema = storedSchema;
+    }
+    this._applySchema();
+
+    // Restore persisted panel
+    const storedPanel = localStorage.getItem('line-panel');
+    if (storedPanel && this._isValidPanel(storedPanel)) {
+      this._panel = storedPanel as PanelKey;
+    }
+  }
+
+  private _isValidPanel(value: string): value is PanelKey {
+    return [
+      'colors',
+      'typography',
+      'spacing',
+      'motion',
+      'surfaces',
+      'decorative',
+      'semantic',
+      'elements',
+      'themes',
+      'generator'
+    ].includes(value);
+  }
+
+  private _applyMode(): void {
+    const root = document.documentElement;
+    if (this._light) {
+      root.classList.add('light');
+      root.classList.remove('dark');
+    } else {
+      root.classList.add('dark');
+      root.classList.remove('light');
+    }
+  }
+
+  private _applySchema(): void {
+    const body = document.body;
+    for (const cls of Array.from(body.classList)) {
+      if (cls.startsWith('line-schema-')) {
+        body.classList.remove(cls);
+      }
+    }
+    body.classList.add(`line-schema-${this._schema}`);
+  }
+
+  private _handleNavigate(e: Event): void {
+    const detail = (e as CustomEvent).detail as { panel: PanelKey };
+    this._panel = detail.panel;
+    localStorage.setItem('line-panel', this._panel);
+  }
+
+  private _handleSchemaChange(e: Event): void {
+    const detail = (e as CustomEvent).detail as { schema: string };
+    this._schema = detail.schema;
+    localStorage.setItem('line-schema', this._schema);
+    this._applySchema();
   }
 
   private _handleModeChange(e: Event): void {
-    const detail = (e as CustomEvent).detail;
-    this._darkMode = detail.mode === 'dark';
+    const detail = (e as CustomEvent).detail as { light: boolean };
+    this._light = detail.light;
+    localStorage.setItem('line-mode', this._light ? 'light' : 'dark');
+    this._applyMode();
+  }
+
+  private _renderPanel() {
+    switch (this._panel) {
+      case 'colors':
+        return html`<sc-page-colors></sc-page-colors>`;
+      case 'typography':
+        return html`<sc-page-typography></sc-page-typography>`;
+      case 'spacing':
+        return html`<sc-page-spacing></sc-page-spacing>`;
+      case 'motion':
+        return html`<sc-page-motion></sc-page-motion>`;
+      case 'surfaces':
+        return html`<sc-page-surfaces></sc-page-surfaces>`;
+      case 'decorative':
+        return html`<sc-page-decorative></sc-page-decorative>`;
+      case 'semantic':
+        return html`<sc-page-semantic></sc-page-semantic>`;
+      case 'elements':
+        return html`<sc-page-elements></sc-page-elements>`;
+      case 'themes':
+        return html`<sc-page-themes></sc-page-themes>`;
+      case 'generator':
+        return html`<sc-page-generator></sc-page-generator>`;
+      default:
+        return nothing;
+    }
   }
 
   override render() {
     return html`
       <sc-nav
-        ?dark=${this._darkMode}
-        @mode-change=${this._handleModeChange}
+        .panel=${this._panel}
+        .schema=${this._schema}
+        ?light=${this._light}
+        @sc-navigate=${this._handleNavigate}
+        @sc-schema-change=${this._handleSchemaChange}
+        @sc-mode-change=${this._handleModeChange}
       ></sc-nav>
-      <main>${this.router.outlet()}</main>
+      <main>${this._renderPanel()}</main>
     `;
   }
 }

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -1,13 +1,9 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-// Validate theme imports resolve correctly
+// Full theme bundle: all color palettes (with dark-mode overrides), schemas,
+// tokens, aliases, normalize, and utilities.
 import '@websublime/line-theme';
-import '@websublime/line-theme/tokens';
-import '@websublime/line-theme/colors/blue';
-import '@websublime/line-theme/schemas/blue';
-import '@websublime/line-theme/aliases';
-import '@websublime/line-theme/normalize';
 
 // Navigation component
 import './components/sc-nav.js';

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -145,7 +145,7 @@ export class ScNav extends LitElement {
       white-space: nowrap;
       border: none;
       background: none;
-      font-family: var(--line-font-mono, monospace);
+      font-family: inherit;
       transition: color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
     }
     .nav-btn:hover { color: var(--line-high-contrast, #ddd); }
@@ -174,7 +174,7 @@ export class ScNav extends LitElement {
       color: var(--line-low-contrast, #999);
       cursor: pointer;
       background: var(--line-subtle-background, #161616);
-      font-family: var(--line-font-mono, monospace);
+      font-family: inherit;
       white-space: nowrap;
       transition:
         border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
@@ -200,7 +200,7 @@ export class ScNav extends LitElement {
       color: var(--line-low-contrast, #999);
       cursor: pointer;
       background: transparent;
-      font-family: var(--line-font-mono, monospace);
+      font-family: inherit;
       white-space: nowrap;
       transition:
         border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
@@ -221,7 +221,7 @@ export class ScNav extends LitElement {
       font-weight: var(--line-font-weight-7, 700);
       color: var(--line-low-contrast, #999);
       background: transparent;
-      font-family: var(--line-font-mono, monospace);
+      font-family: inherit;
       cursor: pointer;
       letter-spacing: 0.03em;
       transition:
@@ -295,7 +295,7 @@ export class ScNav extends LitElement {
       color: var(--line-low-contrast, #999);
       cursor: pointer;
       background: transparent;
-      font-family: var(--line-font-mono, monospace);
+      font-family: inherit;
       text-align: left;
       letter-spacing: 0.01em;
       transition:

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -1,8 +1,9 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import type { PanelKey } from '../app.js';
 
-const PALETTES = [
+const ALL_SCHEMAS = [
   'amber',
   'blue',
   'bronze',
@@ -31,478 +32,472 @@ const PALETTES = [
   'tomato',
   'violet',
   'yellow'
-] as const;
+];
 
-type Palette = (typeof PALETTES)[number];
-
-interface NavGroup {
-  label: string;
-  routes: { path: string; label: string }[];
-}
-
-const NAV_GROUPS: NavGroup[] = [
-  {
-    label: 'Tokens',
-    routes: [
-      { path: '/tokens/colors', label: 'Colors' },
-      { path: '/tokens/typography', label: 'Typography' },
-      { path: '/tokens/spacing', label: 'Spacing' },
-      { path: '/tokens/motion', label: 'Motion' },
-      { path: '/tokens/surfaces', label: 'Surfaces' },
-      { path: '/tokens/decorative', label: 'Decorative' }
-    ]
-  },
-  {
-    label: 'Semantic',
-    routes: [{ path: '/semantic', label: 'Semantic' }]
-  },
-  {
-    label: 'Elements',
-    routes: [{ path: '/elements', label: 'Elements' }]
-  },
-  {
-    label: 'Themes',
-    routes: [{ path: '/themes', label: 'Themes' }]
-  },
-  {
-    label: 'Tools',
-    routes: [{ path: '/generator', label: 'Generator' }]
-  }
+const NAV_ITEMS: { key: PanelKey; label: string }[] = [
+  { key: 'colors', label: 'Colors' },
+  { key: 'typography', label: 'Typography' },
+  { key: 'spacing', label: 'Spacing' },
+  { key: 'motion', label: 'Motion' },
+  { key: 'surfaces', label: 'Surfaces' },
+  { key: 'decorative', label: 'Decorative' },
+  { key: 'semantic', label: 'Semantic' },
+  { key: 'elements', label: 'Elements' },
+  { key: 'themes', label: 'Themes' },
+  { key: 'generator', label: 'Generator' }
 ];
 
 @customElement('sc-nav')
 export class ScNav extends LitElement {
-  /**
-   * Whether the component should render in dark mode.
-   * Set by the parent sc-app to propagate dark mode styling
-   * without relying on :host-context() (unsupported in Firefox/Safari).
-   */
-  @property({ type: Boolean, reflect: true }) dark = false;
+  @property({ type: String }) panel: PanelKey = 'colors';
+  @property({ type: String }) schema = 'violet';
+  @property({ type: Boolean, reflect: true }) light = false;
 
-  @state() private _schema: Palette = 'blue';
-  @state() private _mobileOpen = false;
-  @state() private _currentPath = '/';
+  @state() private _open = false;
+  @state() private _pillLeft = 0;
+  @state() private _pillWidth = 0;
 
   static override styles = css`
     :host {
       display: block;
-    }
-
-    .sidebar {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: var(--sc-sidebar-width, 260px);
-      height: 100dvh;
-      overflow-y: auto;
-      background: var(--line-gray-2, #f5f5f5);
-      border-inline-end: var(--line-border-size-1) solid var(--line-gray-6, #d4d4d4);
-      padding: var(--line-size-5) var(--line-size-3);
-      display: flex;
-      flex-direction: column;
-      gap: var(--line-size-5);
-      z-index: var(--line-z-sticky);
+      background: rgba(8, 8, 8, 0.92);
+      border-bottom: var(--line-border-size-1, 1px) solid var(--line-gray-4, #222);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      position: relative;
+      z-index: 100;
       transition:
-        transform var(--line-duration-moderate-2) var(--line-ease-2),
-        background-color var(--line-duration-moderate-1) var(--line-ease-2),
-        border-color var(--line-duration-moderate-1) var(--line-ease-2);
+        background var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
+        border-color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
     }
 
-    :host([dark]) .sidebar {
-      background: var(--line-gray-2, #1c1c1c);
-      border-inline-end-color: var(--line-gray-6, #3a3a3a);
+    :host([light]) {
+      background: rgba(250, 250, 250, 0.97);
+      border-bottom-color: var(--line-gray-4, #e5e5e5);
+    }
+
+    /* ── Top bar ── */
+    .topbar {
+      height: 52px;
+      display: flex;
+      align-items: center;
+      padding: 0 var(--line-size-5, 1.5rem);
+      max-width: 1400px;
+      margin: 0 auto;
+      width: 100%;
+      box-sizing: border-box;
     }
 
     .logo {
-      font-size: var(--line-font-size-4);
-      font-weight: var(--line-font-weight-7);
-      letter-spacing: -0.02em;
-      text-decoration: none;
-      color: inherit;
+      font-size: var(--line-font-size-2, 1rem);
+      font-weight: var(--line-font-weight-8, 800);
+      color: var(--line-gray-12, #fff);
+      letter-spacing: -0.03em;
+      white-space: nowrap;
+      flex-shrink: 0;
+      transition: color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
     }
+    :host([light]) .logo { color: var(--line-gray-12, #1a1a1a); }
+    .logo-ac { color: var(--line-solid-background, #c8ff00); }
 
-    .logo .accent {
-      color: var(--line-blue-9, #3b82f6);
+    /* Desktop inline nav — hidden on mobile */
+    .nav-inline {
+      flex: 1;
+      overflow-x: auto;
+      overflow-y: hidden;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+      position: relative;
+      margin-left: var(--line-size-6, 1.75rem);
     }
+    .nav-inline::-webkit-scrollbar { display: none; }
 
-    .nav-group-label {
-      font-size: var(--line-font-size-1);
-      font-weight: var(--line-font-weight-6);
-      text-transform: uppercase;
-      letter-spacing: var(--line-font-letterspacing-3);
-      color: var(--line-gray-9, #a1a1a1);
-      padding: 0 var(--line-size-2);
-      margin-block-end: var(--line-size-1);
-    }
-
-    .nav-group {
-      display: flex;
-      flex-direction: column;
-      gap: 0.125rem;
-    }
-
-    .nav-link {
-      display: block;
-      padding: 0.375rem var(--line-size-2);
-      border-radius: var(--line-radius-2);
-      text-decoration: none;
-      font-size: var(--line-font-size-1);
-      font-weight: var(--line-font-weight-5);
-      color: var(--line-gray-11, #6b6b6b);
-      transition:
-        background-color var(--line-duration-fast) var(--line-ease-2),
-        color var(--line-duration-fast) var(--line-ease-2);
-    }
-
-    .nav-link:hover {
-      background: var(--line-gray-4, #e5e5e5);
-      color: var(--line-gray-12, #1a1a1a);
-    }
-
-    :host([dark]) .nav-link:hover {
-      background: var(--line-gray-4, #2c2c2c);
-      color: var(--line-gray-12, #eeeeee);
-    }
-
-    .nav-link.active {
-      background: var(--line-blue-4, #dbeafe);
-      color: var(--line-blue-11, #1d4ed8);
-      font-weight: var(--line-font-weight-6);
-    }
-
-    :host([dark]) .nav-link.active {
-      background: var(--line-blue-4, #172554);
-      color: var(--line-blue-11, #60a5fa);
-    }
-
-    .controls {
-      margin-block-start: auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-      padding-block-start: var(--line-size-3);
-      border-block-start: var(--line-border-size-1) solid var(--line-gray-6, #d4d4d4);
-    }
-
-    :host([dark]) .controls {
-      border-block-start-color: var(--line-gray-6, #3a3a3a);
-    }
-
-    .control-label {
-      font-size: var(--line-font-size-1);
-      font-weight: var(--line-font-weight-6);
-      text-transform: uppercase;
-      letter-spacing: var(--line-font-letterspacing-3);
-      color: var(--line-gray-9, #a1a1a1);
-    }
-
-    .mode-toggle {
+    .nav-row {
       display: flex;
       align-items: center;
+      position: relative;
+      width: max-content;
+      min-width: 100%;
+    }
+
+    .pill {
+      position: absolute;
+      bottom: 0;
+      height: 2px;
+      background: var(--line-solid-background, #c8ff00);
+      border-radius: 2px 2px 0 0;
+      transition:
+        left  280ms cubic-bezier(0.4, 0, 0.2, 1),
+        width 280ms cubic-bezier(0.4, 0, 0.2, 1);
+      pointer-events: none;
+    }
+
+    .nav-btn {
+      padding: 0 var(--line-size-3, 1rem);
+      height: 52px;
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-gray-8, #555);
+      letter-spacing: 0.02em;
+      white-space: nowrap;
+      border: none;
+      background: none;
+      font-family: var(--line-font-mono, monospace);
+      transition: color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    .nav-btn:hover { color: var(--line-gray-10, #888); }
+    :host([light]) .nav-btn { color: var(--line-gray-8, #aaa); }
+    :host([light]) .nav-btn:hover { color: var(--line-gray-11, #555); }
+    .nav-btn.active { color: var(--line-solid-background, #c8ff00); }
+
+    /* ── Right controls ── */
+    .controls {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-2, 0.5rem);
+      flex-shrink: 0;
+      margin-left: var(--line-size-3, 1rem);
+    }
+
+    .schema-chip {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-1, 0.25rem);
+      padding: 5px var(--line-size-3, 1rem);
+      border: var(--line-border-size-1, 1px) solid var(--line-gray-5, #2e2e2e);
+      border-radius: var(--line-radius-2, 4px);
+      font-size: var(--line-font-size-0, 0.5rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-gray-9, #555);
+      cursor: pointer;
+      background: var(--line-gray-2, #161616);
+      font-family: var(--line-font-mono, monospace);
+      white-space: nowrap;
+      transition:
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    .schema-chip:hover { border-color: var(--line-gray-7, #444); color: var(--line-gray-10, #888); }
+    :host([light]) .schema-chip { background: var(--line-gray-3, #eee); border-color: var(--line-gray-6, #d4d4d4); color: var(--line-gray-9, #888); }
+
+    .schema-dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--line-solid-background, #c8ff00);
+      flex-shrink: 0;
+      transition: background var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
+    }
+
+    .mode-btn {
+      padding: 5px var(--line-size-3, 1rem);
+      border: var(--line-border-size-1, 1px) solid var(--line-gray-5, #2e2e2e);
+      border-radius: var(--line-radius-2, 4px);
+      font-size: var(--line-font-size-0, 0.5rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-gray-9, #555);
+      cursor: pointer;
+      background: transparent;
+      font-family: var(--line-font-mono, monospace);
+      white-space: nowrap;
+      transition:
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    .mode-btn:hover { border-color: var(--line-gray-7, #444); color: var(--line-gray-10, #888); }
+    :host([light]) .mode-btn { border-color: var(--line-gray-6, #d4d4d4); color: var(--line-gray-9, #888); }
+
+    /* ── Hamburger / menu button ── */
+    .menu-btn {
+      display: none;
+      align-items: center;
+      gap: 7px;
+      padding: 5px var(--line-size-3, 1rem);
+      border: var(--line-border-size-1, 1px) solid var(--line-gray-5, #2e2e2e);
+      border-radius: var(--line-radius-2, 4px);
+      font-size: var(--line-font-size-0, 0.5rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-gray-8, #666);
+      background: transparent;
+      font-family: var(--line-font-mono, monospace);
+      cursor: pointer;
+      letter-spacing: 0.03em;
+      transition:
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    .menu-btn:hover { border-color: var(--line-gray-7, #444); color: var(--line-gray-10, #888); }
+    .menu-btn.open {
+      border-color: var(--line-solid-background, #c8ff00);
+      color: var(--line-solid-background, #c8ff00);
+    }
+    :host([light]) .menu-btn { border-color: var(--line-gray-6, #d4d4d4); color: var(--line-gray-9, #888); }
+    :host([light]) .menu-btn.open {
+      border-color: var(--line-solid-background, #1a1a1a);
+      color: var(--line-solid-background, #1a1a1a);
+    }
+
+    /* hamburger icon */
+    .hb { width: 14px; height: 10px; display: flex; flex-direction: column; justify-content: space-between; flex-shrink: 0; }
+    .hb span {
+      display: block; height: 1.5px; background: currentColor; border-radius: 1px;
+      transition:
+        transform var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
+        opacity   var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
+    }
+    .menu-btn.open .hb span:nth-child(1) { transform: translateY(4.25px) rotate(45deg); }
+    .menu-btn.open .hb span:nth-child(2) { opacity: 0; transform: scaleX(0); }
+    .menu-btn.open .hb span:nth-child(3) { transform: translateY(-4.25px) rotate(-45deg); }
+
+    /* ── Dropdown ── */
+    .dropdown {
+      overflow: hidden;
+      max-height: 0;
+      transition: max-height var(--line-duration-moderate-2, 260ms) cubic-bezier(0.4, 0, 0.2, 1);
+      border-bottom: 0px solid transparent;
+    }
+    .dropdown.open {
+      max-height: 360px;
+      border-bottom: var(--line-border-size-1, 1px) solid var(--line-gray-4, #222);
+    }
+    :host([light]) .dropdown.open { border-bottom-color: var(--line-gray-4, #e5e5e5); }
+
+    .dropdown-inner {
+      padding: var(--line-size-5, 1.5rem) var(--line-size-5, 1.5rem) var(--line-size-6, 1.75rem);
+      max-width: 1400px;
+      margin: 0 auto;
+    }
+
+    .dd-label {
+      font-size: var(--line-font-size-0, 0.5rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-gray-6, #444);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: var(--line-size-3, 1rem);
+    }
+    :host([light]) .dd-label { color: var(--line-gray-8, #aaa); }
+
+    .dd-grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: var(--line-size-2, 0.5rem);
+    }
+
+    .dd-item {
+      padding: var(--line-size-3, 1rem) var(--line-size-3, 1rem);
+      border-radius: var(--line-radius-2, 4px);
+      border: var(--line-border-size-1, 1px) solid var(--line-gray-3, #1e1e1e);
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-gray-8, #555);
+      cursor: pointer;
+      background: transparent;
+      font-family: var(--line-font-mono, monospace);
+      text-align: left;
+      letter-spacing: 0.01em;
+      transition:
+        background var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    .dd-item:hover {
+      background: var(--line-gray-2, #161616);
+      border-color: var(--line-gray-5, #333);
+      color: var(--line-gray-10, #aaa);
+    }
+    :host([light]) .dd-item {
+      border-color: var(--line-gray-5, #e5e5e5);
+      color: var(--line-gray-9, #888);
+    }
+    :host([light]) .dd-item:hover {
+      background: var(--line-gray-3, #eee);
+      border-color: var(--line-gray-7, #bbb);
+      color: var(--line-gray-11, #444);
+    }
+    .dd-item.active {
+      border-color: var(--line-solid-background, #c8ff00);
+      color: var(--line-solid-background, #c8ff00);
+      background: var(--line-gray-2, #0d0d0d);
+    }
+    :host([light]) .dd-item.active {
+      background: var(--line-gray-3, #f0f0f0);
+    }
+
+    .dd-footer {
+      display: flex;
       justify-content: space-between;
-      gap: var(--line-size-2);
+      align-items: center;
+      margin-top: var(--line-size-4, 1.25rem);
+      padding-top: var(--line-size-4, 1.25rem);
+      border-top: var(--line-border-size-1, 1px) solid var(--line-gray-3, #1a1a1a);
+    }
+    :host([light]) .dd-footer { border-top-color: var(--line-gray-5, #e8e8e8); }
+
+    .dd-cur {
+      font-size: var(--line-font-size-0, 0.5rem);
+      color: var(--line-gray-6, #444);
+    }
+    .dd-cur strong { color: var(--line-gray-9, #666); font-weight: var(--line-font-weight-6, 600); }
+    :host([light]) .dd-cur { color: var(--line-gray-8, #aaa); }
+    :host([light]) .dd-cur strong { color: var(--line-gray-10, #666); }
+
+    /* ── Responsive ── */
+    /* Desktop: inline nav visible, menu-btn hidden */
+    @media (min-width: 769px) {
+      .nav-inline { display: block; }
+      .menu-btn   { display: none; }
+      .dropdown   { display: none; }
     }
 
-    .toggle-btn {
-      appearance: none;
-      background: var(--line-gray-4, #e5e5e5);
-      border: var(--line-border-size-1) solid var(--line-gray-7, #c4c4c4);
-      border-radius: var(--line-radius-2);
-      padding: 0.375rem 0.75rem;
-      font-family: inherit;
-      font-size: var(--line-font-size-1);
-      font-weight: var(--line-font-weight-6);
-      cursor: pointer;
-      color: var(--line-gray-12, #1a1a1a);
-      transition:
-        background-color var(--line-duration-fast) var(--line-ease-2),
-        border-color var(--line-duration-fast) var(--line-ease-2),
-        color var(--line-duration-fast) var(--line-ease-2);
-    }
-
-    .toggle-btn:hover {
-      background: var(--line-gray-5, #d9d9d9);
-    }
-
-    :host([dark]) .toggle-btn {
-      background: var(--line-gray-4, #2c2c2c);
-      border-color: var(--line-gray-7, #484848);
-      color: var(--line-gray-12, #eeeeee);
-    }
-
-    :host([dark]) .toggle-btn:hover {
-      background: var(--line-gray-5, #363636);
-    }
-
-    .schema-select {
-      appearance: none;
-      width: 100%;
-      padding: 0.375rem var(--line-size-2);
-      border-radius: var(--line-radius-2);
-      border: var(--line-border-size-1) solid var(--line-gray-7, #c4c4c4);
-      background: var(--line-gray-3, #eeeeee);
-      color: var(--line-gray-12, #1a1a1a);
-      font-family: inherit;
-      font-size: var(--line-font-size-1);
-      font-weight: var(--line-font-weight-5);
-      cursor: pointer;
-      text-transform: capitalize;
-      transition:
-        background-color var(--line-duration-fast) var(--line-ease-2),
-        border-color var(--line-duration-fast) var(--line-ease-2),
-        color var(--line-duration-fast) var(--line-ease-2);
-    }
-
-    .schema-select:hover {
-      border-color: var(--line-gray-8, #a3a3a3);
-    }
-
-    .schema-select:focus-visible {
-      outline: var(--line-ring-width) solid var(--line-blue-9, #3b82f6);
-      outline-offset: var(--line-ring-offset);
-    }
-
-    :host([dark]) .schema-select {
-      background: var(--line-gray-3, #232323);
-      border-color: var(--line-gray-7, #484848);
-      color: var(--line-gray-12, #eeeeee);
-    }
-
-    /* Hamburger (mobile only) */
-    .hamburger {
-      display: none;
-      position: fixed;
-      top: 0.75rem;
-      left: 0.75rem;
-      z-index: var(--line-z-fixed);
-      appearance: none;
-      background: var(--line-gray-3, #eeeeee);
-      border: var(--line-border-size-1) solid var(--line-gray-7, #c4c4c4);
-      border-radius: var(--line-radius-2);
-      padding: var(--line-size-2);
-      cursor: pointer;
-      color: var(--line-gray-12, #1a1a1a);
-      font-size: var(--line-font-size-4);
-      line-height: 1;
-      transition:
-        background-color var(--line-duration-fast) var(--line-ease-2),
-        color var(--line-duration-fast) var(--line-ease-2);
-    }
-
-    :host([dark]) .hamburger {
-      background: var(--line-gray-3, #232323);
-      border-color: var(--line-gray-7, #484848);
-      color: var(--line-gray-12, #eeeeee);
-    }
-
-    .overlay {
-      display: none;
-    }
-
-    /* Breakpoint: --line-size-md (768px) */
+    /* Mobile: inline nav hidden, menu-btn + dropdown visible */
     @media (max-width: 768px) {
-      .hamburger {
-        display: block;
-      }
-
-      .sidebar {
-        transform: translateX(-100%);
-      }
-
-      .sidebar.open {
-        transform: translateX(0);
-      }
-
-      .overlay {
-        display: block;
-        position: fixed;
-        inset: 0;
-        background: rgb(0 0 0 / 0.4);
-        z-index: var(--line-z-dropdown);
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity var(--line-duration-moderate-2) var(--line-ease-2);
-      }
-
-      .overlay.visible {
-        opacity: 1;
-        pointer-events: auto;
-      }
+      .nav-inline { display: none; }
+      .menu-btn   { display: flex; }
+      .logo       { flex: 1; }
     }
   `;
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this._loadPreferences();
-    this._currentPath = window.location.pathname;
-    window.addEventListener('popstate', this._onPopState);
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('panel') || changed.has('schema')) {
+      requestAnimationFrame(() => this._updatePill());
+    }
+  }
+
+  override firstUpdated(): void {
+    requestAnimationFrame(() => this._updatePill());
+    // Close dropdown on outside click
+    document.addEventListener('click', this._handleOutsideClick);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    window.removeEventListener('popstate', this._onPopState);
+    document.removeEventListener('click', this._handleOutsideClick);
   }
 
-  private _loadPreferences(): void {
-    const storedMode = localStorage.getItem('line-mode');
-    this.dark = storedMode === 'dark';
-    this._applyMode();
-
-    const storedSchema = localStorage.getItem('line-schema');
-    if (storedSchema && PALETTES.includes(storedSchema as Palette)) {
-      this._schema = storedSchema as Palette;
+  private _handleOutsideClick = (e: MouseEvent): void => {
+    if (this._open && !this.shadowRoot?.contains(e.composedPath()[0] as Node)) {
+      this._open = false;
     }
-    this._applySchema();
-  }
-
-  private _applyMode(): void {
-    const root = document.documentElement;
-    if (this.dark) {
-      root.classList.add('dark');
-      root.classList.remove('light');
-    } else {
-      root.classList.add('light');
-      root.classList.remove('dark');
-    }
-  }
-
-  private _applySchema(): void {
-    const body = document.body;
-    // Remove any existing schema classes
-    for (const cls of Array.from(body.classList)) {
-      if (cls.startsWith('line-schema-')) {
-        body.classList.remove(cls);
-      }
-    }
-    body.classList.add(`line-schema-${this._schema}`);
-  }
-
-  private _onPopState = (): void => {
-    this._currentPath = window.location.pathname;
   };
 
-  private _handleNavClick(e: Event): void {
-    // Update the current path for active highlighting
-    // The Router in sc-app intercepts the click and handles navigation
-    const anchor = (e.composedPath() as Element[]).find((el) => el.tagName === 'A');
-    if (anchor) {
-      this._currentPath = (anchor as HTMLAnchorElement).pathname;
-      // Close mobile nav on route selection
-      this._mobileOpen = false;
-    }
+  private _updatePill(): void {
+    const row = this.shadowRoot?.querySelector('.nav-row') as HTMLElement | null;
+    const active = this.shadowRoot?.querySelector('.nav-btn.active') as HTMLElement | null;
+    const scroll = this.shadowRoot?.querySelector('.nav-inline') as HTMLElement | null;
+    if (!(row && active)) return;
+    const rb = row.getBoundingClientRect();
+    const ab = active.getBoundingClientRect();
+    const scrollLeft = scroll?.scrollLeft ?? 0;
+    this._pillLeft = ab.left - rb.left + scrollLeft;
+    this._pillWidth = ab.width;
+    active.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+  }
+
+  private _navigate(key: PanelKey): void {
+    this._open = false;
+    this.dispatchEvent(
+      new CustomEvent('sc-navigate', {
+        detail: { panel: key },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private _cycleSchema(): void {
+    const i = ALL_SCHEMAS.indexOf(this.schema);
+    const next = ALL_SCHEMAS[(i + 1) % ALL_SCHEMAS.length];
+    this.dispatchEvent(
+      new CustomEvent('sc-schema-change', {
+        detail: { schema: next },
+        bubbles: true,
+        composed: true
+      })
+    );
   }
 
   private _toggleMode(): void {
-    this.dark = !this.dark;
-    localStorage.setItem('line-mode', this.dark ? 'dark' : 'light');
-    this._applyMode();
     this.dispatchEvent(
-      new CustomEvent('mode-change', {
-        detail: { mode: this.dark ? 'dark' : 'light' },
+      new CustomEvent('sc-mode-change', {
+        detail: { light: !this.light },
         bubbles: true,
         composed: true
       })
     );
   }
 
-  private _handleSchemaChange(e: Event): void {
-    const select = e.target as HTMLSelectElement;
-    this._schema = select.value as Palette;
-    localStorage.setItem('line-schema', this._schema);
-    this._applySchema();
-    this.dispatchEvent(
-      new CustomEvent('schema-change', {
-        detail: { schema: this._schema },
-        bubbles: true,
-        composed: true
-      })
-    );
-  }
-
-  private _toggleMobileNav(): void {
-    this._mobileOpen = !this._mobileOpen;
-  }
-
-  private _closeMobileNav(): void {
-    this._mobileOpen = false;
-  }
-
-  private _renderNavGroups() {
-    return NAV_GROUPS.map(
-      (group) => html`
-        <div class="nav-section">
-          <div class="nav-group-label">${group.label}</div>
-          <div class="nav-group" @click=${this._handleNavClick}>
-            ${group.routes.map(
-              (route) => html`
-                <a
-                  class=${classMap({
-                    'nav-link': true,
-                    active: this._currentPath === route.path
-                  })}
-                  href=${route.path}
-                  >${route.label}</a
-                >
-              `
-            )}
-          </div>
-        </div>
-      `
-    );
+  private _toggleMenu(): void {
+    this._open = !this._open;
   }
 
   override render() {
+    const currentLabel = NAV_ITEMS.find((n) => n.key === this.panel)?.label ?? '';
+
     return html`
-      <button
-        class="hamburger"
-        @click=${this._toggleMobileNav}
-        aria-label=${this._mobileOpen ? 'Close navigation' : 'Open navigation'}
-        aria-expanded=${this._mobileOpen}
-      >
-        ${this._mobileOpen ? '\u2715' : '\u2630'}
-      </button>
+      <div class="topbar">
+        <div class="logo">line<span class="logo-ac">://</span>ui</div>
 
-      <div
-        class=${classMap({ overlay: true, visible: this._mobileOpen })}
-        @click=${this._closeMobileNav}
-      ></div>
-
-      <nav class=${classMap({ sidebar: true, open: this._mobileOpen })}>
-        <a class="logo" href="/"
-          >line<span class="accent">://</span>ui</a
-        >
-
-        ${this._renderNavGroups()}
-
-        <div class="controls">
-          <div class="mode-toggle">
-            <span class="control-label">Mode</span>
-            <button
-              class="toggle-btn"
-              @click=${this._toggleMode}
-              aria-label=${this.dark ? 'Switch to light mode' : 'Switch to dark mode'}
-            >
-              ${this.dark ? 'Light' : 'Dark'}
-            </button>
-          </div>
-
-          <div>
-            <span class="control-label">Schema</span>
-            <select
-              class="schema-select"
-              .value=${this._schema}
-              @change=${this._handleSchemaChange}
-              aria-label="Select color schema"
-            >
-              ${PALETTES.map(
-                (palette) => html`
-                  <option value=${palette}>${palette}</option>
-                `
-              )}
-            </select>
+        <!-- Desktop: inline pill nav -->
+        <div class="nav-inline">
+          <div class="nav-row">
+            <div class="pill" style="left:${this._pillLeft}px;width:${this._pillWidth}px"></div>
+            ${NAV_ITEMS.map(
+              ({ key, label }) => html`
+              <button
+                class=${classMap({ 'nav-btn': true, active: this.panel === key })}
+                @click=${() => this._navigate(key)}
+              >${label}</button>
+            `
+            )}
           </div>
         </div>
-      </nav>
+
+        <div class="controls">
+          <div class="schema-chip" @click=${this._cycleSchema}>
+            <div class="schema-dot"></div>
+            <span>${this.schema}</span>
+          </div>
+          <button class="mode-btn" @click=${this._toggleMode}>
+            ${this.light ? 'Dark' : 'Light'}
+          </button>
+          <!-- Mobile: hamburger -->
+          <button
+            class=${classMap({ 'menu-btn': true, open: this._open })}
+            @click=${this._toggleMenu}
+            aria-expanded=${this._open}
+            aria-label=${this._open ? 'Close menu' : 'Open menu'}
+          >
+            <div class="hb">
+              <span></span><span></span><span></span>
+            </div>
+            Menu
+          </button>
+        </div>
+      </div>
+
+      <!-- Mobile: dropdown -->
+      <div class=${classMap({ dropdown: true, open: this._open })}>
+        <div class="dropdown-inner">
+          <div class="dd-label">Navigate</div>
+          <div class="dd-grid">
+            ${NAV_ITEMS.map(
+              ({ key, label }) => html`
+              <button
+                class=${classMap({ 'dd-item': true, active: this.panel === key })}
+                @click=${() => this._navigate(key)}
+              >${label}</button>
+            `
+            )}
+          </div>
+          <div class="dd-footer">
+            <span class="dd-cur">Current: <strong>${currentLabel}</strong></span>
+            <span class="dd-cur">tap to navigate</span>
+          </div>
+        </div>
+      </div>
     `;
   }
 }

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -2,37 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import type { PanelKey } from '../app.js';
-
-const ALL_SCHEMAS = [
-  'amber',
-  'blue',
-  'bronze',
-  'brown',
-  'crimson',
-  'cyan',
-  'gold',
-  'grass',
-  'gray',
-  'green',
-  'indigo',
-  'lime',
-  'mauve',
-  'mint',
-  'olive',
-  'orange',
-  'pink',
-  'plum',
-  'purple',
-  'red',
-  'sage',
-  'sand',
-  'sky',
-  'slate',
-  'teal',
-  'tomato',
-  'violet',
-  'yellow'
-];
+import { ALL_SCHEMAS } from '../constants.js';
 
 const NAV_ITEMS: { key: PanelKey; label: string }[] = [
   { key: 'colors', label: 'Colors' },
@@ -405,7 +375,7 @@ export class ScNav extends LitElement {
   }
 
   private _cycleSchema(): void {
-    const i = ALL_SCHEMAS.indexOf(this.schema);
+    const i = (ALL_SCHEMAS as readonly string[]).indexOf(this.schema);
     const next = ALL_SCHEMAS[(i + 1) % ALL_SCHEMAS.length];
     this.dispatchEvent(
       new CustomEvent('sc-schema-change', {

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -61,7 +61,7 @@ export class ScNav extends LitElement {
     :host {
       display: block;
       background: rgba(8, 8, 8, 0.92);
-      border-bottom: var(--line-border-size-1, 1px) solid var(--line-gray-4, #222);
+      border-bottom: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
       position: relative;
@@ -73,7 +73,7 @@ export class ScNav extends LitElement {
 
     :host([light]) {
       background: rgba(250, 250, 250, 0.97);
-      border-bottom-color: var(--line-gray-4, #e5e5e5);
+      border-bottom-color: var(--line-ui-background, #e5e5e5);
     }
 
     /* ── Top bar ── */
@@ -91,13 +91,13 @@ export class ScNav extends LitElement {
     .logo {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-8, 800);
-      color: var(--line-gray-12, #fff);
+      color: var(--line-high-contrast, #fff);
       letter-spacing: -0.03em;
       white-space: nowrap;
       flex-shrink: 0;
       transition: color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
     }
-    :host([light]) .logo { color: var(--line-gray-12, #1a1a1a); }
+    :host([light]) .logo { color: var(--line-high-contrast, #1a1a1a); }
     .logo-ac { color: var(--line-solid-background, #c8ff00); }
 
     /* Desktop inline nav — hidden on mobile */
@@ -140,7 +140,7 @@ export class ScNav extends LitElement {
       cursor: pointer;
       font-size: var(--line-font-size-1, 0.75rem);
       font-weight: var(--line-font-weight-6, 600);
-      color: var(--line-gray-8, #555);
+      color: var(--line-low-contrast, #999);
       letter-spacing: 0.02em;
       white-space: nowrap;
       border: none;
@@ -148,9 +148,9 @@ export class ScNav extends LitElement {
       font-family: var(--line-font-mono, monospace);
       transition: color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
     }
-    .nav-btn:hover { color: var(--line-gray-10, #888); }
-    :host([light]) .nav-btn { color: var(--line-gray-8, #aaa); }
-    :host([light]) .nav-btn:hover { color: var(--line-gray-11, #555); }
+    .nav-btn:hover { color: var(--line-high-contrast, #ddd); }
+    :host([light]) .nav-btn { color: var(--line-low-contrast, #666); }
+    :host([light]) .nav-btn:hover { color: var(--line-high-contrast, #222); }
     .nav-btn.active { color: var(--line-solid-background, #c8ff00); }
 
     /* ── Right controls ── */
@@ -167,21 +167,21 @@ export class ScNav extends LitElement {
       align-items: center;
       gap: var(--line-size-1, 0.25rem);
       padding: 5px var(--line-size-3, 1rem);
-      border: var(--line-border-size-1, 1px) solid var(--line-gray-5, #2e2e2e);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-active-background, #2e2e2e);
       border-radius: var(--line-radius-2, 4px);
       font-size: var(--line-font-size-0, 0.5rem);
       font-weight: var(--line-font-weight-6, 600);
-      color: var(--line-gray-9, #555);
+      color: var(--line-low-contrast, #999);
       cursor: pointer;
-      background: var(--line-gray-2, #161616);
+      background: var(--line-subtle-background, #161616);
       font-family: var(--line-font-mono, monospace);
       white-space: nowrap;
       transition:
         border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
         color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
     }
-    .schema-chip:hover { border-color: var(--line-gray-7, #444); color: var(--line-gray-10, #888); }
-    :host([light]) .schema-chip { background: var(--line-gray-3, #eee); border-color: var(--line-gray-6, #d4d4d4); color: var(--line-gray-9, #888); }
+    .schema-chip:hover { border-color: var(--line-ui-border, #444); color: var(--line-high-contrast, #ddd); }
+    :host([light]) .schema-chip { background: var(--line-ui-background, #eee); border-color: var(--line-subtle-border, #d4d4d4); color: var(--line-low-contrast, #666); }
 
     .schema-dot {
       width: 7px; height: 7px;
@@ -193,11 +193,11 @@ export class ScNav extends LitElement {
 
     .mode-btn {
       padding: 5px var(--line-size-3, 1rem);
-      border: var(--line-border-size-1, 1px) solid var(--line-gray-5, #2e2e2e);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-active-background, #2e2e2e);
       border-radius: var(--line-radius-2, 4px);
       font-size: var(--line-font-size-0, 0.5rem);
       font-weight: var(--line-font-weight-6, 600);
-      color: var(--line-gray-9, #555);
+      color: var(--line-low-contrast, #999);
       cursor: pointer;
       background: transparent;
       font-family: var(--line-font-mono, monospace);
@@ -206,8 +206,8 @@ export class ScNav extends LitElement {
         border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
         color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
     }
-    .mode-btn:hover { border-color: var(--line-gray-7, #444); color: var(--line-gray-10, #888); }
-    :host([light]) .mode-btn { border-color: var(--line-gray-6, #d4d4d4); color: var(--line-gray-9, #888); }
+    .mode-btn:hover { border-color: var(--line-ui-border, #444); color: var(--line-high-contrast, #ddd); }
+    :host([light]) .mode-btn { border-color: var(--line-subtle-border, #d4d4d4); color: var(--line-low-contrast, #666); }
 
     /* ── Hamburger / menu button ── */
     .menu-btn {
@@ -215,11 +215,11 @@ export class ScNav extends LitElement {
       align-items: center;
       gap: 7px;
       padding: 5px var(--line-size-3, 1rem);
-      border: var(--line-border-size-1, 1px) solid var(--line-gray-5, #2e2e2e);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-active-background, #2e2e2e);
       border-radius: var(--line-radius-2, 4px);
       font-size: var(--line-font-size-0, 0.5rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-gray-8, #666);
+      color: var(--line-low-contrast, #999);
       background: transparent;
       font-family: var(--line-font-mono, monospace);
       cursor: pointer;
@@ -228,12 +228,12 @@ export class ScNav extends LitElement {
         border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
         color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
     }
-    .menu-btn:hover { border-color: var(--line-gray-7, #444); color: var(--line-gray-10, #888); }
+    .menu-btn:hover { border-color: var(--line-ui-border, #444); color: var(--line-high-contrast, #ddd); }
     .menu-btn.open {
       border-color: var(--line-solid-background, #c8ff00);
       color: var(--line-solid-background, #c8ff00);
     }
-    :host([light]) .menu-btn { border-color: var(--line-gray-6, #d4d4d4); color: var(--line-gray-9, #888); }
+    :host([light]) .menu-btn { border-color: var(--line-subtle-border, #d4d4d4); color: var(--line-low-contrast, #666); }
     :host([light]) .menu-btn.open {
       border-color: var(--line-solid-background, #1a1a1a);
       color: var(--line-solid-background, #1a1a1a);
@@ -260,9 +260,9 @@ export class ScNav extends LitElement {
     }
     .dropdown.open {
       max-height: 360px;
-      border-bottom: var(--line-border-size-1, 1px) solid var(--line-gray-4, #222);
+      border-bottom: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
     }
-    :host([light]) .dropdown.open { border-bottom-color: var(--line-gray-4, #e5e5e5); }
+    :host([light]) .dropdown.open { border-bottom-color: var(--line-ui-background, #e5e5e5); }
 
     .dropdown-inner {
       padding: var(--line-size-5, 1.5rem) var(--line-size-5, 1.5rem) var(--line-size-6, 1.75rem);
@@ -273,12 +273,12 @@ export class ScNav extends LitElement {
     .dd-label {
       font-size: var(--line-font-size-0, 0.5rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-gray-6, #444);
+      color: var(--line-low-contrast, #999);
       letter-spacing: 0.1em;
       text-transform: uppercase;
       margin-bottom: var(--line-size-3, 1rem);
     }
-    :host([light]) .dd-label { color: var(--line-gray-8, #aaa); }
+    :host([light]) .dd-label { color: var(--line-low-contrast, #666); }
 
     .dd-grid {
       display: grid;
@@ -289,10 +289,10 @@ export class ScNav extends LitElement {
     .dd-item {
       padding: var(--line-size-3, 1rem) var(--line-size-3, 1rem);
       border-radius: var(--line-radius-2, 4px);
-      border: var(--line-border-size-1, 1px) solid var(--line-gray-3, #1e1e1e);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #1e1e1e);
       font-size: var(--line-font-size-1, 0.75rem);
       font-weight: var(--line-font-weight-6, 600);
-      color: var(--line-gray-8, #555);
+      color: var(--line-low-contrast, #999);
       cursor: pointer;
       background: transparent;
       font-family: var(--line-font-mono, monospace);
@@ -304,26 +304,26 @@ export class ScNav extends LitElement {
         color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
     }
     .dd-item:hover {
-      background: var(--line-gray-2, #161616);
-      border-color: var(--line-gray-5, #333);
-      color: var(--line-gray-10, #aaa);
+      background: var(--line-subtle-background, #161616);
+      border-color: var(--line-ui-active-background, #333);
+      color: var(--line-high-contrast, #ddd);
     }
     :host([light]) .dd-item {
-      border-color: var(--line-gray-5, #e5e5e5);
-      color: var(--line-gray-9, #888);
+      border-color: var(--line-ui-active-background, #e5e5e5);
+      color: var(--line-low-contrast, #666);
     }
     :host([light]) .dd-item:hover {
-      background: var(--line-gray-3, #eee);
-      border-color: var(--line-gray-7, #bbb);
-      color: var(--line-gray-11, #444);
+      background: var(--line-ui-background, #eee);
+      border-color: var(--line-ui-border, #bbb);
+      color: var(--line-high-contrast, #222);
     }
     .dd-item.active {
       border-color: var(--line-solid-background, #c8ff00);
       color: var(--line-solid-background, #c8ff00);
-      background: var(--line-gray-2, #0d0d0d);
+      background: var(--line-subtle-background, #0d0d0d);
     }
     :host([light]) .dd-item.active {
-      background: var(--line-gray-3, #f0f0f0);
+      background: var(--line-ui-background, #f0f0f0);
     }
 
     .dd-footer {
@@ -332,17 +332,17 @@ export class ScNav extends LitElement {
       align-items: center;
       margin-top: var(--line-size-4, 1.25rem);
       padding-top: var(--line-size-4, 1.25rem);
-      border-top: var(--line-border-size-1, 1px) solid var(--line-gray-3, #1a1a1a);
+      border-top: var(--line-border-size-1, 1px) solid var(--line-ui-background, #1a1a1a);
     }
-    :host([light]) .dd-footer { border-top-color: var(--line-gray-5, #e8e8e8); }
+    :host([light]) .dd-footer { border-top-color: var(--line-ui-active-background, #e8e8e8); }
 
     .dd-cur {
       font-size: var(--line-font-size-0, 0.5rem);
-      color: var(--line-gray-6, #444);
+      color: var(--line-low-contrast, #999);
     }
-    .dd-cur strong { color: var(--line-gray-9, #666); font-weight: var(--line-font-weight-6, 600); }
-    :host([light]) .dd-cur { color: var(--line-gray-8, #aaa); }
-    :host([light]) .dd-cur strong { color: var(--line-gray-10, #666); }
+    .dd-cur strong { color: var(--line-high-contrast, #ddd); font-weight: var(--line-font-weight-6, 600); }
+    :host([light]) .dd-cur { color: var(--line-low-contrast, #666); }
+    :host([light]) .dd-cur strong { color: var(--line-high-contrast, #222); }
 
     /* ── Responsive ── */
     /* Desktop: inline nav visible alongside menu button */

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -29,30 +29,39 @@ export class ScNav extends LitElement {
 
   static override styles = css`
     :host {
+      /* Layout-local custom properties for repeated magic numbers */
+      --_topbar-h: 52px;
+      --_max-w: 1400px;
+      --_ctrl-pad-block: var(--line-size-1, 0.25rem);
+      --_dot-size: 7px;
+
       display: block;
+      /* Intentional raw rgba for translucent backdrop-filter effect;
+         semantic tokens don't support alpha-channel blending. */
       background: rgba(8, 8, 8, 0.92);
       border-bottom: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
       position: relative;
-      z-index: 100;
+      z-index: var(--line-z-sticky, 100);
       transition:
         background var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
         border-color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
     }
 
     :host([light]) {
+      /* Intentional raw rgba — see :host comment above */
       background: rgba(250, 250, 250, 0.97);
       border-bottom-color: var(--line-ui-background, #e5e5e5);
     }
 
     /* ── Top bar ── */
     .topbar {
-      height: 52px;
+      height: var(--_topbar-h);
       display: flex;
       align-items: center;
       padding: 0 var(--line-size-5, 1.5rem);
-      max-width: 1400px;
+      max-width: var(--_max-w);
       margin: 0 auto;
       width: 100%;
       box-sizing: border-box;
@@ -97,14 +106,14 @@ export class ScNav extends LitElement {
       background: var(--line-solid-background, #c8ff00);
       border-radius: 2px 2px 0 0;
       transition:
-        left  280ms cubic-bezier(0.4, 0, 0.2, 1),
-        width 280ms cubic-bezier(0.4, 0, 0.2, 1);
+        left  var(--line-duration-moderate-2, 260ms) var(--line-ease-4),
+        width var(--line-duration-moderate-2, 260ms) var(--line-ease-4);
       pointer-events: none;
     }
 
     .nav-btn {
       padding: 0 var(--line-size-3, 1rem);
-      height: 52px;
+      height: var(--_topbar-h);
       display: flex;
       align-items: center;
       cursor: pointer;
@@ -136,7 +145,7 @@ export class ScNav extends LitElement {
       display: flex;
       align-items: center;
       gap: var(--line-size-1, 0.25rem);
-      padding: 5px var(--line-size-3, 1rem);
+      padding: var(--_ctrl-pad-block) var(--line-size-3, 1rem);
       border: var(--line-border-size-1, 1px) solid var(--line-ui-active-background, #2e2e2e);
       border-radius: var(--line-radius-2, 4px);
       font-size: var(--line-font-size-0, 0.5rem);
@@ -154,7 +163,7 @@ export class ScNav extends LitElement {
     :host([light]) .schema-chip { background: var(--line-ui-background, #eee); border-color: var(--line-subtle-border, #d4d4d4); color: var(--line-low-contrast, #666); }
 
     .schema-dot {
-      width: 7px; height: 7px;
+      width: var(--_dot-size); height: var(--_dot-size);
       border-radius: 50%;
       background: var(--line-solid-background, #c8ff00);
       flex-shrink: 0;
@@ -162,7 +171,7 @@ export class ScNav extends LitElement {
     }
 
     .mode-btn {
-      padding: 5px var(--line-size-3, 1rem);
+      padding: var(--_ctrl-pad-block) var(--line-size-3, 1rem);
       border: var(--line-border-size-1, 1px) solid var(--line-ui-active-background, #2e2e2e);
       border-radius: var(--line-radius-2, 4px);
       font-size: var(--line-font-size-0, 0.5rem);
@@ -183,8 +192,8 @@ export class ScNav extends LitElement {
     .menu-btn {
       display: flex;
       align-items: center;
-      gap: 7px;
-      padding: 5px var(--line-size-3, 1rem);
+      gap: var(--_dot-size);
+      padding: var(--_ctrl-pad-block) var(--line-size-3, 1rem);
       border: var(--line-border-size-1, 1px) solid var(--line-ui-active-background, #2e2e2e);
       border-radius: var(--line-radius-2, 4px);
       font-size: var(--line-font-size-0, 0.5rem);
@@ -209,7 +218,9 @@ export class ScNav extends LitElement {
       color: var(--line-solid-background, #1a1a1a);
     }
 
-    /* hamburger icon */
+    /* Hamburger icon — 3-bar icon: 14x10px box, 1.5px bars spaced evenly.
+       Bars rotate into an X on open: middle bar fades, top/bottom translateY
+       by half the box height minus half the bar height (4.25px) and rotate ±45deg. */
     .hb { width: 14px; height: 10px; display: flex; flex-direction: column; justify-content: space-between; flex-shrink: 0; }
     .hb span {
       display: block; height: 1.5px; background: currentColor; border-radius: 1px;
@@ -225,7 +236,7 @@ export class ScNav extends LitElement {
     .dropdown {
       overflow: hidden;
       max-height: 0;
-      transition: max-height var(--line-duration-moderate-2, 260ms) cubic-bezier(0.4, 0, 0.2, 1);
+      transition: max-height var(--line-duration-moderate-2, 260ms) var(--line-ease-4);
       border-bottom: 0px solid transparent;
     }
     .dropdown.open {
@@ -236,7 +247,7 @@ export class ScNav extends LitElement {
 
     .dropdown-inner {
       padding: var(--line-size-5, 1.5rem) var(--line-size-5, 1.5rem) var(--line-size-6, 1.75rem);
-      max-width: 1400px;
+      max-width: var(--_max-w);
       margin: 0 auto;
     }
 
@@ -315,6 +326,9 @@ export class ScNav extends LitElement {
     :host([light]) .dd-cur strong { color: var(--line-high-contrast, #222); }
 
     /* ── Responsive ── */
+    /* Breakpoint matches --line-size-md (768px) from the token system.
+       CSS custom properties cannot be used in media queries;
+       PostCSS custom media is not available in Lit tagged template styles. */
     /* Desktop: inline nav visible alongside menu button */
     @media (min-width: 769px) {
       .nav-inline { display: block; }

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -1,14 +1,492 @@
 import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+const PALETTES = [
+  'amber',
+  'blue',
+  'bronze',
+  'brown',
+  'crimson',
+  'cyan',
+  'gold',
+  'grass',
+  'gray',
+  'green',
+  'indigo',
+  'lime',
+  'mauve',
+  'mint',
+  'olive',
+  'orange',
+  'pink',
+  'plum',
+  'purple',
+  'red',
+  'sage',
+  'sand',
+  'sky',
+  'slate',
+  'teal',
+  'tomato',
+  'violet',
+  'yellow'
+] as const;
+
+type Palette = (typeof PALETTES)[number];
+
+interface NavGroup {
+  label: string;
+  routes: { path: string; label: string }[];
+}
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    label: 'Tokens',
+    routes: [
+      { path: '/tokens/colors', label: 'Colors' },
+      { path: '/tokens/typography', label: 'Typography' },
+      { path: '/tokens/spacing', label: 'Spacing' },
+      { path: '/tokens/motion', label: 'Motion' },
+      { path: '/tokens/surfaces', label: 'Surfaces' },
+      { path: '/tokens/decorative', label: 'Decorative' }
+    ]
+  },
+  {
+    label: 'Semantic',
+    routes: [{ path: '/semantic', label: 'Semantic' }]
+  },
+  {
+    label: 'Elements',
+    routes: [{ path: '/elements', label: 'Elements' }]
+  },
+  {
+    label: 'Themes',
+    routes: [{ path: '/themes', label: 'Themes' }]
+  },
+  {
+    label: 'Tools',
+    routes: [{ path: '/generator', label: 'Generator' }]
+  }
+];
 
 @customElement('sc-nav')
 export class ScNav extends LitElement {
+  @state() private _darkMode = false;
+  @state() private _schema: Palette = 'blue';
+  @state() private _mobileOpen = false;
+  @state() private _currentPath = '/';
+
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+    }
+
+    .sidebar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: var(--sc-sidebar-width, 260px);
+      height: 100dvh;
+      overflow-y: auto;
+      background: var(--line-gray-2, #f5f5f5);
+      border-inline-end: 1px solid var(--line-gray-6, #d4d4d4);
+      padding: 1.5rem 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      z-index: 100;
+      transition: transform 0.25s ease, background-color 0.2s ease,
+        border-color 0.2s ease;
+    }
+
+    :host-context(html.dark) .sidebar {
+      background: var(--line-gray-2, #1c1c1c);
+      border-inline-end-color: var(--line-gray-6, #3a3a3a);
+    }
+
+    .logo {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .logo .accent {
+      color: var(--line-blue-9, #3b82f6);
+    }
+
+    .nav-group-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--line-gray-9, #a1a1a1);
+      padding: 0 0.5rem;
+      margin-block-end: 0.25rem;
+    }
+
+    .nav-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.125rem;
+    }
+
+    .nav-link {
+      display: block;
+      padding: 0.375rem 0.5rem;
+      border-radius: 0.375rem;
+      text-decoration: none;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--line-gray-11, #6b6b6b);
+      transition: background-color 0.15s ease, color 0.15s ease;
+    }
+
+    .nav-link:hover {
+      background: var(--line-gray-4, #e5e5e5);
+      color: var(--line-gray-12, #1a1a1a);
+    }
+
+    :host-context(html.dark) .nav-link:hover {
+      background: var(--line-gray-4, #2c2c2c);
+      color: var(--line-gray-12, #eeeeee);
+    }
+
+    .nav-link.active {
+      background: var(--line-blue-4, #dbeafe);
+      color: var(--line-blue-11, #1d4ed8);
+      font-weight: 600;
+    }
+
+    :host-context(html.dark) .nav-link.active {
+      background: var(--line-blue-4, #172554);
+      color: var(--line-blue-11, #60a5fa);
+    }
+
+    .controls {
+      margin-block-start: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding-block-start: 1rem;
+      border-block-start: 1px solid var(--line-gray-6, #d4d4d4);
+    }
+
+    :host-context(html.dark) .controls {
+      border-block-start-color: var(--line-gray-6, #3a3a3a);
+    }
+
+    .control-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--line-gray-9, #a1a1a1);
+    }
+
+    .mode-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .toggle-btn {
+      appearance: none;
+      background: var(--line-gray-4, #e5e5e5);
+      border: 1px solid var(--line-gray-7, #c4c4c4);
+      border-radius: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      font-family: inherit;
+      font-size: 0.75rem;
+      font-weight: 600;
+      cursor: pointer;
+      color: var(--line-gray-12, #1a1a1a);
+      transition: background-color 0.15s ease, border-color 0.15s ease,
+        color 0.15s ease;
+    }
+
+    .toggle-btn:hover {
+      background: var(--line-gray-5, #d9d9d9);
+    }
+
+    :host-context(html.dark) .toggle-btn {
+      background: var(--line-gray-4, #2c2c2c);
+      border-color: var(--line-gray-7, #484848);
+      color: var(--line-gray-12, #eeeeee);
+    }
+
+    :host-context(html.dark) .toggle-btn:hover {
+      background: var(--line-gray-5, #363636);
+    }
+
+    .schema-select {
+      appearance: none;
+      width: 100%;
+      padding: 0.375rem 0.5rem;
+      border-radius: 0.375rem;
+      border: 1px solid var(--line-gray-7, #c4c4c4);
+      background: var(--line-gray-3, #eeeeee);
+      color: var(--line-gray-12, #1a1a1a);
+      font-family: inherit;
+      font-size: 0.75rem;
+      font-weight: 500;
+      cursor: pointer;
+      text-transform: capitalize;
+      transition: background-color 0.15s ease, border-color 0.15s ease,
+        color 0.15s ease;
+    }
+
+    .schema-select:hover {
+      border-color: var(--line-gray-8, #a3a3a3);
+    }
+
+    .schema-select:focus-visible {
+      outline: 2px solid var(--line-blue-9, #3b82f6);
+      outline-offset: 2px;
+    }
+
+    :host-context(html.dark) .schema-select {
+      background: var(--line-gray-3, #232323);
+      border-color: var(--line-gray-7, #484848);
+      color: var(--line-gray-12, #eeeeee);
+    }
+
+    /* Hamburger (mobile only) */
+    .hamburger {
+      display: none;
+      position: fixed;
+      top: 0.75rem;
+      left: 0.75rem;
+      z-index: 200;
+      appearance: none;
+      background: var(--line-gray-3, #eeeeee);
+      border: 1px solid var(--line-gray-7, #c4c4c4);
+      border-radius: 0.375rem;
+      padding: 0.5rem;
+      cursor: pointer;
+      color: var(--line-gray-12, #1a1a1a);
+      font-size: 1.25rem;
+      line-height: 1;
+      transition: background-color 0.15s ease, color 0.15s ease;
+    }
+
+    :host-context(html.dark) .hamburger {
+      background: var(--line-gray-3, #232323);
+      border-color: var(--line-gray-7, #484848);
+      color: var(--line-gray-12, #eeeeee);
+    }
+
+    .overlay {
+      display: none;
+    }
+
+    @media (max-width: 768px) {
+      .hamburger {
+        display: block;
+      }
+
+      .sidebar {
+        transform: translateX(-100%);
+      }
+
+      .sidebar.open {
+        transform: translateX(0);
+      }
+
+      .overlay {
+        display: block;
+        position: fixed;
+        inset: 0;
+        background: rgb(0 0 0 / 0.4);
+        z-index: 50;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.25s ease;
+      }
+
+      .overlay.visible {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
   `;
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this._loadPreferences();
+    this._currentPath = window.location.pathname;
+    window.addEventListener('popstate', this._onPopState);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener('popstate', this._onPopState);
+  }
+
+  private _loadPreferences(): void {
+    const storedMode = localStorage.getItem('line-mode');
+    this._darkMode = storedMode === 'dark';
+    this._applyMode();
+
+    const storedSchema = localStorage.getItem('line-schema');
+    if (storedSchema && PALETTES.includes(storedSchema as Palette)) {
+      this._schema = storedSchema as Palette;
+    }
+    this._applySchema();
+  }
+
+  private _applyMode(): void {
+    const root = document.documentElement;
+    if (this._darkMode) {
+      root.classList.add('dark');
+      root.classList.remove('light');
+    } else {
+      root.classList.add('light');
+      root.classList.remove('dark');
+    }
+  }
+
+  private _applySchema(): void {
+    const body = document.body;
+    // Remove any existing schema classes
+    for (const cls of Array.from(body.classList)) {
+      if (cls.startsWith('line-schema-')) {
+        body.classList.remove(cls);
+      }
+    }
+    body.classList.add(`line-schema-${this._schema}`);
+  }
+
+  private _onPopState = (): void => {
+    this._currentPath = window.location.pathname;
+  };
+
+  private _handleNavClick(e: Event): void {
+    // Update the current path for active highlighting
+    // The Router in sc-app intercepts the click and handles navigation
+    const anchor = (e.composedPath() as Element[]).find((el) => el.tagName === 'A');
+    if (anchor) {
+      this._currentPath = (anchor as HTMLAnchorElement).pathname;
+      // Close mobile nav on route selection
+      this._mobileOpen = false;
+    }
+  }
+
+  private _toggleMode(): void {
+    this._darkMode = !this._darkMode;
+    localStorage.setItem('line-mode', this._darkMode ? 'dark' : 'light');
+    this._applyMode();
+    this.dispatchEvent(
+      new CustomEvent('mode-change', {
+        detail: { mode: this._darkMode ? 'dark' : 'light' },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private _handleSchemaChange(e: Event): void {
+    const select = e.target as HTMLSelectElement;
+    this._schema = select.value as Palette;
+    localStorage.setItem('line-schema', this._schema);
+    this._applySchema();
+    this.dispatchEvent(
+      new CustomEvent('schema-change', {
+        detail: { schema: this._schema },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private _toggleMobileNav(): void {
+    this._mobileOpen = !this._mobileOpen;
+  }
+
+  private _closeMobileNav(): void {
+    this._mobileOpen = false;
+  }
+
+  private _renderNavGroups() {
+    return NAV_GROUPS.map(
+      (group) => html`
+        <div class="nav-section">
+          <div class="nav-group-label">${group.label}</div>
+          <div class="nav-group" @click=${this._handleNavClick}>
+            ${group.routes.map(
+              (route) => html`
+                <a
+                  class=${classMap({
+                    'nav-link': true,
+                    active: this._currentPath === route.path
+                  })}
+                  href=${route.path}
+                  >${route.label}</a
+                >
+              `
+            )}
+          </div>
+        </div>
+      `
+    );
+  }
+
   override render() {
-    return html`<nav><!-- Sidebar navigation --></nav>`;
+    return html`
+      <button
+        class="hamburger"
+        @click=${this._toggleMobileNav}
+        aria-label=${this._mobileOpen ? 'Close navigation' : 'Open navigation'}
+        aria-expanded=${this._mobileOpen}
+      >
+        ${this._mobileOpen ? '\u2715' : '\u2630'}
+      </button>
+
+      <div
+        class=${classMap({ overlay: true, visible: this._mobileOpen })}
+        @click=${this._closeMobileNav}
+      ></div>
+
+      <nav class=${classMap({ sidebar: true, open: this._mobileOpen })}>
+        <a class="logo" href="/"
+          >line<span class="accent">://</span>ui</a
+        >
+
+        ${this._renderNavGroups()}
+
+        <div class="controls">
+          <div class="mode-toggle">
+            <span class="control-label">Mode</span>
+            <button
+              class="toggle-btn"
+              @click=${this._toggleMode}
+              aria-label=${this._darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              ${this._darkMode ? 'Light' : 'Dark'}
+            </button>
+          </div>
+
+          <div>
+            <span class="control-label">Schema</span>
+            <select
+              class="schema-select"
+              .value=${this._schema}
+              @change=${this._handleSchemaChange}
+              aria-label="Select color schema"
+            >
+              ${PALETTES.map(
+                (palette) => html`
+                  <option value=${palette}>${palette}</option>
+                `
+              )}
+            </select>
+          </div>
+        </div>
+      </nav>
+    `;
   }
 }
 

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 const PALETTES = [
@@ -72,7 +72,13 @@ const NAV_GROUPS: NavGroup[] = [
 
 @customElement('sc-nav')
 export class ScNav extends LitElement {
-  @state() private _darkMode = false;
+  /**
+   * Whether the component should render in dark mode.
+   * Set by the parent sc-app to propagate dark mode styling
+   * without relying on :host-context() (unsupported in Firefox/Safari).
+   */
+  @property({ type: Boolean, reflect: true }) dark = false;
+
   @state() private _schema: Palette = 'blue';
   @state() private _mobileOpen = false;
   @state() private _currentPath = '/';
@@ -90,24 +96,26 @@ export class ScNav extends LitElement {
       height: 100dvh;
       overflow-y: auto;
       background: var(--line-gray-2, #f5f5f5);
-      border-inline-end: 1px solid var(--line-gray-6, #d4d4d4);
-      padding: 1.5rem 1rem;
+      border-inline-end: var(--line-border-size-1) solid var(--line-gray-6, #d4d4d4);
+      padding: var(--line-size-5) var(--line-size-3);
       display: flex;
       flex-direction: column;
-      gap: 1.5rem;
-      z-index: 100;
-      transition: transform 0.25s ease, background-color 0.2s ease,
-        border-color 0.2s ease;
+      gap: var(--line-size-5);
+      z-index: var(--line-z-sticky);
+      transition:
+        transform var(--line-duration-moderate-2) var(--line-ease-2),
+        background-color var(--line-duration-moderate-1) var(--line-ease-2),
+        border-color var(--line-duration-moderate-1) var(--line-ease-2);
     }
 
-    :host-context(html.dark) .sidebar {
+    :host([dark]) .sidebar {
       background: var(--line-gray-2, #1c1c1c);
       border-inline-end-color: var(--line-gray-6, #3a3a3a);
     }
 
     .logo {
-      font-size: 1.25rem;
-      font-weight: 700;
+      font-size: var(--line-font-size-4);
+      font-weight: var(--line-font-weight-7);
       letter-spacing: -0.02em;
       text-decoration: none;
       color: inherit;
@@ -118,13 +126,13 @@ export class ScNav extends LitElement {
     }
 
     .nav-group-label {
-      font-size: 0.6875rem;
-      font-weight: 600;
+      font-size: var(--line-font-size-1);
+      font-weight: var(--line-font-weight-6);
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: var(--line-font-letterspacing-3);
       color: var(--line-gray-9, #a1a1a1);
-      padding: 0 0.5rem;
-      margin-block-end: 0.25rem;
+      padding: 0 var(--line-size-2);
+      margin-block-end: var(--line-size-1);
     }
 
     .nav-group {
@@ -135,13 +143,15 @@ export class ScNav extends LitElement {
 
     .nav-link {
       display: block;
-      padding: 0.375rem 0.5rem;
-      border-radius: 0.375rem;
+      padding: 0.375rem var(--line-size-2);
+      border-radius: var(--line-radius-2);
       text-decoration: none;
-      font-size: 0.8125rem;
-      font-weight: 500;
+      font-size: var(--line-font-size-1);
+      font-weight: var(--line-font-weight-5);
       color: var(--line-gray-11, #6b6b6b);
-      transition: background-color 0.15s ease, color 0.15s ease;
+      transition:
+        background-color var(--line-duration-fast) var(--line-ease-2),
+        color var(--line-duration-fast) var(--line-ease-2);
     }
 
     .nav-link:hover {
@@ -149,7 +159,7 @@ export class ScNav extends LitElement {
       color: var(--line-gray-12, #1a1a1a);
     }
 
-    :host-context(html.dark) .nav-link:hover {
+    :host([dark]) .nav-link:hover {
       background: var(--line-gray-4, #2c2c2c);
       color: var(--line-gray-12, #eeeeee);
     }
@@ -157,10 +167,10 @@ export class ScNav extends LitElement {
     .nav-link.active {
       background: var(--line-blue-4, #dbeafe);
       color: var(--line-blue-11, #1d4ed8);
-      font-weight: 600;
+      font-weight: var(--line-font-weight-6);
     }
 
-    :host-context(html.dark) .nav-link.active {
+    :host([dark]) .nav-link.active {
       background: var(--line-blue-4, #172554);
       color: var(--line-blue-11, #60a5fa);
     }
@@ -170,19 +180,19 @@ export class ScNav extends LitElement {
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
-      padding-block-start: 1rem;
-      border-block-start: 1px solid var(--line-gray-6, #d4d4d4);
+      padding-block-start: var(--line-size-3);
+      border-block-start: var(--line-border-size-1) solid var(--line-gray-6, #d4d4d4);
     }
 
-    :host-context(html.dark) .controls {
+    :host([dark]) .controls {
       border-block-start-color: var(--line-gray-6, #3a3a3a);
     }
 
     .control-label {
-      font-size: 0.6875rem;
-      font-weight: 600;
+      font-size: var(--line-font-size-1);
+      font-weight: var(--line-font-weight-6);
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: var(--line-font-letterspacing-3);
       color: var(--line-gray-9, #a1a1a1);
     }
 
@@ -190,53 +200,57 @@ export class ScNav extends LitElement {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 0.5rem;
+      gap: var(--line-size-2);
     }
 
     .toggle-btn {
       appearance: none;
       background: var(--line-gray-4, #e5e5e5);
-      border: 1px solid var(--line-gray-7, #c4c4c4);
-      border-radius: 0.375rem;
+      border: var(--line-border-size-1) solid var(--line-gray-7, #c4c4c4);
+      border-radius: var(--line-radius-2);
       padding: 0.375rem 0.75rem;
       font-family: inherit;
-      font-size: 0.75rem;
-      font-weight: 600;
+      font-size: var(--line-font-size-1);
+      font-weight: var(--line-font-weight-6);
       cursor: pointer;
       color: var(--line-gray-12, #1a1a1a);
-      transition: background-color 0.15s ease, border-color 0.15s ease,
-        color 0.15s ease;
+      transition:
+        background-color var(--line-duration-fast) var(--line-ease-2),
+        border-color var(--line-duration-fast) var(--line-ease-2),
+        color var(--line-duration-fast) var(--line-ease-2);
     }
 
     .toggle-btn:hover {
       background: var(--line-gray-5, #d9d9d9);
     }
 
-    :host-context(html.dark) .toggle-btn {
+    :host([dark]) .toggle-btn {
       background: var(--line-gray-4, #2c2c2c);
       border-color: var(--line-gray-7, #484848);
       color: var(--line-gray-12, #eeeeee);
     }
 
-    :host-context(html.dark) .toggle-btn:hover {
+    :host([dark]) .toggle-btn:hover {
       background: var(--line-gray-5, #363636);
     }
 
     .schema-select {
       appearance: none;
       width: 100%;
-      padding: 0.375rem 0.5rem;
-      border-radius: 0.375rem;
-      border: 1px solid var(--line-gray-7, #c4c4c4);
+      padding: 0.375rem var(--line-size-2);
+      border-radius: var(--line-radius-2);
+      border: var(--line-border-size-1) solid var(--line-gray-7, #c4c4c4);
       background: var(--line-gray-3, #eeeeee);
       color: var(--line-gray-12, #1a1a1a);
       font-family: inherit;
-      font-size: 0.75rem;
-      font-weight: 500;
+      font-size: var(--line-font-size-1);
+      font-weight: var(--line-font-weight-5);
       cursor: pointer;
       text-transform: capitalize;
-      transition: background-color 0.15s ease, border-color 0.15s ease,
-        color 0.15s ease;
+      transition:
+        background-color var(--line-duration-fast) var(--line-ease-2),
+        border-color var(--line-duration-fast) var(--line-ease-2),
+        color var(--line-duration-fast) var(--line-ease-2);
     }
 
     .schema-select:hover {
@@ -244,11 +258,11 @@ export class ScNav extends LitElement {
     }
 
     .schema-select:focus-visible {
-      outline: 2px solid var(--line-blue-9, #3b82f6);
-      outline-offset: 2px;
+      outline: var(--line-ring-width) solid var(--line-blue-9, #3b82f6);
+      outline-offset: var(--line-ring-offset);
     }
 
-    :host-context(html.dark) .schema-select {
+    :host([dark]) .schema-select {
       background: var(--line-gray-3, #232323);
       border-color: var(--line-gray-7, #484848);
       color: var(--line-gray-12, #eeeeee);
@@ -260,20 +274,22 @@ export class ScNav extends LitElement {
       position: fixed;
       top: 0.75rem;
       left: 0.75rem;
-      z-index: 200;
+      z-index: var(--line-z-fixed);
       appearance: none;
       background: var(--line-gray-3, #eeeeee);
-      border: 1px solid var(--line-gray-7, #c4c4c4);
-      border-radius: 0.375rem;
-      padding: 0.5rem;
+      border: var(--line-border-size-1) solid var(--line-gray-7, #c4c4c4);
+      border-radius: var(--line-radius-2);
+      padding: var(--line-size-2);
       cursor: pointer;
       color: var(--line-gray-12, #1a1a1a);
-      font-size: 1.25rem;
+      font-size: var(--line-font-size-4);
       line-height: 1;
-      transition: background-color 0.15s ease, color 0.15s ease;
+      transition:
+        background-color var(--line-duration-fast) var(--line-ease-2),
+        color var(--line-duration-fast) var(--line-ease-2);
     }
 
-    :host-context(html.dark) .hamburger {
+    :host([dark]) .hamburger {
       background: var(--line-gray-3, #232323);
       border-color: var(--line-gray-7, #484848);
       color: var(--line-gray-12, #eeeeee);
@@ -283,6 +299,7 @@ export class ScNav extends LitElement {
       display: none;
     }
 
+    /* Breakpoint: --line-size-md (768px) */
     @media (max-width: 768px) {
       .hamburger {
         display: block;
@@ -301,10 +318,10 @@ export class ScNav extends LitElement {
         position: fixed;
         inset: 0;
         background: rgb(0 0 0 / 0.4);
-        z-index: 50;
+        z-index: var(--line-z-dropdown);
         opacity: 0;
         pointer-events: none;
-        transition: opacity 0.25s ease;
+        transition: opacity var(--line-duration-moderate-2) var(--line-ease-2);
       }
 
       .overlay.visible {
@@ -328,7 +345,7 @@ export class ScNav extends LitElement {
 
   private _loadPreferences(): void {
     const storedMode = localStorage.getItem('line-mode');
-    this._darkMode = storedMode === 'dark';
+    this.dark = storedMode === 'dark';
     this._applyMode();
 
     const storedSchema = localStorage.getItem('line-schema');
@@ -340,7 +357,7 @@ export class ScNav extends LitElement {
 
   private _applyMode(): void {
     const root = document.documentElement;
-    if (this._darkMode) {
+    if (this.dark) {
       root.classList.add('dark');
       root.classList.remove('light');
     } else {
@@ -376,12 +393,12 @@ export class ScNav extends LitElement {
   }
 
   private _toggleMode(): void {
-    this._darkMode = !this._darkMode;
-    localStorage.setItem('line-mode', this._darkMode ? 'dark' : 'light');
+    this.dark = !this.dark;
+    localStorage.setItem('line-mode', this.dark ? 'dark' : 'light');
     this._applyMode();
     this.dispatchEvent(
       new CustomEvent('mode-change', {
-        detail: { mode: this._darkMode ? 'dark' : 'light' },
+        detail: { mode: this.dark ? 'dark' : 'light' },
         bubbles: true,
         composed: true
       })
@@ -463,9 +480,9 @@ export class ScNav extends LitElement {
             <button
               class="toggle-btn"
               @click=${this._toggleMode}
-              aria-label=${this._darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+              aria-label=${this.dark ? 'Switch to light mode' : 'Switch to dark mode'}
             >
-              ${this._darkMode ? 'Light' : 'Dark'}
+              ${this.dark ? 'Light' : 'Dark'}
             </button>
           </div>
 

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -211,7 +211,7 @@ export class ScNav extends LitElement {
 
     /* ── Hamburger / menu button ── */
     .menu-btn {
-      display: none;
+      display: flex;
       align-items: center;
       gap: 7px;
       padding: 5px var(--line-size-3, 1rem);
@@ -345,17 +345,14 @@ export class ScNav extends LitElement {
     :host([light]) .dd-cur strong { color: var(--line-gray-10, #666); }
 
     /* ── Responsive ── */
-    /* Desktop: inline nav visible, menu-btn hidden */
+    /* Desktop: inline nav visible alongside menu button */
     @media (min-width: 769px) {
       .nav-inline { display: block; }
-      .menu-btn   { display: none; }
-      .dropdown   { display: none; }
     }
 
-    /* Mobile: inline nav hidden, menu-btn + dropdown visible */
+    /* Mobile: inline nav hidden, menu button always visible */
     @media (max-width: 768px) {
       .nav-inline { display: none; }
-      .menu-btn   { display: flex; }
       .logo       { flex: 1; }
     }
   `;

--- a/apps/showcase/src/constants.ts
+++ b/apps/showcase/src/constants.ts
@@ -1,0 +1,41 @@
+/**
+ * All available color schema palette names.
+ * Shared between sc-app and sc-nav to avoid duplication.
+ */
+export const ALL_SCHEMAS = [
+  'amber',
+  'blue',
+  'bronze',
+  'brown',
+  'crimson',
+  'cyan',
+  'gold',
+  'grass',
+  'gray',
+  'green',
+  'indigo',
+  'lime',
+  'mauve',
+  'mint',
+  'olive',
+  'orange',
+  'pink',
+  'plum',
+  'purple',
+  'red',
+  'sage',
+  'sand',
+  'sky',
+  'slate',
+  'teal',
+  'tomato',
+  'violet',
+  'yellow'
+] as const;
+
+export type SchemaName = (typeof ALL_SCHEMAS)[number];
+
+/** Type-safe check that a string is a valid schema name. */
+export function isValidSchema(value: string): value is SchemaName {
+  return (ALL_SCHEMAS as readonly string[]).includes(value);
+}

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -13,6 +13,9 @@ export class ScPageHome extends LitElement {
       margin-block-end: 0.5rem;
     }
 
+    /* TODO(line-ui-6zy.3): Replace raw palette stops with semantic tokens
+       (--line-blue-9 -> --line-solid-background, --line-gray-11 -> --line-low-contrast)
+       when home page is fully implemented */
     .accent {
       color: var(--line-blue-9, #3b82f6);
     }

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -6,23 +6,23 @@ html {
   font-family: "JetBrains Mono", monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color-scheme: light;
+  color-scheme: dark;
 }
 
-html.dark {
-  color-scheme: dark;
+html.light {
+  color-scheme: light;
 }
 
 body {
   min-height: 100dvh;
-  background-color: var(--line-gray-1, #fafafa);
-  color: var(--line-gray-12, #1a1a1a);
+  background-color: var(--line-gray-1, #111111);
+  color: var(--line-gray-12, #eeeeee);
   transition:
     background-color var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
     color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
 }
 
-html.dark body {
-  background-color: var(--line-gray-1, #111111);
-  color: var(--line-gray-12, #eeeeee);
+html.light body {
+  background-color: var(--line-gray-1, #fafafa);
+  color: var(--line-gray-12, #1a1a1a);
 }

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -10,8 +10,23 @@ html {
   font-family: "JetBrains Mono", monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
+}
+
+html.dark {
+  color-scheme: dark;
 }
 
 body {
   min-height: 100dvh;
+  background-color: var(--line-gray-1, #fafafa);
+  color: var(--line-gray-12, #1a1a1a);
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+html.dark body {
+  background-color: var(--line-gray-1, #111111);
+  color: var(--line-gray-12, #eeeeee);
 }

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -1,10 +1,6 @@
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+/* Dogfood: normalize from the theme package is imported via
+   app.ts as `import '@websublime/line-theme/normalize'`.
+   That provides box-sizing, margin reset, and base element styles. */
 
 html {
   font-family: "JetBrains Mono", monospace;
@@ -22,8 +18,8 @@ body {
   background-color: var(--line-gray-1, #fafafa);
   color: var(--line-gray-12, #1a1a1a);
   transition:
-    background-color 0.2s ease,
-    color 0.2s ease;
+    background-color var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
+    color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
 }
 
 html.dark body {

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -27,10 +27,11 @@ html.light body {
 
 /* View Transitions API — panel crossfade */
 ::view-transition-old(panel-content) {
-  animation: 180ms ease-out both fade-out;
+  animation: var(--line-duration-moderate-1, 180ms) var(--line-ease-out-2, ease-out) both fade-out;
 }
 ::view-transition-new(panel-content) {
-  animation: 260ms ease-out 80ms both fade-in-up;
+  animation: var(--line-duration-moderate-2, 260ms) var(--line-ease-out-2, ease-out) var(--line-duration-quick-1, 80ms)
+    both fade-in-up;
 }
 
 @keyframes fade-out {

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -15,8 +15,8 @@ html.light {
 
 body {
   min-height: 100dvh;
-  background-color: var(--line-gray-1, #111111);
-  color: var(--line-gray-12, #eeeeee);
+  background-color: var(--line-gray-12, #111111);
+  color: var(--line-gray-1, #eeeeee);
   transition:
     background-color var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
     color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -3,9 +3,7 @@
    That provides box-sizing, margin reset, and base element styles. */
 
 html {
-  font-family: "JetBrains Mono", monospace;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-family: "Geist", system-ui, sans-serif;
   color-scheme: dark;
 }
 
@@ -25,4 +23,28 @@ body {
 html.light body {
   background-color: var(--line-background, #fafafa);
   color: var(--line-high-contrast, #1a1a1a);
+}
+
+/* View Transitions API — panel crossfade */
+::view-transition-old(panel-content) {
+  animation: 180ms ease-out both fade-out;
+}
+::view-transition-new(panel-content) {
+  animation: 260ms ease-out 80ms both fade-in-up;
+}
+
+@keyframes fade-out {
+  to {
+    opacity: 0;
+  }
+}
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/apps/showcase/src/styles/showcase.css
+++ b/apps/showcase/src/styles/showcase.css
@@ -15,14 +15,14 @@ html.light {
 
 body {
   min-height: 100dvh;
-  background-color: var(--line-gray-12, #111111);
-  color: var(--line-gray-1, #eeeeee);
+  background-color: var(--line-background, #111111);
+  color: var(--line-high-contrast, #eeeeee);
   transition:
     background-color var(--line-duration-moderate-1, 180ms) var(--line-ease-2),
     color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
 }
 
 html.light body {
-  background-color: var(--line-gray-1, #fafafa);
-  color: var(--line-gray-12, #1a1a1a);
+  background-color: var(--line-background, #fafafa);
+  color: var(--line-high-contrast, #1a1a1a);
 }


### PR DESCRIPTION
- sc-nav: full sidebar with logo wordmark, grouped route links (Tokens/
  Semantic/Elements/Themes/Tools), active route highlight, dark/light
  mode toggle persisting to localStorage('line-mode'), schema palette
  picker (28 palettes) persisting to localStorage('line-schema'),
  mobile hamburger collapse with overlay
- app.ts: import all 11 page components, wire router to actual page
  elements instead of placeholders, render sc-nav alongside router
  outlet in a sidebar+main grid layout with responsive mobile breakpoint
- showcase.css: add color-scheme toggling, dark mode body colors,
  smooth transitions for mode switching