### PR TITLE
docs(theme): add clarifying comments to sizing token sub-zero convention

### DIFF
--- a/packages/theme/src/tokens/sizing.css
+++ b/packages/theme/src/tokens/sizing.css
@@ -11,6 +11,10 @@
 /* ── Rem Sizes (17) ── */
 
 :where(html) {
+  /* Sizing convention: the 000 and 00 suffixes denote sub-zero negative values,
+     not half-steps. Unlike --line-font-size-00 (a positive half-step between 0
+     and 1 per Open Props convention), these are true negatives useful for
+     negative margins, insets, and offset adjustments. */
   --line-size-000: -0.5rem;
   --line-size-00: -0.25rem;
   --line-size-1: 0.25rem;
@@ -33,6 +37,7 @@
 /* ── Px Sizes (17) ── */
 
 :where(html) {
+  /* Same sub-zero convention as rem sizes — see comment above. */
   --line-size-px-000: -8px;
   --line-size-px-00: -4px;
   --line-size-px-1: 4px;
@@ -98,6 +103,7 @@
 /* ── Relative / ch-based (17) ── */
 
 :where(html) {
+  /* Same sub-zero convention as rem sizes — see comment above. */
   --line-size-relative-000: -0.5ch;
   --line-size-relative-00: -0.25ch;
   --line-size-relative-1: 0.25ch;


### PR DESCRIPTION
The 000/00 suffixes in sizing tokens use negative values (unlike --line-font-size-00 which is a positive half-step per Open Props convention). Added inline comments to rem, px, and relative/ch sizing blocks to prevent developer confusion about this difference.

Resolves line-ui-p3v.42