### PR TITLE
chore(theme): add inline comment explaining Open Props --line-font-si…

### DIFF
--- a/packages/theme/src/tokens/typography.css
+++ b/packages/theme/src/tokens/typography.css
@@ -87,6 +87,9 @@
 
 :where(html) {
   --line-font-size-0: 0.5rem;
+  /* Open Props convention: the double-zero suffix (00) denotes a half-step
+     between 0 and 1, not a value below 0. The name sorts after 0 alphabetically
+     but the value (0.625rem) sits between 0 (0.5rem) and 1 (0.75rem). */
   --line-font-size-00: 0.625rem;
   --line-font-size-1: 0.75rem;
   --line-font-size-2: 1rem;


### PR DESCRIPTION
…ze-00 ordering convention

The double-zero suffix denotes a half-step between 0 and 1, not a value below 0. This prevents developer confusion since the name sorts after 0 alphabetically yet the value sits between 0 and 1.