### PR TITLE
chore(showcase): replace hardcoded rgba with color-mix token in contr…

### DIFF
--- a/apps/showcase/src/pages/colors.ts
+++ b/apps/showcase/src/pages/colors.ts
@@ -184,7 +184,7 @@ export class ScPageColors extends LitElement {
       font-weight: var(--line-font-weight-7, 700);
       padding: var(--line-size-1, 0.25rem) var(--line-size-3, 1rem);
       border-radius: var(--line-radius-2, 4px);
-      background: rgba(0, 0, 0, 0.3);
+      background: color-mix(in srgb, var(--line-black) 30%, transparent);
     }
 
     .contrast-pass {


### PR DESCRIPTION
…ast-ratio-badge

Use color-mix(in srgb, var(--line-black) 30%, transparent) instead of rgba(0, 0, 0, 0.3) to follow the token-first principle established by the adjacent .pass-aa, .pass-aaa, and .fail classes.