### PR TITLE
chore: add per-package biome.json extending root config

### DIFF
--- a/apps/showcase/biome.json
+++ b/apps/showcase/biome.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "root": false,
+  "extends": ["../../biome.json"],
+  "overrides": [
+    {
+      "includes": ["**/*.css"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnknownPseudoClass": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
   },
   "dependencies": {
     "@lit-labs/router": "^0.1.3",

--- a/biome.json
+++ b/biome.json
@@ -25,10 +25,7 @@
       },
       "correctness": {
         "noUnusedImports": "error",
-        "noUnusedVariables": "error",
-        "noUnknownMediaFeatureName": "off",
-        "noUnknownPseudoClass": "off",
-        "noInvalidDirectionInLinearGradient": "off"
+        "noUnusedVariables": "error"
       },
       "style": {
         "noParameterAssign": "error",
@@ -47,8 +44,7 @@
             "allow": ["error", "info", "group"]
           }
         },
-        "noExplicitAny": "warn",
-        "noUnknownAtRules": "off"
+        "noExplicitAny": "warn"
       },
       "performance": {
         "noBarrelFile": "warn"

--- a/packages/core/biome.json
+++ b/packages/core/biome.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "root": false,
+  "extends": ["../../biome.json"]
+}

--- a/packages/presets/biome.json
+++ b/packages/presets/biome.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "root": false,
+  "extends": ["../../biome.json"],
+  "overrides": [
+    {
+      "includes": ["**/*.css"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnknownMediaFeatureName": "off",
+            "noUnknownPseudoClass": "off",
+            "noInvalidDirectionInLinearGradient": "off"
+          },
+          "suspicious": {
+            "noUnknownAtRules": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -9,7 +9,9 @@
     "./*": "./dist/*.min.css"
   },
   "scripts": {
-    "build": "postcss src/default/index.css -o dist/preset.min.css"
+    "build": "postcss src/default/index.css -o dist/preset.min.css",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
   },
   "peerDependencies": {
     "@websublime/line-theme": "workspace:*"

--- a/packages/theme/biome.json
+++ b/packages/theme/biome.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "root": false,
+  "extends": ["../../biome.json"],
+  "overrides": [
+    {
+      "includes": ["**/*.css"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnknownMediaFeatureName": "off",
+            "noUnknownPseudoClass": "off",
+            "noInvalidDirectionInLinearGradient": "off"
+          },
+          "suspicious": {
+            "noUnknownAtRules": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -21,6 +21,8 @@
     "build": "rm -rf dist && bun run src/build.ts",
     "build:css": "bun run src/build.ts",
     "build:css:single": "bun run src/build.ts --entry",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "test": "bun test",
     "test:no-snapshot": "bun test --test-name-pattern '^(?!.*snapshot)' test/",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Move CSS-specific lint suppressions (noUnknownAtRules, noUnknownPseudoClass, noInvalidDirectionInLinearGradient, noUnknownMediaFeatureName) from the global root biome.json into per-package overrides scoped to CSS files.

- packages/core/biome.json: extends root, no overrides needed (no CSS)
- packages/theme/biome.json: extends root, CSS overrides for PostCSS at-rules
- packages/presets/biome.json: extends root, same CSS overrides as theme
- apps/showcase/biome.json: extends root, noUnknownPseudoClass for view transitions
- Root biome.json: stripped of CSS-specific suppressions (strict baseline)
- Added lint/lint:fix scripts to theme, presets, and showcase package.json