### PR TITLE
chore(presets): remove premature CSS rule suppressions from biome.json

### DIFF
--- a/packages/presets/biome.json
+++ b/packages/presets/biome.json
@@ -1,22 +1,5 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
   "root": false,
-  "extends": ["../../biome.json"],
-  "overrides": [
-    {
-      "includes": ["**/*.css"],
-      "linter": {
-        "rules": {
-          "correctness": {
-            "noUnknownMediaFeatureName": "off",
-            "noUnknownPseudoClass": "off",
-            "noInvalidDirectionInLinearGradient": "off"
-          },
-          "suspicious": {
-            "noUnknownAtRules": "off"
-          }
-        }
-      }
-    }
-  ]
+  "extends": ["../../biome.json"]
 }


### PR DESCRIPTION
The presets package biome.json suppressed four CSS-specific Biome rules (noUnknownAtRules, noUnknownPseudoClass, noInvalidDirectionInLinearGradient, noUnknownMediaFeatureName) that were copied from theme's config proactively. Since presets has zero CSS content triggering these rules (only a stub index.css exists), the suppressions provide no value and silently hide future misconfigurations. Removed them; they can be re-added just-in-time when presets gains PostCSS files that legitimately require them.