### PR TITLE
feat(showcase): implement home page with hero, stats, code snippet, a…

### DIFF
--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -73,12 +73,13 @@ export class ScApp extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
-    // Restore persisted mode
+    // Restore persisted mode — fall back to OS preference
     const storedMode = localStorage.getItem('line-mode');
-    if (storedMode === 'light') {
-      this._light = true;
+    if (storedMode === 'light' || storedMode === 'dark') {
+      this._light = storedMode === 'light';
+    } else {
+      this._light = window.matchMedia('(prefers-color-scheme: light)').matches;
     }
-    // Default is dark (light = false)
     this._applyMode();
 
     // Restore persisted schema

--- a/apps/showcase/src/app.ts
+++ b/apps/showcase/src/app.ts
@@ -11,7 +11,6 @@ import { isValidSchema } from './constants.js';
 import './components/sc-nav.js';
 
 // Page imports
-// TODO(line-ui-6zy.3): home page is imported but not rendered — wire into panel system when home page task is implemented
 import './pages/home.js';
 import './pages/colors.js';
 import './pages/typography.js';
@@ -25,6 +24,7 @@ import './pages/themes.js';
 import './pages/generator.js';
 
 export type PanelKey =
+  | 'home'
   | 'colors'
   | 'typography'
   | 'spacing'
@@ -38,7 +38,7 @@ export type PanelKey =
 
 @customElement('sc-app')
 export class ScApp extends LitElement {
-  @state() private _panel: PanelKey = 'colors';
+  @state() private _panel: PanelKey = 'home';
   @state() private _schema = 'violet';
   @state() private _light = false;
 
@@ -97,6 +97,7 @@ export class ScApp extends LitElement {
 
   private _isValidPanel(value: string): value is PanelKey {
     return [
+      'home',
       'colors',
       'typography',
       'spacing',
@@ -177,6 +178,8 @@ export class ScApp extends LitElement {
 
   private _renderPanel() {
     switch (this._panel) {
+      case 'home':
+        return html`<sc-page-home ?light=${this._light}></sc-page-home>`;
       case 'colors':
         return html`<sc-page-colors></sc-page-colors>`;
       case 'typography':

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -5,6 +5,7 @@ import type { PanelKey } from '../app.js';
 import { ALL_SCHEMAS } from '../constants.js';
 
 const NAV_ITEMS: { key: PanelKey; label: string }[] = [
+  { key: 'home', label: 'Home' },
   { key: 'colors', label: 'Colors' },
   { key: 'typography', label: 'Typography' },
   { key: 'spacing', label: 'Spacing' },

--- a/apps/showcase/src/components/sc-nav.ts
+++ b/apps/showcase/src/components/sc-nav.ts
@@ -74,6 +74,7 @@ export class ScNav extends LitElement {
       letter-spacing: -0.03em;
       white-space: nowrap;
       flex-shrink: 0;
+      cursor: pointer;
       transition: color var(--line-duration-moderate-1, 180ms) var(--line-ease-2);
     }
     :host([light]) .logo { color: var(--line-high-contrast, #1a1a1a); }
@@ -419,7 +420,7 @@ export class ScNav extends LitElement {
 
     return html`
       <div class="topbar">
-        <div class="logo">line<span class="logo-ac">://</span>ui</div>
+        <div class="logo" @click=${() => this._navigate('home' as PanelKey)}>line<span class="logo-ac">://</span>ui</div>
 
         <!-- Desktop: inline pill nav -->
         <div class="nav-inline">

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -1,34 +1,377 @@
 import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
+
+import '../components/sc-code-block.js';
+
+/* ─────────────────────────────────────────────────────────
+   Navigation card data — one per non-home panel
+   ───────────────────────────────────────────────────────── */
+
+interface NavCard {
+  readonly key: string;
+  readonly category: string;
+  readonly title: string;
+  readonly description: string;
+  readonly tokens: number;
+}
+
+const NAV_CARDS: readonly NavCard[] = [
+  {
+    key: 'colors',
+    category: 'Foundation',
+    title: 'Colors',
+    description: 'L0: 28 palettes x 12 levels, contrast tokens, color-mix',
+    tokens: 364
+  },
+  {
+    key: 'typography',
+    category: 'Foundation',
+    title: 'Typography',
+    description: '62 tokens: families, sizes, weights, line-heights, spacings',
+    tokens: 62
+  },
+  {
+    key: 'spacing',
+    category: 'Foundation',
+    title: 'Spacing',
+    description: '74 tokens: rem, px, fluid, breakpoints, widths',
+    tokens: 74
+  },
+  {
+    key: 'motion',
+    category: 'Foundation',
+    title: 'Motion',
+    description: '81 easings, 12 durations, 23 animations',
+    tokens: 116
+  },
+  {
+    key: 'surfaces',
+    category: 'Foundation',
+    title: 'Surfaces',
+    description: 'Shadows, borders, radii, opacity, focus, aspects',
+    tokens: 65
+  },
+  {
+    key: 'decorative',
+    category: 'Visual',
+    title: 'Decorative',
+    description: 'Gradients, noise, masks, highlights, SVG, layouts',
+    tokens: 85
+  },
+  {
+    key: 'semantic',
+    category: 'System',
+    title: 'Semantic',
+    description: 'L2 defaults, L3 aliases, override demo',
+    tokens: 68
+  },
+  {
+    key: 'elements',
+    category: 'System',
+    title: 'Elements',
+    description: 'Normalize/reset for all native HTML elements',
+    tokens: 0
+  },
+  {
+    key: 'themes',
+    category: 'System',
+    title: 'Themes',
+    description: '28 pre-built palette+schema bundles',
+    tokens: 0
+  },
+  {
+    key: 'generator',
+    category: 'Tools',
+    title: 'Generator',
+    description: 'Create custom palettes with OKLCH',
+    tokens: 0
+  }
+] as const;
+
+/* ─────────────────────────────────────────────────────────
+   CSS usage snippet — educates about dual-layer theming
+   ───────────────────────────────────────────────────────── */
+
+const CSS_SNIPPET = `/* Color schema — pick your palette */
+body.line-schema-violet { }
+
+/* Mode: two layers work together */
+
+/* 1. Native browser property — drives CSS light-dark() resolution
+      and inherits through shadow DOM boundaries */
+html { color-scheme: dark; }
+
+/* 2. Class on <html> — needed because shadow/elevation tokens
+      use partial HSL values that cannot use light-dark() */
+html.dark { }
+
+/* Semantic tokens adapt to both layers automatically */
+.card {
+  background: var(--line-subtle-background);
+  color: var(--line-high-contrast);
+  border: 1px solid var(--line-subtle-border);
+  box-shadow: var(--line-shadow-3);
+}`;
+
+/* ─────────────────────────────────────────────────────────
+   Stats data
+   ───────────────────────────────────────────────────────── */
+
+interface Stat {
+  readonly value: number;
+  readonly label: string;
+}
+
+const STATS: readonly Stat[] = [
+  { value: 440, label: 'Tokens' },
+  { value: 28, label: 'Palettes' },
+  { value: 336, label: 'Color Tokens' },
+  { value: 54, label: 'Aliases' }
+] as const;
 
 @customElement('sc-page-home')
 export class ScPageHome extends LitElement {
+  @property({ type: Boolean, reflect: true }) light = false;
+
   static override styles = css`
     :host {
       display: block;
     }
 
-    h1 {
-      font-size: 2rem;
-      margin-block-end: 0.5rem;
+    /* ── Hero ── */
+    .hero {
+      text-align: center;
+      padding: var(--line-size-11, 7.5rem) 0 var(--line-size-8, 3rem);
     }
 
-    /* TODO(line-ui-6zy.3): Replace raw palette stops with semantic tokens
-       (--line-blue-9 -> --line-solid-background, --line-gray-11 -> --line-low-contrast)
-       when home page is fully implemented */
-    .accent {
-      color: var(--line-blue-9, #3b82f6);
+    .wordmark {
+      font-size: clamp(2.5rem, 6vw, 4rem);
+      font-weight: 800;
+      letter-spacing: -0.04em;
+      color: var(--line-high-contrast, #fff);
+      margin: 0;
+      line-height: 1.1;
+    }
+    :host([light]) .wordmark { color: var(--line-high-contrast, #1a1a1a); }
+
+    .wordmark-accent {
+      color: var(--line-solid-background, #c8ff00);
     }
 
-    p {
-      color: var(--line-gray-11, #6b7280);
+    .tagline {
+      font-size: var(--line-font-size-3, 1.25rem);
+      color: var(--line-low-contrast, #999);
+      margin: var(--line-size-3, 1rem) 0 0;
+      font-weight: var(--line-font-weight-4, 400);
     }
+    :host([light]) .tagline { color: var(--line-low-contrast, #666); }
+
+    /* ── Intro blurb ── */
+    .intro {
+      text-align: center;
+      max-width: 600px;
+      margin: 0 auto var(--line-size-8, 3rem);
+      font-size: var(--line-font-size-2, 1rem);
+      line-height: var(--line-lineheight-3, 1.6);
+      color: var(--line-low-contrast, #999);
+    }
+    :host([light]) .intro { color: var(--line-low-contrast, #666); }
+
+    /* ── Code snippet ── */
+    .snippet {
+      max-width: 640px;
+      margin: 0 auto var(--line-size-9, 4rem);
+    }
+
+    /* ── Stats ── */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: var(--line-size-3, 1rem);
+      margin-bottom: var(--line-size-9, 4rem);
+    }
+
+    @media (max-width: 600px) {
+      .stats { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    .stat {
+      text-align: center;
+      padding: var(--line-size-5, 1.5rem) var(--line-size-3, 1rem);
+      background: var(--line-subtle-background, #161616);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-2, 4px);
+    }
+    :host([light]) .stat {
+      background: var(--line-subtle-background, #fafafa);
+      border-color: var(--line-ui-background, #e5e5e5);
+    }
+
+    .stat-value {
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      font-weight: 800;
+      color: var(--line-solid-background, #c8ff00);
+      font-family: 'IBM Plex Mono', monospace;
+      letter-spacing: -0.02em;
+    }
+
+    .stat-label {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      margin-top: var(--line-size-1, 0.25rem);
+      font-weight: var(--line-font-weight-6, 600);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    :host([light]) .stat-label { color: var(--line-low-contrast, #666); }
+
+    /* ── Section title ── */
+    .section-title {
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-low-contrast, #999);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: var(--line-size-4, 1.25rem);
+    }
+    :host([light]) .section-title { color: var(--line-low-contrast, #666); }
+
+    /* ── Card grid ── */
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: var(--line-size-3, 1rem);
+    }
+
+    .card {
+      display: flex;
+      flex-direction: column;
+      padding: var(--line-size-5, 1.5rem);
+      background: var(--line-subtle-background, #161616);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-2, 4px);
+      cursor: pointer;
+      transition:
+        background var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        transform var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .card:hover {
+      background: var(--line-ui-background, #1e1e1e);
+      border-color: var(--line-ui-border, #444);
+      transform: translateY(-1px);
+    }
+
+    :host([light]) .card {
+      background: var(--line-subtle-background, #fafafa);
+      border-color: var(--line-ui-background, #e5e5e5);
+    }
+    :host([light]) .card:hover {
+      background: var(--line-ui-background, #eee);
+      border-color: var(--line-ui-border, #bbb);
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: var(--line-size-2, 0.5rem);
+    }
+
+    .card-category {
+      font-size: var(--line-font-size-00, 0.625rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-solid-background, #c8ff00);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .card-badge {
+      font-size: var(--line-font-size-00, 0.625rem);
+      font-family: 'IBM Plex Mono', monospace;
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-low-contrast, #999);
+      background: var(--line-ui-background, #1e1e1e);
+      padding: var(--line-size-1, 0.25rem) var(--line-size-2, 0.5rem);
+      border-radius: var(--line-radius-2, 4px);
+    }
+    :host([light]) .card-badge {
+      background: var(--line-ui-background, #e5e5e5);
+      color: var(--line-low-contrast, #666);
+    }
+
+    .card-title {
+      font-size: var(--line-font-size-2, 1rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-high-contrast, #fff);
+      margin-bottom: var(--line-size-1, 0.25rem);
+    }
+    :host([light]) .card-title { color: var(--line-high-contrast, #1a1a1a); }
+
+    .card-desc {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      line-height: var(--line-lineheight-3, 1.6);
+      flex: 1;
+    }
+    :host([light]) .card-desc { color: var(--line-low-contrast, #666); }
   `;
+
+  private _navigate(panel: string): void {
+    this.dispatchEvent(
+      new CustomEvent('sc-navigate', {
+        detail: { panel },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
 
   override render() {
     return html`
-      <h1>line<span class="accent">://</span>ui</h1>
-      <p>Design System Showcase</p>
+      <section class="hero">
+        <h1 class="wordmark">line<span class="wordmark-accent">://</span>ui</h1>
+        <p class="tagline">Design System Showcase</p>
+      </section>
+
+      <p class="intro">
+        The design system for the AI — future is bright!
+      </p>
+
+      <div class="snippet">
+        <sc-code-block
+          language="css"
+          .code=${CSS_SNIPPET}
+        ></sc-code-block>
+      </div>
+
+      <div class="stats">
+        ${STATS.map(
+          (s) => html`
+          <div class="stat">
+            <div class="stat-value">${s.value}</div>
+            <div class="stat-label">${s.label}</div>
+          </div>
+        `
+        )}
+      </div>
+
+      <div class="section-title">Explore</div>
+      <div class="card-grid">
+        ${NAV_CARDS.map(
+          (card) => html`
+          <div class="card" @click=${() => this._navigate(card.key)}>
+            <div class="card-header">
+              <span class="card-category">${card.category}</span>
+              ${card.tokens > 0 ? html`<span class="card-badge">${card.tokens} tokens</span>` : html``}
+            </div>
+            <div class="card-title">${card.title}</div>
+            <div class="card-desc">${card.description}</div>
+          </div>
+        `
+        )}
+      </div>
     `;
   }
 }

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -136,78 +136,95 @@ export class ScPageHome extends LitElement {
   static override styles = css`
     :host {
       display: block;
-    }
-
-    /* ── Hero (full width, gradient background) ── */
-    .hero {
       position: relative;
-      text-align: center;
-      padding: var(--line-size-11, 7.5rem) 0 var(--line-size-8, 3rem);
-      overflow: hidden;
     }
 
-    .hero::before {
+    /* ── Page-wide gradient background ── */
+    :host::before {
       content: '';
       position: absolute;
-      inset: -20% -10%;
-      background: radial-gradient(
-        ellipse 60% 70% at 50% 40%,
-        color-mix(in oklch, var(--line-solid-background) 18%, transparent) 0%,
-        color-mix(in oklch, var(--line-solid-background) 6%, transparent) 40%,
-        transparent 70%
-      );
+      inset: 0;
+      background:
+        radial-gradient(
+          ellipse 80% 50% at 50% 15%,
+          color-mix(in oklch, var(--line-solid-background) 20%, transparent) 0%,
+          color-mix(in oklch, var(--line-solid-background) 8%, transparent) 35%,
+          transparent 65%
+        ),
+        radial-gradient(
+          ellipse 50% 30% at 20% 60%,
+          color-mix(in oklch, var(--line-solid-background) 6%, transparent) 0%,
+          transparent 50%
+        ),
+        radial-gradient(
+          ellipse 50% 30% at 80% 45%,
+          color-mix(in oklch, var(--line-solid-background) 6%, transparent) 0%,
+          transparent 50%
+        );
       pointer-events: none;
       z-index: 0;
     }
-    :host([light]) .hero::before {
-      background: radial-gradient(
-        ellipse 60% 70% at 50% 40%,
-        color-mix(in oklch, var(--line-solid-background) 12%, transparent) 0%,
-        color-mix(in oklch, var(--line-solid-background) 4%, transparent) 40%,
-        transparent 70%
-      );
+    :host([light])::before {
+      background:
+        radial-gradient(
+          ellipse 80% 50% at 50% 15%,
+          color-mix(in oklch, var(--line-solid-background) 14%, transparent) 0%,
+          color-mix(in oklch, var(--line-solid-background) 5%, transparent) 35%,
+          transparent 65%
+        ),
+        radial-gradient(
+          ellipse 50% 30% at 20% 60%,
+          color-mix(in oklch, var(--line-solid-background) 4%, transparent) 0%,
+          transparent 50%
+        ),
+        radial-gradient(
+          ellipse 50% 30% at 80% 45%,
+          color-mix(in oklch, var(--line-solid-background) 4%, transparent) 0%,
+          transparent 50%
+        );
     }
 
-    .hero::after {
+    /* ── Dot grid pattern across page ── */
+    :host::after {
       content: '';
       position: absolute;
       inset: 0;
       background-image: radial-gradient(
-        color-mix(in oklch, var(--line-ui-border, #444) 25%, transparent) 1px,
+        color-mix(in oklch, var(--line-solid-background) 20%, var(--line-ui-border, #444)) 1px,
         transparent 1px
       );
       background-size: 24px 24px;
-      opacity: 0.4;
+      opacity: 0.25;
       pointer-events: none;
       z-index: 0;
-      mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 0%, transparent 70%);
-      -webkit-mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 0%, transparent 70%);
+      mask-image: linear-gradient(to bottom, black 0%, transparent 60%);
+      -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 60%);
     }
-    :host([light]) .hero::after {
-      opacity: 0.5;
+    :host([light])::after {
+      opacity: 0.3;
     }
 
-    .hero > * {
+    :host > * {
       position: relative;
       z-index: 1;
+    }
+
+    /* ── Hero ── */
+    .hero {
+      text-align: center;
+      padding: var(--line-size-11, 7.5rem) 0 var(--line-size-8, 3rem);
     }
 
     .wordmark {
       font-size: clamp(2.5rem, 6vw, 4rem);
       font-weight: 800;
       letter-spacing: -0.04em;
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       margin: 0;
       line-height: 1.1;
       text-shadow:
-        0 0 60px color-mix(in oklch, var(--line-solid-background, #c8ff00) 35%, transparent),
-        0 0 120px color-mix(in oklch, var(--line-solid-background, #c8ff00) 15%, transparent);
-    }
-    :host([light]) .wordmark {
-      color: var(--line-high-contrast, #1a1a1a);
-      text-shadow:
-        0 0 60px color-mix(in oklch, var(--line-solid-background, #c8ff00) 25%, transparent),
-        0 0 120px color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, transparent);
+        0 0 60px color-mix(in oklch, var(--line-solid-background) 35%, transparent),
+        0 0 120px color-mix(in oklch, var(--line-solid-background) 15%, transparent);
     }
 
     .wordmark-accent {
@@ -216,7 +233,7 @@ export class ScPageHome extends LitElement {
 
     .tagline {
       font-size: var(--line-font-size-3, 1.25rem);
-      color: var(--line-low-contrast);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-low-contrast));
       margin: var(--line-size-3, 1rem) 0 0;
       font-weight: var(--line-font-weight-4, 400);
     }
@@ -227,9 +244,8 @@ export class ScPageHome extends LitElement {
       margin: 0 auto var(--line-size-8, 3rem);
       font-size: var(--line-font-size-2, 1rem);
       line-height: var(--line-lineheight-3, 1.6);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
     }
-    :host([light]) .intro { color: var(--line-low-contrast, #666); }
 
     /* ── Section header (full width above two-column) ── */
     .section-title {
@@ -243,7 +259,7 @@ export class ScPageHome extends LitElement {
 
     .section-subtitle {
       font-size: var(--line-font-size-2, 1rem);
-      color: var(--line-low-contrast);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       margin-top: var(--line-size-1, 0.25rem);
       margin-bottom: var(--line-size-6, 2rem);
       line-height: var(--line-lineheight-3, 1.6);
@@ -333,17 +349,16 @@ export class ScPageHome extends LitElement {
     .comp-card-title {
       font-size: var(--line-font-size-3, 1.25rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       margin: 0 0 var(--line-size-2, 0.5rem);
     }
 
     .comp-card-text {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       line-height: var(--line-lineheight-3, 1.6);
       margin: 0;
     }
-    :host([light]) .comp-card-text { color: var(--line-low-contrast, #666); }
 
     .comp-card-footer {
       padding: var(--line-size-3, 1rem) var(--line-size-5, 1.5rem);
@@ -358,12 +373,11 @@ export class ScPageHome extends LitElement {
 
     .comp-card-footer-label {
       font-size: var(--line-font-size-00, 0.625rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       text-transform: uppercase;
       letter-spacing: 0.06em;
       font-weight: var(--line-font-weight-6, 600);
     }
-    :host([light]) .comp-card-footer-label { color: var(--line-low-contrast, #666); }
 
     .comp-card-footer-value {
       font-size: var(--line-font-size-00, 0.625rem);
@@ -392,18 +406,16 @@ export class ScPageHome extends LitElement {
     .comp-info-title {
       font-size: var(--line-font-size-1, 0.75rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       margin: 0 0 var(--line-size-1, 0.25rem);
     }
-    :host([light]) .comp-info-title { color: var(--line-high-contrast, #1a1a1a); }
 
     .comp-info-text {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       line-height: var(--line-lineheight-3, 1.6);
       margin: 0;
     }
-    :host([light]) .comp-info-text { color: var(--line-low-contrast, #666); }
 
     /* ── 3. Image card ── */
     .comp-image-card {
@@ -447,17 +459,16 @@ export class ScPageHome extends LitElement {
     .comp-image-title {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       margin: 0 0 var(--line-size-1, 0.25rem);
     }
 
     .comp-image-desc {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       margin: 0;
       line-height: var(--line-lineheight-3, 1.6);
     }
-    :host([light]) .comp-image-desc { color: var(--line-low-contrast, #666); }
 
     /* ── 4. Pricing card ── */
     .comp-pricing {
@@ -478,17 +489,16 @@ export class ScPageHome extends LitElement {
     .comp-pricing-price {
       font-size: clamp(1.75rem, 3vw, 2.25rem);
       font-weight: 800;
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       font-family: 'IBM Plex Mono', monospace;
       letter-spacing: -0.03em;
       margin: 0 0 var(--line-size-1, 0.25rem);
       line-height: 1.1;
     }
-    :host([light]) .comp-pricing-price { color: var(--line-high-contrast, #1a1a1a); }
 
     .comp-pricing-period {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       font-weight: var(--line-font-weight-4, 400);
       font-family: inherit;
     }
@@ -505,12 +515,11 @@ export class ScPageHome extends LitElement {
 
     .comp-pricing-features li {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       line-height: var(--line-lineheight-3, 1.6);
       padding-left: var(--line-size-4, 1.25rem);
       position: relative;
     }
-    :host([light]) .comp-pricing-features li { color: var(--line-low-contrast, #666); }
 
     .comp-pricing-features li::before {
       content: '';
@@ -554,7 +563,7 @@ export class ScPageHome extends LitElement {
     .comp-login-heading {
       font-size: var(--line-font-size-3, 1.25rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       margin: 0;
     }
 
@@ -567,11 +576,10 @@ export class ScPageHome extends LitElement {
     .comp-login-label {
       font-size: var(--line-font-size-00, 0.625rem);
       font-weight: var(--line-font-weight-6, 600);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       text-transform: uppercase;
       letter-spacing: 0.05em;
     }
-    :host([light]) .comp-login-label { color: var(--line-low-contrast, #666); }
 
     .comp-login-input {
       padding: var(--line-size-3, 1rem);
@@ -711,13 +719,12 @@ export class ScPageHome extends LitElement {
 
     .stat-label {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       margin-top: var(--line-size-1, 0.25rem);
       font-weight: var(--line-font-weight-6, 600);
       text-transform: uppercase;
       letter-spacing: 0.05em;
     }
-    :host([light]) .stat-label { color: var(--line-low-contrast, #666); }
 
     /* ── Explore card grid (full width) ── */
     .card-grid {
@@ -787,17 +794,16 @@ export class ScPageHome extends LitElement {
     .card-title {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast);
+      color: color-mix(in oklch, var(--line-solid-background) 15%, var(--line-high-contrast));
       margin-bottom: var(--line-size-1, 0.25rem);
     }
 
     .card-desc {
       font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));
       line-height: var(--line-lineheight-3, 1.6);
       flex: 1;
     }
-    :host([light]) .card-desc { color: var(--line-low-contrast, #666); }
   `;
 
   private _navigate(panel: string): void {

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -149,43 +149,23 @@ export class ScPageHome extends LitElement {
     .hero::before {
       content: '';
       position: absolute;
-      inset: 0;
-      background:
-        radial-gradient(
-          ellipse 100% 80% at 50% 0%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 22%, transparent) 0%,
-          transparent 70%
-        ),
-        radial-gradient(
-          ellipse 60% 50% at 30% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 14%, transparent) 0%,
-          transparent 60%
-        ),
-        radial-gradient(
-          ellipse 60% 50% at 70% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 14%, transparent) 0%,
-          transparent 60%
-        );
+      inset: -20% -10%;
+      background: radial-gradient(
+        ellipse 60% 70% at 50% 40%,
+        color-mix(in oklch, var(--line-solid-background) 18%, transparent) 0%,
+        color-mix(in oklch, var(--line-solid-background) 6%, transparent) 40%,
+        transparent 70%
+      );
       pointer-events: none;
       z-index: 0;
     }
     :host([light]) .hero::before {
-      background:
-        radial-gradient(
-          ellipse 100% 80% at 50% 0%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 16%, transparent) 0%,
-          transparent 70%
-        ),
-        radial-gradient(
-          ellipse 60% 50% at 30% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, transparent) 0%,
-          transparent 60%
-        ),
-        radial-gradient(
-          ellipse 60% 50% at 70% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, transparent) 0%,
-          transparent 60%
-        );
+      background: radial-gradient(
+        ellipse 60% 70% at 50% 40%,
+        color-mix(in oklch, var(--line-solid-background) 12%, transparent) 0%,
+        color-mix(in oklch, var(--line-solid-background) 4%, transparent) 40%,
+        transparent 70%
+      );
     }
 
     .hero::after {
@@ -236,7 +216,7 @@ export class ScPageHome extends LitElement {
 
     .tagline {
       font-size: var(--line-font-size-3, 1.25rem);
-      color: color-mix(in oklch, var(--line-solid-background) 50%, var(--line-low-contrast));
+      color: var(--line-low-contrast);
       margin: var(--line-size-3, 1rem) 0 0;
       font-weight: var(--line-font-weight-4, 400);
     }
@@ -263,7 +243,7 @@ export class ScPageHome extends LitElement {
 
     .section-subtitle {
       font-size: var(--line-font-size-2, 1rem);
-      color: color-mix(in oklch, var(--line-solid-background) 60%, var(--line-low-contrast));
+      color: var(--line-low-contrast);
       margin-top: var(--line-size-1, 0.25rem);
       margin-bottom: var(--line-size-6, 2rem);
       line-height: var(--line-lineheight-3, 1.6);
@@ -353,7 +333,7 @@ export class ScPageHome extends LitElement {
     .comp-card-title {
       font-size: var(--line-font-size-3, 1.25rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: color-mix(in oklch, var(--line-solid-background) 40%, var(--line-high-contrast));
+      color: var(--line-high-contrast);
       margin: 0 0 var(--line-size-2, 0.5rem);
     }
 
@@ -467,7 +447,7 @@ export class ScPageHome extends LitElement {
     .comp-image-title {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: color-mix(in oklch, var(--line-solid-background) 40%, var(--line-high-contrast));
+      color: var(--line-high-contrast);
       margin: 0 0 var(--line-size-1, 0.25rem);
     }
 
@@ -574,7 +554,7 @@ export class ScPageHome extends LitElement {
     .comp-login-heading {
       font-size: var(--line-font-size-3, 1.25rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: color-mix(in oklch, var(--line-solid-background) 40%, var(--line-high-contrast));
+      color: var(--line-high-contrast);
       margin: 0;
     }
 
@@ -807,7 +787,7 @@ export class ScPageHome extends LitElement {
     .card-title {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: color-mix(in oklch, var(--line-solid-background) 30%, var(--line-high-contrast));
+      color: var(--line-high-contrast);
       margin-bottom: var(--line-size-1, 0.25rem);
     }
 

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -138,10 +138,78 @@ export class ScPageHome extends LitElement {
       display: block;
     }
 
-    /* ── Hero ── */
+    /* ── Hero (A: gradient background) ── */
     .hero {
+      position: relative;
       text-align: center;
       padding: var(--line-size-11, 7.5rem) 0 var(--line-size-8, 3rem);
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(
+          ellipse 80% 60% at 50% 0%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 12%, transparent) 0%,
+          transparent 70%
+        ),
+        radial-gradient(
+          ellipse 50% 40% at 30% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 6%, transparent) 0%,
+          transparent 60%
+        ),
+        radial-gradient(
+          ellipse 50% 40% at 70% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 6%, transparent) 0%,
+          transparent 60%
+        );
+      pointer-events: none;
+      z-index: 0;
+    }
+    :host([light]) .hero::before {
+      background:
+        radial-gradient(
+          ellipse 80% 60% at 50% 0%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 8%, transparent) 0%,
+          transparent 70%
+        ),
+        radial-gradient(
+          ellipse 50% 40% at 30% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 4%, transparent) 0%,
+          transparent 60%
+        ),
+        radial-gradient(
+          ellipse 50% 40% at 70% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 4%, transparent) 0%,
+          transparent 60%
+        );
+    }
+
+    .hero::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image: radial-gradient(
+        color-mix(in oklch, var(--line-ui-border, #444) 25%, transparent) 1px,
+        transparent 1px
+      );
+      background-size: 24px 24px;
+      opacity: 0.3;
+      pointer-events: none;
+      z-index: 0;
+      mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 0%, transparent 70%);
+      -webkit-mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 0%, transparent 70%);
+    }
+    :host([light]) .hero::after {
+      opacity: 0.4;
+    }
+
+    .hero > * {
+      position: relative;
+      z-index: 1;
     }
 
     .wordmark {
@@ -235,6 +303,402 @@ export class ScPageHome extends LitElement {
       margin-bottom: var(--line-size-4, 1.25rem);
     }
     :host([light]) .section-title { color: var(--line-low-contrast, #666); }
+
+    .section-subtitle {
+      font-size: var(--line-font-size-2, 1rem);
+      color: var(--line-low-contrast, #999);
+      margin-top: var(--line-size-1, 0.25rem);
+      margin-bottom: var(--line-size-6, 2rem);
+      line-height: var(--line-lineheight-3, 1.6);
+      max-width: 520px;
+    }
+    :host([light]) .section-subtitle { color: var(--line-low-contrast, #666); }
+
+    /* ── Built with tokens — compositions grid ── */
+    .compositions-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: var(--line-size-4, 1.25rem);
+      margin-bottom: var(--line-size-9, 4rem);
+    }
+
+    @media (max-width: 900px) {
+      .compositions-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 560px) {
+      .compositions-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ── Shared composition card shell ── */
+    .comp {
+      background: var(--line-subtle-background, #161616);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-3, 8px);
+      overflow: hidden;
+    }
+    :host([light]) .comp {
+      background: var(--line-subtle-background, #fafafa);
+      border-color: var(--line-ui-background, #e5e5e5);
+    }
+
+    /* ── 1. Content card ── */
+    .comp-card {
+      display: flex;
+      flex-direction: column;
+    }
+    .comp-card-body {
+      padding: var(--line-size-5, 1.5rem);
+      flex: 1;
+    }
+    .comp-card-title {
+      font-size: var(--line-font-size-3, 1.25rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-high-contrast, #fff);
+      margin: 0 0 var(--line-size-2, 0.5rem);
+    }
+    :host([light]) .comp-card-title { color: var(--line-high-contrast, #1a1a1a); }
+
+    .comp-card-text {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      line-height: var(--line-lineheight-3, 1.6);
+      margin: 0;
+    }
+    :host([light]) .comp-card-text { color: var(--line-low-contrast, #666); }
+
+    .comp-card-footer {
+      padding: var(--line-size-3, 1rem) var(--line-size-5, 1.5rem);
+      border-top: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    :host([light]) .comp-card-footer {
+      border-color: var(--line-ui-background, #e5e5e5);
+    }
+
+    .comp-card-footer-label {
+      font-size: var(--line-font-size-00, 0.625rem);
+      color: var(--line-low-contrast, #999);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: var(--line-font-weight-6, 600);
+    }
+    :host([light]) .comp-card-footer-label { color: var(--line-low-contrast, #666); }
+
+    .comp-card-footer-value {
+      font-size: var(--line-font-size-00, 0.625rem);
+      font-family: 'IBM Plex Mono', monospace;
+      color: var(--line-solid-background, #c8ff00);
+      font-weight: var(--line-font-weight-6, 600);
+    }
+
+    /* ── 2. Info banner ── */
+    .comp-info {
+      padding: var(--line-size-4, 1.25rem) var(--line-size-5, 1.5rem);
+      display: flex;
+      gap: var(--line-size-3, 1rem);
+      align-items: flex-start;
+    }
+
+    .comp-info-indicator {
+      flex-shrink: 0;
+      width: var(--line-size-3, 1rem);
+      height: var(--line-size-3, 1rem);
+      margin-top: var(--line-size-1, 0.25rem);
+      border-radius: var(--line-radius-round, 50%);
+      background: var(--line-solid-background, #c8ff00);
+    }
+
+    .comp-info-title {
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-high-contrast, #fff);
+      margin: 0 0 var(--line-size-1, 0.25rem);
+    }
+    :host([light]) .comp-info-title { color: var(--line-high-contrast, #1a1a1a); }
+
+    .comp-info-text {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      line-height: var(--line-lineheight-3, 1.6);
+      margin: 0;
+    }
+    :host([light]) .comp-info-text { color: var(--line-low-contrast, #666); }
+
+    /* ── 3. Image card ── */
+    .comp-image-card {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .comp-image-placeholder {
+      height: 140px;
+      background: linear-gradient(
+        135deg,
+        var(--line-subtle-background, #161616) 0%,
+        color-mix(in oklch, var(--line-solid-background, #c8ff00) 15%, var(--line-subtle-background, #161616)) 50%,
+        var(--line-hover-background, #1e1e1e) 100%
+      );
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    :host([light]) .comp-image-placeholder {
+      background: linear-gradient(
+        135deg,
+        var(--line-subtle-background, #fafafa) 0%,
+        color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, var(--line-subtle-background, #fafafa)) 50%,
+        var(--line-hover-background, #eee) 100%
+      );
+    }
+
+    .comp-image-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: var(--line-radius-2, 4px);
+      background: color-mix(in oklch, var(--line-solid-background, #c8ff00) 25%, transparent);
+      border: var(--line-border-size-1, 1px) solid color-mix(in oklch, var(--line-solid-background, #c8ff00) 40%, transparent);
+    }
+
+    .comp-image-caption {
+      padding: var(--line-size-4, 1.25rem) var(--line-size-5, 1.5rem);
+    }
+
+    .comp-image-title {
+      font-size: var(--line-font-size-2, 1rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-high-contrast, #fff);
+      margin: 0 0 var(--line-size-1, 0.25rem);
+    }
+    :host([light]) .comp-image-title { color: var(--line-high-contrast, #1a1a1a); }
+
+    .comp-image-desc {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      margin: 0;
+      line-height: var(--line-lineheight-3, 1.6);
+    }
+    :host([light]) .comp-image-desc { color: var(--line-low-contrast, #666); }
+
+    /* ── 4. Pricing card ── */
+    .comp-pricing {
+      display: flex;
+      flex-direction: column;
+      padding: var(--line-size-5, 1.5rem);
+    }
+
+    .comp-pricing-plan {
+      font-size: var(--line-font-size-00, 0.625rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-solid-background, #c8ff00);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin: 0 0 var(--line-size-2, 0.5rem);
+    }
+
+    .comp-pricing-price {
+      font-size: clamp(1.75rem, 3vw, 2.25rem);
+      font-weight: 800;
+      color: var(--line-high-contrast, #fff);
+      font-family: 'IBM Plex Mono', monospace;
+      letter-spacing: -0.03em;
+      margin: 0 0 var(--line-size-1, 0.25rem);
+      line-height: 1.1;
+    }
+    :host([light]) .comp-pricing-price { color: var(--line-high-contrast, #1a1a1a); }
+
+    .comp-pricing-period {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      font-weight: var(--line-font-weight-4, 400);
+      font-family: inherit;
+    }
+
+    .comp-pricing-features {
+      list-style: none;
+      padding: 0;
+      margin: var(--line-size-4, 1.25rem) 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--line-size-2, 0.5rem);
+      flex: 1;
+    }
+
+    .comp-pricing-features li {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      line-height: var(--line-lineheight-3, 1.6);
+      padding-left: var(--line-size-4, 1.25rem);
+      position: relative;
+    }
+    :host([light]) .comp-pricing-features li { color: var(--line-low-contrast, #666); }
+
+    .comp-pricing-features li::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0.45em;
+      width: 6px;
+      height: 6px;
+      border-radius: var(--line-radius-round, 50%);
+      background: var(--line-solid-background, #c8ff00);
+    }
+
+    .comp-pricing-cta {
+      display: block;
+      width: 100%;
+      padding: var(--line-size-3, 1rem);
+      border: none;
+      border-radius: var(--line-radius-2, 4px);
+      background: var(--line-solid-background, #c8ff00);
+      color: var(--line-solid-foreground, #000);
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-7, 700);
+      font-family: inherit;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: opacity var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .comp-pricing-cta:hover {
+      opacity: 0.85;
+    }
+
+    /* ── 5. Login form ── */
+    .comp-login {
+      padding: var(--line-size-5, 1.5rem);
+      display: flex;
+      flex-direction: column;
+      gap: var(--line-size-4, 1.25rem);
+    }
+
+    .comp-login-heading {
+      font-size: var(--line-font-size-3, 1.25rem);
+      font-weight: var(--line-font-weight-7, 700);
+      color: var(--line-high-contrast, #fff);
+      margin: 0;
+    }
+    :host([light]) .comp-login-heading { color: var(--line-high-contrast, #1a1a1a); }
+
+    .comp-login-field {
+      display: flex;
+      flex-direction: column;
+      gap: var(--line-size-1, 0.25rem);
+    }
+
+    .comp-login-label {
+      font-size: var(--line-font-size-00, 0.625rem);
+      font-weight: var(--line-font-weight-6, 600);
+      color: var(--line-low-contrast, #999);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    :host([light]) .comp-login-label { color: var(--line-low-contrast, #666); }
+
+    .comp-login-input {
+      padding: var(--line-size-3, 1rem);
+      background: var(--line-hover-background, #1a1a1a);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-border, #333);
+      border-radius: var(--line-radius-2, 4px);
+      color: var(--line-high-contrast, #fff);
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-family: inherit;
+      outline: none;
+      transition:
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        box-shadow var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    :host([light]) .comp-login-input {
+      background: var(--line-hover-background, #f5f5f5);
+      border-color: var(--line-ui-border, #ccc);
+      color: var(--line-high-contrast, #1a1a1a);
+    }
+
+    .comp-login-input::placeholder {
+      color: var(--line-subtle-border, #444);
+    }
+    :host([light]) .comp-login-input::placeholder {
+      color: var(--line-subtle-border, #aaa);
+    }
+
+    .comp-login-input:focus {
+      border-color: var(--line-solid-background, #c8ff00);
+      box-shadow: 0 0 0 2px color-mix(in oklch, var(--line-solid-background, #c8ff00) 20%, transparent);
+    }
+
+    .comp-login-submit {
+      display: block;
+      width: 100%;
+      padding: var(--line-size-3, 1rem);
+      border: none;
+      border-radius: var(--line-radius-2, 4px);
+      background: var(--line-solid-background, #c8ff00);
+      color: var(--line-solid-foreground, #000);
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-7, 700);
+      font-family: inherit;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: opacity var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+
+    .comp-login-submit:hover {
+      opacity: 0.85;
+    }
+
+    .comp-login-divider {
+      text-align: center;
+      font-size: var(--line-font-size-00, 0.625rem);
+      color: var(--line-subtle-border, #444);
+      position: relative;
+    }
+    :host([light]) .comp-login-divider { color: var(--line-subtle-border, #aaa); }
+
+    .comp-login-divider::before,
+    .comp-login-divider::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      width: calc(50% - 1.5em);
+      height: 1px;
+      background: var(--line-ui-background, #222);
+    }
+    :host([light]) .comp-login-divider::before,
+    :host([light]) .comp-login-divider::after {
+      background: var(--line-ui-background, #e5e5e5);
+    }
+    .comp-login-divider::before { left: 0; }
+    .comp-login-divider::after { right: 0; }
+
+    .comp-login-ghost {
+      display: block;
+      width: 100%;
+      padding: var(--line-size-3, 1rem);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-border, #333);
+      border-radius: var(--line-radius-2, 4px);
+      background: transparent;
+      color: var(--line-high-contrast, #fff);
+      font-size: var(--line-font-size-1, 0.75rem);
+      font-weight: var(--line-font-weight-6, 600);
+      font-family: inherit;
+      cursor: pointer;
+      transition:
+        background var(--line-duration-quick-1, 80ms) var(--line-ease-2),
+        border-color var(--line-duration-quick-1, 80ms) var(--line-ease-2);
+    }
+    :host([light]) .comp-login-ghost {
+      border-color: var(--line-ui-border, #ccc);
+      color: var(--line-high-contrast, #1a1a1a);
+    }
+
+    .comp-login-ghost:hover {
+      background: var(--line-hover-background, #1a1a1a);
+      border-color: var(--line-solid-background, #c8ff00);
+    }
+    :host([light]) .comp-login-ghost:hover {
+      background: var(--line-hover-background, #f5f5f5);
+    }
 
     /* ── Card grid ── */
     .card-grid {
@@ -355,6 +819,103 @@ export class ScPageHome extends LitElement {
           </div>
         `
         )}
+      </div>
+
+      <!-- ── Built with tokens ── -->
+      <div class="section-title">Built with tokens</div>
+      <p class="section-subtitle">
+        Native HTML elements styled purely with
+        <span style="font-family: 'IBM Plex Mono', monospace;">--line-*</span>
+        design tokens. No components required.
+      </p>
+
+      <div class="compositions-grid">
+
+        <!-- 1. Content card -->
+        <div class="comp comp-card">
+          <div class="comp-card-body">
+            <h3 class="comp-card-title">Headless by design</h3>
+            <p class="comp-card-text">
+              Every component ships zero opinions on visuals.
+              Semantic tokens and <span style="font-family: 'IBM Plex Mono', monospace;">::part()</span>
+              give you full control over the look and feel.
+            </p>
+          </div>
+          <div class="comp-card-footer">
+            <span class="comp-card-footer-label">Tokens used</span>
+            <span class="comp-card-footer-value">12</span>
+          </div>
+        </div>
+
+        <!-- 2. Info banner -->
+        <div class="comp comp-info">
+          <div class="comp-info-indicator"></div>
+          <div>
+            <p class="comp-info-title">Schema applied</p>
+            <p class="comp-info-text">
+              The active color schema automatically maps 12 semantic
+              stops to your chosen palette. Switch schemas and every
+              surface adapts instantly.
+            </p>
+          </div>
+        </div>
+
+        <!-- 3. Image card -->
+        <div class="comp comp-image-card">
+          <div class="comp-image-placeholder">
+            <div class="comp-image-icon"></div>
+          </div>
+          <div class="comp-image-caption">
+            <h3 class="comp-image-title">Visual tokens</h3>
+            <p class="comp-image-desc">
+              Gradients, shadows, and radii adapt across light and
+              dark modes using semantic color references.
+            </p>
+          </div>
+        </div>
+
+        <!-- 4. Pricing card -->
+        <div class="comp comp-pricing">
+          <span class="comp-pricing-plan">Pro</span>
+          <div class="comp-pricing-price">
+            $0<span class="comp-pricing-period"> /forever</span>
+          </div>
+          <ul class="comp-pricing-features">
+            <li>440+ design tokens</li>
+            <li>28 color palettes</li>
+            <li>Light and dark modes</li>
+            <li>Framework-agnostic</li>
+            <li>MIT licensed</li>
+          </ul>
+          <button class="comp-pricing-cta" type="button">Get started</button>
+        </div>
+
+        <!-- 5. Login form -->
+        <div class="comp comp-login">
+          <h3 class="comp-login-heading">Sign in</h3>
+          <div class="comp-login-field">
+            <label class="comp-login-label">Email</label>
+            <input
+              class="comp-login-input"
+              type="email"
+              placeholder="you@example.com"
+              autocomplete="off"
+            />
+          </div>
+          <div class="comp-login-field">
+            <label class="comp-login-label">Password</label>
+            <input
+              class="comp-login-input"
+              type="password"
+              placeholder="Enter password"
+              autocomplete="off"
+            />
+          </div>
+          <button class="comp-login-submit" type="button">Continue</button>
+          <div class="comp-login-divider">or</div>
+          <button class="comp-login-ghost" type="button">Sign in with SSO</button>
+        </div>
+
       </div>
 
       <div class="section-title">Explore</div>

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -211,8 +211,8 @@ export class ScPageHome extends LitElement {
 
     /* ── Hero ── */
     .hero {
-      text-align: center;
-      padding: var(--line-size-11, 7.5rem) 0 var(--line-size-8, 3rem);
+      text-align: left;
+      padding: var(--line-size-5, 1.5rem) 0 var(--line-size-8, 3rem);
     }
 
     .wordmark {
@@ -239,9 +239,9 @@ export class ScPageHome extends LitElement {
     }
 
     .intro {
-      text-align: center;
+      text-align: left;
       max-width: 600px;
-      margin: 0 auto var(--line-size-8, 3rem);
+      margin: 0 0 var(--line-size-8, 3rem);
       font-size: var(--line-font-size-2, 1rem);
       line-height: var(--line-lineheight-3, 1.6);
       color: color-mix(in oklch, var(--line-solid-background) 10%, var(--line-low-contrast));

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -138,7 +138,7 @@ export class ScPageHome extends LitElement {
       display: block;
     }
 
-    /* ── Hero (A: gradient background) ── */
+    /* ── Hero (full width, gradient background) ── */
     .hero {
       position: relative;
       text-align: center;
@@ -234,7 +234,6 @@ export class ScPageHome extends LitElement {
     }
     :host([light]) .tagline { color: var(--line-low-contrast, #666); }
 
-    /* ── Intro blurb ── */
     .intro {
       text-align: center;
       max-width: 600px;
@@ -245,55 +244,7 @@ export class ScPageHome extends LitElement {
     }
     :host([light]) .intro { color: var(--line-low-contrast, #666); }
 
-    /* ── Code snippet ── */
-    .snippet {
-      max-width: 640px;
-      margin: 0 auto var(--line-size-9, 4rem);
-    }
-
-    /* ── Stats ── */
-    .stats {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: var(--line-size-3, 1rem);
-      margin-bottom: var(--line-size-9, 4rem);
-    }
-
-    @media (max-width: 600px) {
-      .stats { grid-template-columns: repeat(2, 1fr); }
-    }
-
-    .stat {
-      text-align: center;
-      padding: var(--line-size-5, 1.5rem) var(--line-size-3, 1rem);
-      background: var(--line-subtle-background, #161616);
-      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
-      border-radius: var(--line-radius-2, 4px);
-    }
-    :host([light]) .stat {
-      background: var(--line-subtle-background, #fafafa);
-      border-color: var(--line-ui-background, #e5e5e5);
-    }
-
-    .stat-value {
-      font-size: clamp(1.5rem, 3vw, 2rem);
-      font-weight: 800;
-      color: var(--line-solid-background, #c8ff00);
-      font-family: 'IBM Plex Mono', monospace;
-      letter-spacing: -0.02em;
-    }
-
-    .stat-label {
-      font-size: var(--line-font-size-1, 0.75rem);
-      color: var(--line-low-contrast, #999);
-      margin-top: var(--line-size-1, 0.25rem);
-      font-weight: var(--line-font-weight-6, 600);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    :host([light]) .stat-label { color: var(--line-low-contrast, #666); }
-
-    /* ── Section title ── */
+    /* ── Section header (full width above two-column) ── */
     .section-title {
       font-size: var(--line-font-size-1, 0.75rem);
       font-weight: var(--line-font-weight-7, 700);
@@ -314,19 +265,63 @@ export class ScPageHome extends LitElement {
     }
     :host([light]) .section-subtitle { color: var(--line-low-contrast, #666); }
 
-    /* ── Built with tokens — compositions grid ── */
-    .compositions-grid {
+    /* ── Two-column showcase layout ── */
+    .showcase {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: var(--line-size-4, 1.25rem);
+      grid-template-columns: 45% 55%;
+      gap: var(--line-size-6, 2rem);
       margin-bottom: var(--line-size-9, 4rem);
+      align-items: start;
     }
 
-    @media (max-width: 900px) {
-      .compositions-grid { grid-template-columns: repeat(2, 1fr); }
+    @media (max-width: 768px) {
+      .showcase {
+        grid-template-columns: 1fr;
+      }
     }
-    @media (max-width: 560px) {
-      .compositions-grid { grid-template-columns: 1fr; }
+
+    /* ── Left column: code snippet ── */
+    .showcase-code {
+      position: sticky;
+      top: var(--line-size-6, 2rem);
+    }
+
+    @media (max-width: 768px) {
+      .showcase-code {
+        position: static;
+      }
+    }
+
+    /* ── Right column: compositions showcase wall ── */
+    .showcase-wall {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: auto;
+      gap: var(--line-size-4, 1.25rem);
+    }
+
+    @media (max-width: 768px) {
+      .showcase-wall {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+    @media (max-width: 480px) {
+      .showcase-wall {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    /* Named grid placements for visual interest */
+    .showcase-wall .comp-card {
+      grid-column: 1 / -1;
+    }
+
+    .showcase-wall .comp-login {
+      grid-row: span 2;
+    }
+
+    .showcase-wall .comp-pricing {
+      grid-column: 1 / -1;
     }
 
     /* ── Shared composition card shell ── */
@@ -433,7 +428,7 @@ export class ScPageHome extends LitElement {
     }
 
     .comp-image-placeholder {
-      height: 140px;
+      height: 120px;
       background: linear-gradient(
         135deg,
         var(--line-subtle-background, #161616) 0%,
@@ -700,7 +695,49 @@ export class ScPageHome extends LitElement {
       background: var(--line-hover-background, #f5f5f5);
     }
 
-    /* ── Card grid ── */
+    /* ── Stats row (full width) ── */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: var(--line-size-3, 1rem);
+      margin-bottom: var(--line-size-9, 4rem);
+    }
+
+    @media (max-width: 600px) {
+      .stats { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    .stat {
+      text-align: center;
+      padding: var(--line-size-5, 1.5rem) var(--line-size-3, 1rem);
+      background: var(--line-subtle-background, #161616);
+      border: var(--line-border-size-1, 1px) solid var(--line-ui-background, #222);
+      border-radius: var(--line-radius-2, 4px);
+    }
+    :host([light]) .stat {
+      background: var(--line-subtle-background, #fafafa);
+      border-color: var(--line-ui-background, #e5e5e5);
+    }
+
+    .stat-value {
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      font-weight: 800;
+      color: var(--line-solid-background, #c8ff00);
+      font-family: 'IBM Plex Mono', monospace;
+      letter-spacing: -0.02em;
+    }
+
+    .stat-label {
+      font-size: var(--line-font-size-1, 0.75rem);
+      color: var(--line-low-contrast, #999);
+      margin-top: var(--line-size-1, 0.25rem);
+      font-weight: var(--line-font-weight-6, 600);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    :host([light]) .stat-label { color: var(--line-low-contrast, #666); }
+
+    /* ── Explore card grid (full width) ── */
     .card-grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -803,13 +840,116 @@ export class ScPageHome extends LitElement {
         The design system for the AI — future is bright!
       </p>
 
-      <div class="snippet">
-        <sc-code-block
-          language="css"
-          .code=${CSS_SNIPPET}
-        ></sc-code-block>
+      <!-- ── Built with tokens — full-width header ── -->
+      <div class="section-title">Built with tokens</div>
+      <p class="section-subtitle">
+        Native HTML elements styled purely with
+        <span style="font-family: 'IBM Plex Mono', monospace;">--line-*</span>
+        design tokens. No components required.
+      </p>
+
+      <!-- ── Two-column showcase ── -->
+      <div class="showcase">
+
+        <!-- LEFT: Code snippet -->
+        <div class="showcase-code">
+          <sc-code-block
+            language="css"
+            .code=${CSS_SNIPPET}
+          ></sc-code-block>
+        </div>
+
+        <!-- RIGHT: Compositions showcase wall -->
+        <div class="showcase-wall">
+
+          <!-- 1. Content card (spans full width of right column) -->
+          <div class="comp comp-card">
+            <div class="comp-card-body">
+              <h3 class="comp-card-title">Token-driven styling</h3>
+              <p class="comp-card-text">
+                Every surface, color, and spacing value comes from semantic
+                tokens. Switch schemas and the entire UI adapts — no component
+                changes needed.
+              </p>
+            </div>
+            <div class="comp-card-footer">
+              <span class="comp-card-footer-label">Tokens used</span>
+              <span class="comp-card-footer-value">12</span>
+            </div>
+          </div>
+
+          <!-- 2. Login form (tall, spans 2 rows) -->
+          <div class="comp comp-login">
+            <h3 class="comp-login-heading">Sign in</h3>
+            <div class="comp-login-field">
+              <label class="comp-login-label">Email</label>
+              <input
+                class="comp-login-input"
+                type="email"
+                placeholder="you@example.com"
+                autocomplete="off"
+              />
+            </div>
+            <div class="comp-login-field">
+              <label class="comp-login-label">Password</label>
+              <input
+                class="comp-login-input"
+                type="password"
+                placeholder="Enter password"
+                autocomplete="off"
+              />
+            </div>
+            <button class="comp-login-submit" type="button">Continue</button>
+            <div class="comp-login-divider">or</div>
+            <button class="comp-login-ghost" type="button">Sign in with SSO</button>
+          </div>
+
+          <!-- 3. Info banner (beside login, top) -->
+          <div class="comp comp-info">
+            <div class="comp-info-indicator"></div>
+            <div>
+              <p class="comp-info-title">Schema applied</p>
+              <p class="comp-info-text">
+                The active color schema maps 12 semantic stops to your
+                chosen palette. Switch schemas and every surface adapts.
+              </p>
+            </div>
+          </div>
+
+          <!-- 4. Image card (beside login, bottom) -->
+          <div class="comp comp-image-card">
+            <div class="comp-image-placeholder">
+              <div class="comp-image-icon"></div>
+            </div>
+            <div class="comp-image-caption">
+              <h3 class="comp-image-title">Visual tokens</h3>
+              <p class="comp-image-desc">
+                Gradients, shadows, and radii adapt across light and
+                dark modes using semantic color references.
+              </p>
+            </div>
+          </div>
+
+          <!-- 5. Pricing card (spans full width of right column) -->
+          <div class="comp comp-pricing">
+            <span class="comp-pricing-plan">Pro</span>
+            <div class="comp-pricing-price">
+              $0<span class="comp-pricing-period"> /forever</span>
+            </div>
+            <ul class="comp-pricing-features">
+              <li>440+ design tokens</li>
+              <li>28 color palettes</li>
+              <li>Light and dark modes</li>
+              <li>Framework-agnostic</li>
+              <li>MIT licensed</li>
+            </ul>
+            <button class="comp-pricing-cta" type="button">Get started</button>
+          </div>
+
+        </div>
       </div>
 
+      <!-- ── Stats row (full width) ── -->
       <div class="stats">
         ${STATS.map(
           (s) => html`
@@ -821,103 +961,7 @@ export class ScPageHome extends LitElement {
         )}
       </div>
 
-      <!-- ── Built with tokens ── -->
-      <div class="section-title">Built with tokens</div>
-      <p class="section-subtitle">
-        Native HTML elements styled purely with
-        <span style="font-family: 'IBM Plex Mono', monospace;">--line-*</span>
-        design tokens. No components required.
-      </p>
-
-      <div class="compositions-grid">
-
-        <!-- 1. Content card -->
-        <div class="comp comp-card">
-          <div class="comp-card-body">
-            <h3 class="comp-card-title">Headless by design</h3>
-            <p class="comp-card-text">
-              Every component ships zero opinions on visuals.
-              Semantic tokens and <span style="font-family: 'IBM Plex Mono', monospace;">::part()</span>
-              give you full control over the look and feel.
-            </p>
-          </div>
-          <div class="comp-card-footer">
-            <span class="comp-card-footer-label">Tokens used</span>
-            <span class="comp-card-footer-value">12</span>
-          </div>
-        </div>
-
-        <!-- 2. Info banner -->
-        <div class="comp comp-info">
-          <div class="comp-info-indicator"></div>
-          <div>
-            <p class="comp-info-title">Schema applied</p>
-            <p class="comp-info-text">
-              The active color schema automatically maps 12 semantic
-              stops to your chosen palette. Switch schemas and every
-              surface adapts instantly.
-            </p>
-          </div>
-        </div>
-
-        <!-- 3. Image card -->
-        <div class="comp comp-image-card">
-          <div class="comp-image-placeholder">
-            <div class="comp-image-icon"></div>
-          </div>
-          <div class="comp-image-caption">
-            <h3 class="comp-image-title">Visual tokens</h3>
-            <p class="comp-image-desc">
-              Gradients, shadows, and radii adapt across light and
-              dark modes using semantic color references.
-            </p>
-          </div>
-        </div>
-
-        <!-- 4. Pricing card -->
-        <div class="comp comp-pricing">
-          <span class="comp-pricing-plan">Pro</span>
-          <div class="comp-pricing-price">
-            $0<span class="comp-pricing-period"> /forever</span>
-          </div>
-          <ul class="comp-pricing-features">
-            <li>440+ design tokens</li>
-            <li>28 color palettes</li>
-            <li>Light and dark modes</li>
-            <li>Framework-agnostic</li>
-            <li>MIT licensed</li>
-          </ul>
-          <button class="comp-pricing-cta" type="button">Get started</button>
-        </div>
-
-        <!-- 5. Login form -->
-        <div class="comp comp-login">
-          <h3 class="comp-login-heading">Sign in</h3>
-          <div class="comp-login-field">
-            <label class="comp-login-label">Email</label>
-            <input
-              class="comp-login-input"
-              type="email"
-              placeholder="you@example.com"
-              autocomplete="off"
-            />
-          </div>
-          <div class="comp-login-field">
-            <label class="comp-login-label">Password</label>
-            <input
-              class="comp-login-input"
-              type="password"
-              placeholder="Enter password"
-              autocomplete="off"
-            />
-          </div>
-          <button class="comp-login-submit" type="button">Continue</button>
-          <div class="comp-login-divider">or</div>
-          <button class="comp-login-ghost" type="button">Sign in with SSO</button>
-        </div>
-
-      </div>
-
+      <!-- ── Explore card grid (full width) ── -->
       <div class="section-title">Explore</div>
       <div class="card-grid">
         ${NAV_CARDS.map(

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -142,7 +142,7 @@ export class ScPageHome extends LitElement {
     /* ── Page-wide gradient background ── */
     :host::before {
       content: '';
-      position: absolute;
+      position: fixed;
       inset: 0;
       background:
         radial-gradient(
@@ -187,7 +187,7 @@ export class ScPageHome extends LitElement {
     /* ── Dot grid pattern across page ── */
     :host::after {
       content: '';
-      position: absolute;
+      position: fixed;
       inset: 0;
       background-image: radial-gradient(
         color-mix(in oklch, var(--line-solid-background) 15%, var(--line-ui-border, #444)) 0.5px,

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -152,18 +152,18 @@ export class ScPageHome extends LitElement {
       inset: 0;
       background:
         radial-gradient(
-          ellipse 80% 60% at 50% 0%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 12%, transparent) 0%,
+          ellipse 100% 80% at 50% 0%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 22%, transparent) 0%,
           transparent 70%
         ),
         radial-gradient(
-          ellipse 50% 40% at 30% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 6%, transparent) 0%,
+          ellipse 60% 50% at 30% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 14%, transparent) 0%,
           transparent 60%
         ),
         radial-gradient(
-          ellipse 50% 40% at 70% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 6%, transparent) 0%,
+          ellipse 60% 50% at 70% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 14%, transparent) 0%,
           transparent 60%
         );
       pointer-events: none;
@@ -172,18 +172,18 @@ export class ScPageHome extends LitElement {
     :host([light]) .hero::before {
       background:
         radial-gradient(
-          ellipse 80% 60% at 50% 0%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 8%, transparent) 0%,
+          ellipse 100% 80% at 50% 0%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 16%, transparent) 0%,
           transparent 70%
         ),
         radial-gradient(
-          ellipse 50% 40% at 30% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 4%, transparent) 0%,
+          ellipse 60% 50% at 30% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, transparent) 0%,
           transparent 60%
         ),
         radial-gradient(
-          ellipse 50% 40% at 70% 20%,
-          color-mix(in oklch, var(--line-solid-background, #c8ff00) 4%, transparent) 0%,
+          ellipse 60% 50% at 70% 20%,
+          color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, transparent) 0%,
           transparent 60%
         );
     }
@@ -197,14 +197,14 @@ export class ScPageHome extends LitElement {
         transparent 1px
       );
       background-size: 24px 24px;
-      opacity: 0.3;
+      opacity: 0.4;
       pointer-events: none;
       z-index: 0;
       mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 0%, transparent 70%);
       -webkit-mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 0%, transparent 70%);
     }
     :host([light]) .hero::after {
-      opacity: 0.4;
+      opacity: 0.5;
     }
 
     .hero > * {
@@ -219,8 +219,16 @@ export class ScPageHome extends LitElement {
       color: var(--line-high-contrast, #fff);
       margin: 0;
       line-height: 1.1;
+      text-shadow:
+        0 0 60px color-mix(in oklch, var(--line-solid-background, #c8ff00) 35%, transparent),
+        0 0 120px color-mix(in oklch, var(--line-solid-background, #c8ff00) 15%, transparent);
     }
-    :host([light]) .wordmark { color: var(--line-high-contrast, #1a1a1a); }
+    :host([light]) .wordmark {
+      color: var(--line-high-contrast, #1a1a1a);
+      text-shadow:
+        0 0 60px color-mix(in oklch, var(--line-solid-background, #c8ff00) 25%, transparent),
+        0 0 120px color-mix(in oklch, var(--line-solid-background, #c8ff00) 10%, transparent);
+    }
 
     .wordmark-accent {
       color: var(--line-solid-background, #c8ff00);
@@ -228,11 +236,10 @@ export class ScPageHome extends LitElement {
 
     .tagline {
       font-size: var(--line-font-size-3, 1.25rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 50%, var(--line-low-contrast));
       margin: var(--line-size-3, 1rem) 0 0;
       font-weight: var(--line-font-weight-4, 400);
     }
-    :host([light]) .tagline { color: var(--line-low-contrast, #666); }
 
     .intro {
       text-align: center;
@@ -248,22 +255,20 @@ export class ScPageHome extends LitElement {
     .section-title {
       font-size: var(--line-font-size-1, 0.75rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-low-contrast, #999);
+      color: var(--line-solid-background, #c8ff00);
       letter-spacing: 0.1em;
       text-transform: uppercase;
       margin-bottom: var(--line-size-4, 1.25rem);
     }
-    :host([light]) .section-title { color: var(--line-low-contrast, #666); }
 
     .section-subtitle {
       font-size: var(--line-font-size-2, 1rem);
-      color: var(--line-low-contrast, #999);
+      color: color-mix(in oklch, var(--line-solid-background) 60%, var(--line-low-contrast));
       margin-top: var(--line-size-1, 0.25rem);
       margin-bottom: var(--line-size-6, 2rem);
       line-height: var(--line-lineheight-3, 1.6);
       max-width: 520px;
     }
-    :host([light]) .section-subtitle { color: var(--line-low-contrast, #666); }
 
     /* ── Two-column showcase layout ── */
     .showcase {
@@ -348,10 +353,9 @@ export class ScPageHome extends LitElement {
     .comp-card-title {
       font-size: var(--line-font-size-3, 1.25rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 40%, var(--line-high-contrast));
       margin: 0 0 var(--line-size-2, 0.5rem);
     }
-    :host([light]) .comp-card-title { color: var(--line-high-contrast, #1a1a1a); }
 
     .comp-card-text {
       font-size: var(--line-font-size-1, 0.75rem);
@@ -463,10 +467,9 @@ export class ScPageHome extends LitElement {
     .comp-image-title {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 40%, var(--line-high-contrast));
       margin: 0 0 var(--line-size-1, 0.25rem);
     }
-    :host([light]) .comp-image-title { color: var(--line-high-contrast, #1a1a1a); }
 
     .comp-image-desc {
       font-size: var(--line-font-size-1, 0.75rem);
@@ -571,10 +574,9 @@ export class ScPageHome extends LitElement {
     .comp-login-heading {
       font-size: var(--line-font-size-3, 1.25rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 40%, var(--line-high-contrast));
       margin: 0;
     }
-    :host([light]) .comp-login-heading { color: var(--line-high-contrast, #1a1a1a); }
 
     .comp-login-field {
       display: flex;
@@ -805,10 +807,9 @@ export class ScPageHome extends LitElement {
     .card-title {
       font-size: var(--line-font-size-2, 1rem);
       font-weight: var(--line-font-weight-7, 700);
-      color: var(--line-high-contrast, #fff);
+      color: color-mix(in oklch, var(--line-solid-background) 30%, var(--line-high-contrast));
       margin-bottom: var(--line-size-1, 0.25rem);
     }
-    :host([light]) .card-title { color: var(--line-high-contrast, #1a1a1a); }
 
     .card-desc {
       font-size: var(--line-font-size-1, 0.75rem);

--- a/apps/showcase/src/pages/home.ts
+++ b/apps/showcase/src/pages/home.ts
@@ -190,18 +190,18 @@ export class ScPageHome extends LitElement {
       position: absolute;
       inset: 0;
       background-image: radial-gradient(
-        color-mix(in oklch, var(--line-solid-background) 20%, var(--line-ui-border, #444)) 1px,
-        transparent 1px
+        color-mix(in oklch, var(--line-solid-background) 15%, var(--line-ui-border, #444)) 0.5px,
+        transparent 0.5px
       );
-      background-size: 24px 24px;
-      opacity: 0.25;
+      background-size: 20px 20px;
+      opacity: 0.2;
       pointer-events: none;
       z-index: 0;
-      mask-image: linear-gradient(to bottom, black 0%, transparent 60%);
-      -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 60%);
+      mask-image: linear-gradient(to bottom, transparent 0%, black 5%, black 40%, transparent 65%);
+      -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 5%, black 40%, transparent 65%);
     }
     :host([light])::after {
-      opacity: 0.3;
+      opacity: 0.25;
     }
 
     :host > * {
@@ -212,7 +212,11 @@ export class ScPageHome extends LitElement {
     /* ── Hero ── */
     .hero {
       text-align: left;
-      padding: var(--line-size-5, 1.5rem) 0 var(--line-size-8, 3rem);
+      padding: var(--line-size-6, 2rem);
+      margin-bottom: var(--line-size-8, 3rem);
+      background: color-mix(in oklch, var(--line-solid-background) 5%, var(--line-subtle-background));
+      border: 1px solid color-mix(in oklch, var(--line-solid-background) 10%, var(--line-ui-background));
+      border-radius: var(--line-radius-3, 8px);
     }
 
     .wordmark {


### PR DESCRIPTION
…nd navigation cards

Wire 'home' into the panel system as the default landing page. Add logo click handler in sc-nav to navigate back to home. Full home page with wordmark hero, intro blurb, CSS theming snippet (using sc-code-block), 4-stat summary row, and 10 navigation cards dispatching sc-navigate events.