### PR TITLE
feat(showcase): implement Colors page with 6 sections per SHOWCASE-AP…

### DIFF
--- a/apps/showcase/src/components/sc-code-block.ts
+++ b/apps/showcase/src/components/sc-code-block.ts
@@ -1,14 +1,102 @@
 import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 @customElement('sc-code-block')
 export class ScCodeBlock extends LitElement {
+  /** Code content to display. */
+  @property({ type: String }) code = '';
+  /** Optional language label shown in the header. */
+  @property({ type: String }) language = 'css';
+
+  @state() private _copied = false;
+
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+    }
+
+    .block {
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-2, 4px);
+      background: var(--line-subtle-background, #161616);
+      overflow: hidden;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--line-size-1, 0.25rem) var(--line-size-3, 1rem);
+      border-bottom: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+    }
+
+    .lang {
+      font-size: 10px;
+      font-family: 'IBM Plex Mono', monospace;
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-low-contrast, #999);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .copy-btn {
+      border: none;
+      background: none;
+      font-size: 11px;
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-low-contrast, #999);
+      cursor: pointer;
+      padding: var(--line-size-1, 0.25rem) var(--line-size-2, 0.5rem);
+      border-radius: var(--line-radius-2, 4px);
+      transition: color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .copy-btn:hover {
+      color: var(--line-high-contrast, #fff);
+    }
+
+    .copy-btn.copied {
+      color: var(--line-solid-background, #c8ff00);
+    }
+
+    pre {
+      margin: 0;
+      padding: var(--line-size-3, 1rem) var(--line-size-4, 1.25rem);
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    code {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: var(--line-font-size-1, 0.75rem);
+      line-height: var(--line-lineheight-3, 1.6);
+      color: var(--line-high-contrast, #fff);
+      white-space: pre;
+    }
   `;
 
+  private _handleCopy(): void {
+    navigator.clipboard.writeText(this.code).then(() => {
+      this._copied = true;
+      setTimeout(() => {
+        this._copied = false;
+      }, 1200);
+    });
+  }
+
   override render() {
-    return html`<pre><code><slot></slot></code></pre>`;
+    return html`
+      <div class="block">
+        <div class="header">
+          <span class="lang">${this.language}</span>
+          <button
+            class="copy-btn ${this._copied ? 'copied' : ''}"
+            @click=${this._handleCopy}
+          >${this._copied ? 'Copied!' : 'Copy'}</button>
+        </div>
+        <pre><code>${this.code}</code></pre>
+      </div>
+    `;
   }
 }
 

--- a/apps/showcase/src/components/sc-code-block.ts
+++ b/apps/showcase/src/components/sc-code-block.ts
@@ -76,12 +76,18 @@ export class ScCodeBlock extends LitElement {
   `;
 
   private _handleCopy(): void {
-    navigator.clipboard.writeText(this.code).then(() => {
-      this._copied = true;
-      setTimeout(() => {
-        this._copied = false;
-      }, 1200);
-    });
+    navigator.clipboard
+      .writeText(this.code)
+      .then(() => {
+        this._copied = true;
+        setTimeout(() => {
+          this._copied = false;
+        }, 1200);
+      })
+      .catch(() => {
+        // Clipboard access denied (iframe sandbox, non-HTTPS).
+        // The button stays as "Copy" (no "Copied!" feedback), signalling the failure.
+      });
   }
 
   override render() {

--- a/apps/showcase/src/components/sc-section.ts
+++ b/apps/showcase/src/components/sc-section.ts
@@ -1,14 +1,64 @@
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 
 @customElement('sc-section')
 export class ScSection extends LitElement {
+  @property({ type: String }) heading = '';
+  @property({ type: String }) description = '';
+  @property({ type: Number }) count = 0;
+
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+      margin-bottom: var(--line-size-9, 3rem);
+    }
+
+    .header {
+      display: flex;
+      align-items: baseline;
+      gap: var(--line-size-3, 1rem);
+      margin-bottom: var(--line-size-2, 0.5rem);
+    }
+
+    h2 {
+      margin: 0;
+      font-size: var(--line-font-size-4, 1.5rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-high-contrast, #fff);
+      letter-spacing: -0.02em;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: var(--line-size-1, 0.25rem) var(--line-size-2, 0.5rem);
+      border-radius: var(--line-radius-2, 4px);
+      background: var(--line-subtle-background, #161616);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      font-size: var(--line-font-size-0, 0.5rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-low-contrast, #999);
+      font-family: 'IBM Plex Mono', monospace;
+    }
+
+    .desc {
+      margin: 0 0 var(--line-size-5, 1.5rem);
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      line-height: var(--line-lineheight-3, 1.6);
+      max-width: 64ch;
+    }
   `;
 
   override render() {
-    return html`<section><slot></slot></section>`;
+    return html`
+      <div class="header">
+        <h2>${this.heading}</h2>
+        ${this.count > 0 ? html`<span class="badge">${this.count} tokens</span>` : nothing}
+      </div>
+      ${this.description ? html`<p class="desc">${this.description}</p>` : nothing}
+      <slot></slot>
+    `;
   }
 }
 

--- a/apps/showcase/src/components/sc-swatch.ts
+++ b/apps/showcase/src/components/sc-swatch.ts
@@ -148,12 +148,18 @@ export class ScSwatch extends LitElement {
 
   private _handleClick(): void {
     const text = this._tokenVar;
-    navigator.clipboard.writeText(text).then(() => {
-      this._copied = true;
-      setTimeout(() => {
-        this._copied = false;
-      }, 700);
-    });
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        this._copied = true;
+        setTimeout(() => {
+          this._copied = false;
+        }, 700);
+      })
+      .catch(() => {
+        // Clipboard access denied (iframe sandbox, non-HTTPS).
+        // No visual feedback is shown, which signals the failure to the user.
+      });
   }
 
   private _handleMouseEnter(): void {

--- a/apps/showcase/src/components/sc-swatch.ts
+++ b/apps/showcase/src/components/sc-swatch.ts
@@ -1,14 +1,195 @@
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+import type { PaletteLevel } from '../constants.js';
+
+export type SwatchSize = 'sm' | 'md' | 'lg';
 
 @customElement('sc-swatch')
 export class ScSwatch extends LitElement {
+  @property({ type: String }) palette = '';
+  @property({ type: Number }) level: PaletteLevel = 9;
+  @property({ type: String }) size: SwatchSize = 'md';
+  /** Optional label shown below the swatch. */
+  @property({ type: String }) label = '';
+  /** Optional semantic role description for tooltip. */
+  @property({ type: String, attribute: 'semantic-role' }) semanticRole = '';
+  /** If true, shows the active indicator ring. */
+  @property({ type: Boolean, reflect: true }) active = false;
+
+  @state() private _copied = false;
+  @state() private _hovered = false;
+  @state() private _resolvedColor = '';
+
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: inline-block;
+      position: relative;
+    }
+
+    .swatch {
+      border-radius: var(--line-radius-2, 4px);
+      cursor: pointer;
+      position: relative;
+      transition:
+        transform var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        box-shadow var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .swatch:hover {
+      transform: scale(1.08);
+      z-index: 1;
+    }
+
+    .swatch.sm {
+      width: 32px;
+      height: 32px;
+    }
+
+    .swatch.md {
+      width: 56px;
+      height: 56px;
+    }
+
+    .swatch.lg {
+      width: 80px;
+      height: 80px;
+    }
+
+    :host([active]) .swatch {
+      box-shadow:
+        0 0 0 2px var(--line-background, #111),
+        0 0 0 4px var(--line-solid-background, #c8ff00);
+    }
+
+    .label {
+      display: block;
+      margin-top: var(--line-size-1, 0.25rem);
+      font-size: 10px;
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-low-contrast, #999);
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* ── Tooltip ── */
+    .tooltip {
+      position: absolute;
+      bottom: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%);
+      padding: var(--line-size-2, 0.5rem) var(--line-size-3, 1rem);
+      background: var(--line-subtle-background, #161616);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-2, 4px);
+      font-size: 11px;
+      color: var(--line-high-contrast, #fff);
+      white-space: nowrap;
+      pointer-events: none;
+      z-index: var(--line-z-popup, 200);
+      opacity: 0;
+      transition: opacity var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .tooltip.visible {
+      opacity: 1;
+    }
+
+    .tooltip-token {
+      font-family: 'IBM Plex Mono', monospace;
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-solid-background, #c8ff00);
+    }
+
+    .tooltip-resolved {
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-low-contrast, #999);
+      margin-top: 2px;
+    }
+
+    .tooltip-role {
+      color: var(--line-low-contrast, #999);
+      margin-top: 2px;
+      font-style: italic;
+    }
+
+    /* ── Copy feedback ── */
+    .copied-badge {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.6);
+      border-radius: var(--line-radius-2, 4px);
+      color: #fff;
+      font-size: 16px;
+      pointer-events: none;
+      animation: fade-out 600ms var(--line-ease-2) forwards;
+    }
+
+    @keyframes fade-out {
+      0% { opacity: 1; }
+      70% { opacity: 1; }
+      100% { opacity: 0; }
+    }
   `;
 
+  private get _tokenName(): string {
+    return `--line-${this.palette}-${this.level}`;
+  }
+
+  private get _tokenVar(): string {
+    return `var(${this._tokenName})`;
+  }
+
+  private _handleClick(): void {
+    const text = this._tokenVar;
+    navigator.clipboard.writeText(text).then(() => {
+      this._copied = true;
+      setTimeout(() => {
+        this._copied = false;
+      }, 700);
+    });
+  }
+
+  private _handleMouseEnter(): void {
+    this._hovered = true;
+    // Resolve computed color value from the host document
+    const resolved = getComputedStyle(document.documentElement).getPropertyValue(this._tokenName).trim();
+    this._resolvedColor = resolved || '(unresolved)';
+  }
+
+  private _handleMouseLeave(): void {
+    this._hovered = false;
+  }
+
   override render() {
-    return html`<div class="swatch"><slot></slot></div>`;
+    const bgStyle = styleMap({
+      'background-color': this._tokenVar
+    });
+
+    return html`
+      <div class="tooltip ${classMap({ visible: this._hovered })}">
+        <div class="tooltip-token">${this._tokenName}</div>
+        <div class="tooltip-resolved">${this._resolvedColor}</div>
+        ${this.semanticRole ? html`<div class="tooltip-role">${this.semanticRole}</div>` : nothing}
+      </div>
+      <div
+        class="swatch ${this.size}"
+        style=${bgStyle}
+        @click=${this._handleClick}
+        @mouseenter=${this._handleMouseEnter}
+        @mouseleave=${this._handleMouseLeave}
+        title="${this._tokenName}"
+      >
+        ${this._copied ? html`<div class="copied-badge">&#10003;</div>` : nothing}
+      </div>
+      ${this.label ? html`<span class="label">${this.label}</span>` : nothing}
+    `;
   }
 }
 

--- a/apps/showcase/src/components/sc-swatch.ts
+++ b/apps/showcase/src/components/sc-swatch.ts
@@ -123,9 +123,9 @@ export class ScSwatch extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(0, 0, 0, 0.6);
+      background: color-mix(in srgb, var(--line-background, #111) 60%, transparent);
       border-radius: var(--line-radius-2, 4px);
-      color: #fff;
+      color: var(--line-high-contrast, #fff);
       font-size: 16px;
       pointer-events: none;
       animation: fade-out 600ms var(--line-ease-2) forwards;

--- a/apps/showcase/src/constants.ts
+++ b/apps/showcase/src/constants.ts
@@ -35,7 +35,53 @@ export const ALL_SCHEMAS = [
 
 export type SchemaName = (typeof ALL_SCHEMAS)[number];
 
+/** Type alias — palette names and schema names are identical. */
+export type PaletteName = SchemaName;
+
 /** Type-safe check that a string is a valid schema name. */
 export function isValidSchema(value: string): value is SchemaName {
   return (ALL_SCHEMAS as readonly string[]).includes(value);
 }
+
+/** All 12 palette levels (1-based). */
+export const PALETTE_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+
+export type PaletteLevel = (typeof PALETTE_LEVELS)[number];
+
+/**
+ * Semantic role description for each palette level.
+ * Sourced from the schema CSS mapping (see packages/theme/src/schemas/*.css).
+ */
+export const LEVEL_ROLES: Record<PaletteLevel, string> = {
+  1: 'App background',
+  2: 'Subtle background',
+  3: 'UI element background',
+  4: 'Hovered UI element background',
+  5: 'Active / Selected UI element background',
+  6: 'Subtle borders and separators',
+  7: 'UI element border and focus rings',
+  8: 'Hovered UI element border',
+  9: 'Solid backgrounds',
+  10: 'Hovered solid backgrounds',
+  11: 'Low-contrast text',
+  12: 'High-contrast text'
+};
+
+/**
+ * Semantic token name for each palette level.
+ * Maps the 12-level scale to the semantic CSS custom property names.
+ */
+export const LEVEL_SEMANTIC_TOKENS: Record<PaletteLevel, string> = {
+  1: '--line-background',
+  2: '--line-subtle-background',
+  3: '--line-ui-background',
+  4: '--line-ui-hover-background',
+  5: '--line-ui-active-background',
+  6: '--line-subtle-border',
+  7: '--line-ui-border',
+  8: '--line-ui-border-hover',
+  9: '--line-solid-background',
+  10: '--line-solid-hover',
+  11: '--line-low-contrast',
+  12: '--line-high-contrast'
+};

--- a/apps/showcase/src/pages/colors.ts
+++ b/apps/showcase/src/pages/colors.ts
@@ -195,9 +195,9 @@ export class ScPageColors extends LitElement {
       border-radius: var(--line-radius-2, 4px);
     }
 
-    .pass-aa { background: rgba(34, 197, 94, 0.2); color: #22c55e; }
-    .pass-aaa { background: rgba(34, 197, 94, 0.3); color: #22c55e; }
-    .fail { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+    .pass-aa { background: color-mix(in srgb, var(--line-green-9) 20%, transparent); color: var(--line-green-9); }
+    .pass-aaa { background: color-mix(in srgb, var(--line-green-9) 30%, transparent); color: var(--line-green-9); }
+    .fail { background: color-mix(in srgb, var(--line-red-9) 20%, transparent); color: var(--line-red-9); }
 
     .contrast-tokens {
       font-family: 'IBM Plex Mono', monospace;
@@ -420,8 +420,8 @@ export class ScPageColors extends LitElement {
       transform: translateX(-50%);
       font-size: 9px;
       font-family: 'IBM Plex Mono', monospace;
-      color: rgba(255, 255, 255, 0.7);
-      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+      color: var(--line-high-contrast, #fff);
+      text-shadow: 0 1px 2px color-mix(in srgb, var(--line-background, #111) 50%, transparent);
     }
 
     .mix-code {

--- a/apps/showcase/src/pages/colors.ts
+++ b/apps/showcase/src/pages/colors.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, nothing } from 'lit';
+import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -457,8 +457,10 @@ export class ScPageColors extends LitElement {
     }
   }
 
-  override updated(): void {
-    this._computeContrast();
+  protected override willUpdate(changed: PropertyValues): void {
+    if (changed.has('_activePalette')) {
+      this._computeContrast();
+    }
   }
 
   private _computeContrast(): void {

--- a/apps/showcase/src/pages/colors.ts
+++ b/apps/showcase/src/pages/colors.ts
@@ -1,14 +1,791 @@
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+import { ALL_SCHEMAS, LEVEL_ROLES, LEVEL_SEMANTIC_TOKENS, PALETTE_LEVELS, type PaletteName } from '../constants.js';
+
+import '../components/sc-section.js';
+import '../components/sc-swatch.js';
+import '../components/sc-code-block.js';
+
+/**
+ * Compute relative luminance from an RGB triplet (0-255).
+ * Used for WCAG contrast ratio calculation.
+ */
+function relativeLuminance(r: number, g: number, b: number): number {
+  const [rs, gs, bs] = [r / 255, g / 255, b / 255].map((c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  );
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+}
+
+/** WCAG contrast ratio between two luminances. */
+function contrastRatio(l1: number, l2: number): number {
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Parse a CSS color string to RGB. Works with rgb(), hsl(), hex, and
+ * color function outputs from getComputedStyle.
+ */
+function parseColorToRgb(color: string): { r: number; g: number; b: number } | null {
+  // Try using an offscreen canvas to resolve any CSS color to RGB
+  if (typeof OffscreenCanvas !== 'undefined') {
+    try {
+      const canvas = new OffscreenCanvas(1, 1);
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, 1, 1);
+        const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+        return { r, g, b };
+      }
+    } catch {
+      // Fallback below
+    }
+  }
+
+  // Regex fallback for rgb(r, g, b) / rgba(r, g, b, a)
+  const rgbMatch = color.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/);
+  if (rgbMatch) {
+    return {
+      r: Number(rgbMatch[1]),
+      g: Number(rgbMatch[2]),
+      b: Number(rgbMatch[3])
+    };
+  }
+
+  // Hex fallback
+  const hexMatch = color.match(/^#([0-9a-f]{3,8})$/i);
+  if (hexMatch) {
+    let hex = hexMatch[1];
+    if (hex.length === 3) {
+      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    }
+    return {
+      r: Number.parseInt(hex.slice(0, 2), 16),
+      g: Number.parseInt(hex.slice(2, 4), 16),
+      b: Number.parseInt(hex.slice(4, 6), 16)
+    };
+  }
+
+  return null;
+}
 
 @customElement('sc-page-colors')
 export class ScPageColors extends LitElement {
+  /** Currently active/inspected palette. */
+  @state() private _activePalette: PaletteName = 'violet';
+
+  /** Color-mix: palette A. */
+  @state() private _mixPaletteA: PaletteName = 'blue';
+  /** Color-mix: palette B. */
+  @state() private _mixPaletteB: PaletteName = 'red';
+  /** Color-mix: blend percentage (0 = all A, 100 = all B). */
+  @state() private _mixPercent = 50;
+
+  /** Contrast ratio computed for the active palette level-9 vs contrast token. */
+  @state() private _contrastRatio = 0;
+  @state() private _contrastBgColor = '';
+  @state() private _contrastFgColor = '';
+
+  /** Expanded palettes in the full explorer (Section 4). */
+  @state() private _expandedPalettes = new Set<PaletteName>();
+
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+    }
+
+    .page-title {
+      font-size: var(--line-font-size-6, 2rem);
+      font-weight: var(--line-font-weight-8, 800);
+      color: var(--line-high-contrast, #fff);
+      letter-spacing: -0.03em;
+      margin: 0 0 var(--line-size-2, 0.5rem);
+    }
+
+    .page-subtitle {
+      font-size: var(--line-font-size-2, 1rem);
+      color: var(--line-low-contrast, #999);
+      margin: 0 0 var(--line-size-8, 2.5rem);
+      line-height: var(--line-lineheight-3, 1.6);
+    }
+
+    .page-subtitle strong {
+      color: var(--line-high-contrast, #fff);
+      font-weight: var(--line-font-weight-6, 600);
+    }
+
+    /* ── Section 1: Active palette strip ── */
+    .strip-grid {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: var(--line-size-2, 0.5rem);
+    }
+
+    .strip-cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--line-size-1, 0.25rem);
+    }
+
+    .strip-level {
+      font-size: 10px;
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-low-contrast, #999);
+      text-align: center;
+    }
+
+    .strip-semantic {
+      font-size: 9px;
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-low-contrast, #999);
+      text-align: center;
+      max-width: 72px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* ── Section 2: Contrast demo ── */
+    .contrast-box {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: var(--line-size-3, 1rem);
+      padding: var(--line-size-7, 2rem) var(--line-size-5, 1.5rem);
+      border-radius: var(--line-radius-3, 8px);
+      min-height: 120px;
+    }
+
+    .contrast-text {
+      font-size: var(--line-font-size-5, 1.75rem);
+      font-weight: var(--line-font-weight-8, 800);
+      letter-spacing: -0.02em;
+    }
+
+    .contrast-meta {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-4, 1.25rem);
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .contrast-ratio-badge {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: var(--line-font-size-2, 1rem);
+      font-weight: var(--line-font-weight-7, 700);
+      padding: var(--line-size-1, 0.25rem) var(--line-size-3, 1rem);
+      border-radius: var(--line-radius-2, 4px);
+      background: rgba(0, 0, 0, 0.3);
+    }
+
+    .contrast-pass {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      padding: var(--line-size-1, 0.25rem) var(--line-size-2, 0.5rem);
+      border-radius: var(--line-radius-2, 4px);
+    }
+
+    .pass-aa { background: rgba(34, 197, 94, 0.2); color: #22c55e; }
+    .pass-aaa { background: rgba(34, 197, 94, 0.3); color: #22c55e; }
+    .fail { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+
+    .contrast-tokens {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      opacity: 0.8;
+    }
+
+    /* ── Section 3: All palettes mini grid ── */
+    .palettes-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+      gap: var(--line-size-3, 1rem);
+    }
+
+    .palette-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--line-size-1, 0.25rem);
+      cursor: pointer;
+      padding: var(--line-size-2, 0.5rem);
+      border-radius: var(--line-radius-2, 4px);
+      border: var(--line-border-size-1, 1px) solid transparent;
+      transition:
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        background var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .palette-card:hover {
+      border-color: var(--line-ui-background, #222);
+      background: var(--line-subtle-background, #161616);
+    }
+
+    .palette-card.active {
+      border-color: var(--line-solid-background, #c8ff00);
+      background: var(--line-subtle-background, #161616);
+    }
+
+    .palette-dot {
+      width: 40px;
+      height: 40px;
+      border-radius: var(--line-radius-2, 4px);
+    }
+
+    .palette-name {
+      font-size: 11px;
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-low-contrast, #999);
+      text-align: center;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+
+    .palette-card.active .palette-name {
+      color: var(--line-high-contrast, #fff);
+    }
+
+    /* ── Section 4: Full palette explorer ── */
+    .explorer-palette {
+      margin-bottom: var(--line-size-3, 1rem);
+    }
+
+    .explorer-header {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-3, 1rem);
+      padding: var(--line-size-2, 0.5rem) var(--line-size-3, 1rem);
+      border-radius: var(--line-radius-2, 4px);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      cursor: pointer;
+      background: transparent;
+      font-family: inherit;
+      width: 100%;
+      box-sizing: border-box;
+      transition:
+        background var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .explorer-header:hover {
+      background: var(--line-subtle-background, #161616);
+      border-color: var(--line-ui-active-background, #333);
+    }
+
+    .explorer-header.expanded {
+      border-color: var(--line-solid-background, #c8ff00);
+      background: var(--line-subtle-background, #161616);
+    }
+
+    .explorer-preview {
+      display: flex;
+      gap: 2px;
+      flex: 1;
+    }
+
+    .explorer-preview-dot {
+      flex: 1;
+      height: 8px;
+      border-radius: 1px;
+    }
+
+    .explorer-name {
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-low-contrast, #999);
+      min-width: 60px;
+    }
+
+    .explorer-header.expanded .explorer-name {
+      color: var(--line-high-contrast, #fff);
+    }
+
+    .explorer-chevron {
+      font-size: 12px;
+      color: var(--line-low-contrast, #999);
+      transition: transform var(--line-duration-quick-2, 120ms) var(--line-ease-2);
+    }
+
+    .explorer-chevron.expanded {
+      transform: rotate(90deg);
+    }
+
+    .explorer-body {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: var(--line-size-2, 0.5rem);
+      padding: var(--line-size-3, 1rem) 0;
+    }
+
+    /* ── Section 5: Color-mix demo ── */
+    .mix-controls {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-4, 1.25rem);
+      margin-bottom: var(--line-size-5, 1.5rem);
+      flex-wrap: wrap;
+    }
+
+    .mix-selector {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-2, 0.5rem);
+    }
+
+    .mix-selector-label {
+      font-size: 11px;
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-low-contrast, #999);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .mix-cycle-btn {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-1, 0.25rem);
+      padding: var(--line-size-1, 0.25rem) var(--line-size-3, 1rem);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-2, 4px);
+      background: transparent;
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-high-contrast, #fff);
+      cursor: pointer;
+      transition:
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        background var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .mix-cycle-btn:hover {
+      border-color: var(--line-ui-border, #444);
+      background: var(--line-subtle-background, #161616);
+    }
+
+    .mix-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+    }
+
+    .mix-range-group {
+      display: flex;
+      align-items: center;
+      gap: var(--line-size-2, 0.5rem);
+      flex: 1;
+      min-width: 200px;
+    }
+
+    .mix-range {
+      flex: 1;
+      accent-color: var(--line-solid-background, #c8ff00);
+    }
+
+    .mix-pct {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-high-contrast, #fff);
+      min-width: 40px;
+      text-align: right;
+    }
+
+    .mix-strip {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: var(--line-size-1, 0.25rem);
+    }
+
+    .mix-swatch {
+      height: 56px;
+      border-radius: var(--line-radius-2, 4px);
+      position: relative;
+    }
+
+    .mix-swatch-label {
+      position: absolute;
+      bottom: 4px;
+      left: 50%;
+      transform: translateX(-50%);
+      font-size: 9px;
+      font-family: 'IBM Plex Mono', monospace;
+      color: rgba(255, 255, 255, 0.7);
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    }
+
+    .mix-code {
+      margin-top: var(--line-size-4, 1.25rem);
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .strip-grid {
+        grid-template-columns: repeat(6, 1fr);
+      }
+      .explorer-body {
+        grid-template-columns: repeat(6, 1fr);
+      }
+      .mix-strip {
+        grid-template-columns: repeat(6, 1fr);
+      }
+    }
   `;
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    // Try to use the active schema from body class as the initial palette
+    const bodyClasses = document.body.classList;
+    for (const cls of bodyClasses) {
+      if (cls.startsWith('line-schema-')) {
+        const schema = cls.replace('line-schema-', '') as PaletteName;
+        if ((ALL_SCHEMAS as readonly string[]).includes(schema)) {
+          this._activePalette = schema;
+          break;
+        }
+      }
+    }
+  }
+
+  override updated(): void {
+    this._computeContrast();
+  }
+
+  private _computeContrast(): void {
+    const root = document.documentElement;
+    const style = getComputedStyle(root);
+
+    const bg = style.getPropertyValue(`--line-${this._activePalette}-9`).trim();
+    const fg = style.getPropertyValue(`--line-${this._activePalette}-contrast`).trim();
+
+    if (!(bg && fg)) return;
+
+    const bgRgb = parseColorToRgb(bg);
+    const fgRgb = parseColorToRgb(fg);
+
+    if (bgRgb && fgRgb) {
+      const bgLum = relativeLuminance(bgRgb.r, bgRgb.g, bgRgb.b);
+      const fgLum = relativeLuminance(fgRgb.r, fgRgb.g, fgRgb.b);
+      this._contrastRatio = contrastRatio(bgLum, fgLum);
+    }
+
+    this._contrastBgColor = bg;
+    this._contrastFgColor = fg;
+  }
+
+  private _setActivePalette(palette: PaletteName): void {
+    this._activePalette = palette;
+  }
+
+  private _toggleExplorer(palette: PaletteName): void {
+    const next = new Set(this._expandedPalettes);
+    if (next.has(palette)) {
+      next.delete(palette);
+    } else {
+      next.add(palette);
+    }
+    this._expandedPalettes = next;
+  }
+
+  private _cycleMixPalette(which: 'a' | 'b'): void {
+    const current = which === 'a' ? this._mixPaletteA : this._mixPaletteB;
+    const i = (ALL_SCHEMAS as readonly string[]).indexOf(current);
+    const next = ALL_SCHEMAS[(i + 1) % ALL_SCHEMAS.length];
+    if (which === 'a') {
+      this._mixPaletteA = next;
+    } else {
+      this._mixPaletteB = next;
+    }
+  }
+
+  private _handleMixRange(e: Event): void {
+    this._mixPercent = Number((e.target as HTMLInputElement).value);
+  }
+
+  // ── Render helpers ──
+
+  private _renderActivePaletteStrip() {
+    return html`
+      <sc-section
+        heading="Active Palette"
+        description="The 12-step scale for ${this._activePalette}. Hover for token details, click to copy."
+        .count=${12}
+      >
+        <div class="strip-grid">
+          ${PALETTE_LEVELS.map(
+            (level) => html`
+            <div class="strip-cell">
+              <sc-swatch
+                palette=${this._activePalette}
+                .level=${level}
+                size="md"
+                semantic-role=${LEVEL_ROLES[level]}
+              ></sc-swatch>
+              <span class="strip-level">${level}</span>
+              <span class="strip-semantic">${LEVEL_SEMANTIC_TOKENS[level].replace('--line-', '')}</span>
+            </div>
+          `
+          )}
+        </div>
+      </sc-section>
+    `;
+  }
+
+  private _renderWcagBadge(label: string, passes: boolean) {
+    const cls = passes ? 'pass-aa' : 'fail';
+    const text = passes ? 'Pass' : 'Fail';
+    return html`<span class="contrast-pass ${cls}">${label} ${text}</span>`;
+  }
+
+  private _renderContrastDemo() {
+    const ratio = this._contrastRatio;
+    const hasRatio = ratio > 0;
+
+    return html`
+      <sc-section
+        heading="Contrast Token"
+        description="The contrast token defines readable text color on solid-9 backgrounds. WCAG 2.1 requires 4.5:1 for normal text (AA) and 7:1 for enhanced (AAA)."
+        .count=${1}
+      >
+        <div
+          class="contrast-box"
+          style=${styleMap({
+            'background-color': `var(--line-${this._activePalette}-9)`,
+            color: `var(--line-${this._activePalette}-contrast)`
+          })}
+        >
+          <span class="contrast-text">
+            The quick brown fox jumps over the lazy dog
+          </span>
+          <div class="contrast-meta">
+            <span class="contrast-ratio-badge">
+              ${hasRatio ? `${ratio.toFixed(2)}:1` : 'Computing...'}
+            </span>
+            ${
+              hasRatio
+                ? html`
+              ${this._renderWcagBadge('AAA', ratio >= 7)}
+              ${this._renderWcagBadge('AA', ratio >= 4.5)}
+              ${this._renderWcagBadge('AA Large', ratio >= 3)}
+            `
+                : nothing
+            }
+          </div>
+          <div class="contrast-tokens">
+            bg: --line-${this._activePalette}-9 (${this._contrastBgColor})
+            &nbsp;&middot;&nbsp;
+            fg: --line-${this._activePalette}-contrast (${this._contrastFgColor})
+          </div>
+        </div>
+      </sc-section>
+    `;
+  }
+
+  private _renderAllPalettesGrid() {
+    return html`
+      <sc-section
+        heading="All Palettes"
+        description="28 palettes at level 9. Click to switch the active palette."
+        .count=${28}
+      >
+        <div class="palettes-grid">
+          ${ALL_SCHEMAS.map(
+            (name) => html`
+            <div
+              class=${classMap({
+                'palette-card': true,
+                active: this._activePalette === name
+              })}
+              @click=${() => this._setActivePalette(name)}
+            >
+              <div
+                class="palette-dot"
+                style=${styleMap({
+                  'background-color': `var(--line-${name}-9)`
+                })}
+              ></div>
+              <span class="palette-name">${name}</span>
+            </div>
+          `
+          )}
+        </div>
+      </sc-section>
+    `;
+  }
+
+  private _renderFullExplorer() {
+    return html`
+      <sc-section
+        heading="Full Palette Explorer"
+        description="Expand any palette to inspect all 12 levels. Click a swatch to copy its token."
+        .count=${364}
+      >
+        ${ALL_SCHEMAS.map((name) => {
+          const expanded = this._expandedPalettes.has(name);
+          return html`
+            <div class="explorer-palette">
+              <button
+                class=${classMap({
+                  'explorer-header': true,
+                  expanded
+                })}
+                @click=${() => this._toggleExplorer(name)}
+              >
+                <span class=${classMap({
+                  'explorer-chevron': true,
+                  expanded
+                })}>&#9654;</span>
+                <span class="explorer-name">${name}</span>
+                <div class="explorer-preview">
+                  ${PALETTE_LEVELS.map(
+                    (level) => html`
+                    <div
+                      class="explorer-preview-dot"
+                      style=${styleMap({
+                        'background-color': `var(--line-${name}-${level})`
+                      })}
+                    ></div>
+                  `
+                  )}
+                </div>
+              </button>
+              ${
+                expanded
+                  ? html`
+                  <div class="explorer-body">
+                    ${PALETTE_LEVELS.map(
+                      (level) => html`
+                      <sc-swatch
+                        palette=${name}
+                        .level=${level}
+                        size="md"
+                        label="${level}"
+                        semantic-role=${LEVEL_ROLES[level]}
+                      ></sc-swatch>
+                    `
+                    )}
+                  </div>
+                `
+                  : nothing
+              }
+            </div>
+          `;
+        })}
+      </sc-section>
+    `;
+  }
+
+  private _renderColorMixDemo() {
+    const pctB = this._mixPercent;
+    const code = `/* color-mix in oklch */
+.mixed {
+  background: color-mix(
+    in oklch,
+    var(--line-${this._mixPaletteA}-9),
+    var(--line-${this._mixPaletteB}-9) ${pctB}%
+  );
+}`;
+
+    return html`
+      <sc-section
+        heading="Color-Mix Demo"
+        description="Blend two palette scales using CSS color-mix(in oklch). Requires Chrome 111+, Safari 16.2+, Firefox 113+."
+      >
+        <div class="mix-controls">
+          <div class="mix-selector">
+            <span class="mix-selector-label">A</span>
+            <button
+              class="mix-cycle-btn"
+              @click=${() => this._cycleMixPalette('a')}
+            >
+              <span
+                class="mix-dot"
+                style=${styleMap({
+                  'background-color': `var(--line-${this._mixPaletteA}-9)`
+                })}
+              ></span>
+              ${this._mixPaletteA}
+            </button>
+          </div>
+
+          <div class="mix-range-group">
+            <input
+              class="mix-range"
+              type="range"
+              min="0"
+              max="100"
+              .value=${String(this._mixPercent)}
+              @input=${this._handleMixRange}
+            />
+            <span class="mix-pct">${pctB}%</span>
+          </div>
+
+          <div class="mix-selector">
+            <span class="mix-selector-label">B</span>
+            <button
+              class="mix-cycle-btn"
+              @click=${() => this._cycleMixPalette('b')}
+            >
+              <span
+                class="mix-dot"
+                style=${styleMap({
+                  'background-color': `var(--line-${this._mixPaletteB}-9)`
+                })}
+              ></span>
+              ${this._mixPaletteB}
+            </button>
+          </div>
+        </div>
+
+        <div class="mix-strip">
+          ${PALETTE_LEVELS.map(
+            (level) => html`
+            <div
+              class="mix-swatch"
+              style=${styleMap({
+                background: `color-mix(in oklch, var(--line-${this._mixPaletteA}-${level}), var(--line-${this._mixPaletteB}-${level}) ${pctB}%)`
+              })}
+            >
+              <span class="mix-swatch-label">${level}</span>
+            </div>
+          `
+          )}
+        </div>
+
+        <div class="mix-code">
+          <sc-code-block
+            .code=${code}
+            language="css"
+          ></sc-code-block>
+        </div>
+      </sc-section>
+    `;
+  }
+
   override render() {
-    return html`<h2>Colors</h2><p>L0: 28 palettes x 12 levels</p>`;
+    return html`
+      <h1 class="page-title">Color Palettes</h1>
+      <p class="page-subtitle">
+        <strong>28 palettes</strong> x <strong>12 levels</strong> + 28 contrast tokens = <strong>364</strong> color tokens.
+        Click any swatch to copy its CSS custom property reference.
+      </p>
+
+      ${this._renderActivePaletteStrip()}
+      ${this._renderContrastDemo()}
+      ${this._renderAllPalettesGrid()}
+      ${this._renderFullExplorer()}
+      ${this._renderColorMixDemo()}
+    `;
   }
 }
 


### PR DESCRIPTION
…P-SPEC §4.2

- Add PALETTE_LEVELS, LEVEL_ROLES, LEVEL_SEMANTIC_TOKENS to constants.ts
- Build sc-swatch: color preview with hover tooltip, click-to-copy, size variants
- Build sc-section: heading, description, token count badge, content slot
- Build sc-code-block: syntax display with copy-to-clipboard button
- Implement sc-page-colors with all 6 spec sections:
  1. Active palette strip (12-step grid with semantic role labels)
  2. Contrast token demo (WCAG AA/AAA ratio with live computation)
  3. All 28 palettes mini grid (click to switch active palette)
  4. Full palette explorer (expandable/collapsible per-palette view)
  5. Color-mix demo (oklch blending with range slider + code preview)
  6. Copy-to-clipboard (integrated into sc-swatch click handler)
- All UI colors use semantic tokens per Decision D6