### PR TITLE
chore(showcase): remove unused @lit-labs/router dependency

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -11,7 +11,6 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
-    "@lit-labs/router": "^0.1.3",
     "@websublime/line-theme": "workspace:*",
     "culori": "^4.0.1",
     "lit": "^3.2.1"

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
       "name": "@websublime/showcase",
       "version": "0.0.0",
       "dependencies": {
-        "@lit-labs/router": "^0.1.3",
         "@websublime/line-theme": "workspace:*",
         "culori": "^4.0.1",
         "lit": "^3.2.1",
@@ -263,8 +262,6 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
-
-    "@lit-labs/router": ["@lit-labs/router@0.1.4", "", { "dependencies": { "lit": "^2.0.0 || ^3.0.0" } }, "sha512-xURH6fOPE0MYfXa1nyl+qTIhZRVWkFa2oggTRodKAI2q/HjA2Va7HEKe7fMm8DdnFE+zEI2aUGnStawKpVh3lQ=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 


### PR DESCRIPTION
The showcase app switched to panel-based navigation (Decision D2) but the @lit-labs/router dependency was never cleaned up. No code references this package.