### PR TITLE
fix(showcase): extract product card into headless component with ::pa…

### DIFF
--- a/apps/showcase/src/components/sc-product-card.ts
+++ b/apps/showcase/src/components/sc-product-card.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 /**
  * Headless e-commerce product card component.
@@ -35,6 +35,9 @@ export class ScProductCard extends LitElement {
 
   /** Button label text */
   @property({ type: String, attribute: 'button-label' }) buttonLabel = 'Add to Cart';
+
+  /** Tracks whether the image failed to load, triggering placeholder rendering */
+  @state() private _imageError = false;
 
   /** Comma-separated list of size chip labels (e.g. "S,M,L,XL") */
   @property({ type: String }) sizes = '';
@@ -217,19 +220,8 @@ export class ScProductCard extends LitElement {
     }
   `;
 
-  private _handleImageError(event: Event) {
-    const img = event.target as HTMLImageElement;
-    const placeholder = document.createElement('div');
-    placeholder.className = 'image-placeholder';
-    placeholder.setAttribute('part', 'image-placeholder');
-    placeholder.innerHTML = `
-      <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="8" y="12" width="48" height="36" rx="4" stroke="currentColor" stroke-width="2"/>
-        <circle cx="22" cy="26" r="5" stroke="currentColor" stroke-width="2"/>
-        <path d="M8 40 L24 28 L36 38 L44 32 L56 42" stroke="currentColor" stroke-width="2" fill="none"/>
-      </svg>
-    `;
-    img.replaceWith(placeholder);
+  private _handleImageError() {
+    this._imageError = true;
   }
 
   private _renderSizeChips() {
@@ -251,6 +243,10 @@ export class ScProductCard extends LitElement {
 
   private _renderColorDots() {
     if (!this.colors || this.colors.length === 0) return nothing;
+    // NOTE: Showcase-only pattern. Color values come from the consumer via .colors
+    // property binding and are inserted as inline styles. In production line://ui
+    // components, user-supplied values must be sanitized before inline style injection
+    // to prevent CSS injection vectors (e.g. url() exfiltration via background-image).
     return html`
       <div class="color-dots" part="color-dots">
         ${this.colors.map(
@@ -271,7 +267,7 @@ export class ScProductCard extends LitElement {
     return html`
       <div class="card" part="card">
         ${
-          this.imageSrc
+          this.imageSrc && !this._imageError
             ? html`
               <img
                 class="image"

--- a/apps/showcase/src/components/sc-product-card.ts
+++ b/apps/showcase/src/components/sc-product-card.ts
@@ -1,0 +1,325 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+/**
+ * Headless e-commerce product card component.
+ *
+ * Defines structure and layout only — no design system tokens internally.
+ * Every visual zone is exposed via `::part()` for external styling.
+ *
+ * Generic CSS custom properties (no `--line-*` prefix) allow structural
+ * customisation from the consumer.
+ */
+@customElement('sc-product-card')
+export class ScProductCard extends LitElement {
+  /** Product title */
+  @property({ type: String }) heading = '';
+
+  /** Product description text */
+  @property({ type: String }) description = '';
+
+  /** Product price display string */
+  @property({ type: String }) price = '';
+
+  /** Rating display string (e.g. "★★★★☆") */
+  @property({ type: String }) rating = '';
+
+  /** Accessible label for rating (e.g. "4 out of 5 stars") */
+  @property({ type: String, attribute: 'rating-label' }) ratingLabel = '';
+
+  /** Image src URL */
+  @property({ type: String, attribute: 'image-src' }) imageSrc = '';
+
+  /** Image alt text */
+  @property({ type: String, attribute: 'image-alt' }) imageAlt = '';
+
+  /** Button label text */
+  @property({ type: String, attribute: 'button-label' }) buttonLabel = 'Add to Cart';
+
+  /** Comma-separated list of size chip labels (e.g. "S,M,L,XL") */
+  @property({ type: String }) sizes = '';
+
+  /** Index of the active size chip (0-based) */
+  @property({ type: Number, attribute: 'active-size' }) activeSize = -1;
+
+  /**
+   * Color dot definitions as JSON string array of objects.
+   * Each object: { color: string; label: string; selected?: boolean }
+   */
+  @property({ type: Array }) colors: { color: string; label: string; selected?: boolean }[] = [];
+
+  static override styles = css`
+    :host {
+      --card-radius: 8px;
+      --card-padding: 1.25rem;
+      --card-gap: 1rem;
+      --card-image-height: 200px;
+      --card-border-width: 1px;
+
+      --title-font-size: 1rem;
+      --title-font-weight: 700;
+      --title-letter-spacing: -0.01em;
+
+      --desc-font-size: 0.875rem;
+      --desc-line-height: 1.6;
+
+      --price-font-size: 1.25rem;
+      --price-font-weight: 800;
+
+      --rating-font-size: 0.875rem;
+      --rating-letter-spacing: 0.05em;
+
+      --chip-min-width: 36px;
+      --chip-height: 32px;
+      --chip-padding-inline: 0.5rem;
+      --chip-radius: 4px;
+      --chip-font-size: 0.75rem;
+      --chip-font-weight: 600;
+      --chip-border-width: 1px;
+
+      --dot-size: 20px;
+      --dot-border-width: 2px;
+
+      --button-padding: 1rem;
+      --button-radius: 4px;
+      --button-font-size: 0.875rem;
+      --button-font-weight: 700;
+
+      --placeholder-icon-size: 64px;
+
+      display: block;
+    }
+
+    /* ── Card shell ── */
+    .card {
+      border-radius: var(--card-radius);
+      overflow: hidden;
+      border: var(--card-border-width) solid;
+      border-color: transparent;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ── Image ── */
+    .image {
+      width: 100%;
+      height: var(--card-image-height);
+      object-fit: cover;
+      display: block;
+    }
+
+    .image-placeholder {
+      width: 100%;
+      height: var(--card-image-height);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .image-placeholder svg {
+      width: var(--placeholder-icon-size);
+      height: var(--placeholder-icon-size);
+      opacity: 0.4;
+    }
+
+    /* ── Body ── */
+    .body {
+      padding: var(--card-padding);
+      display: flex;
+      flex-direction: column;
+      gap: var(--card-gap);
+      flex: 1;
+    }
+
+    /* ── Title ── */
+    .title {
+      font-size: var(--title-font-size);
+      font-weight: var(--title-font-weight);
+      letter-spacing: var(--title-letter-spacing);
+      margin: 0;
+    }
+
+    /* ── Description ── */
+    .description {
+      font-size: var(--desc-font-size);
+      line-height: var(--desc-line-height);
+      margin: 0;
+    }
+
+    /* ── Price row ── */
+    .price-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .price {
+      font-size: var(--price-font-size);
+      font-weight: var(--price-font-weight);
+    }
+
+    .rating {
+      font-size: var(--rating-font-size);
+      letter-spacing: var(--rating-letter-spacing);
+    }
+
+    /* ── Size chips ── */
+    .size-chips {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: var(--chip-min-width);
+      height: var(--chip-height);
+      padding: 0 var(--chip-padding-inline);
+      border-radius: var(--chip-radius);
+      font-size: var(--chip-font-size);
+      font-weight: var(--chip-font-weight);
+      cursor: pointer;
+      border: var(--chip-border-width) solid;
+      border-color: transparent;
+      transition: all 150ms ease-in-out;
+    }
+
+    /* ── Color dots ── */
+    .color-dots {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .dot {
+      width: var(--dot-size);
+      height: var(--dot-size);
+      border-radius: 50%;
+      cursor: pointer;
+      border: var(--dot-border-width) solid transparent;
+      transition: border-color 150ms ease-in-out;
+    }
+
+    /* ── Button ── */
+    .button {
+      width: 100%;
+      padding: var(--button-padding);
+      border: none;
+      border-radius: var(--button-radius);
+      font-size: var(--button-font-size);
+      font-weight: var(--button-font-weight);
+      cursor: pointer;
+      transition: background 150ms ease-in-out;
+      margin-top: auto;
+    }
+  `;
+
+  private _handleImageError(event: Event) {
+    const img = event.target as HTMLImageElement;
+    const placeholder = document.createElement('div');
+    placeholder.className = 'image-placeholder';
+    placeholder.setAttribute('part', 'image-placeholder');
+    placeholder.innerHTML = `
+      <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="8" y="12" width="48" height="36" rx="4" stroke="currentColor" stroke-width="2"/>
+        <circle cx="22" cy="26" r="5" stroke="currentColor" stroke-width="2"/>
+        <path d="M8 40 L24 28 L36 38 L44 32 L56 42" stroke="currentColor" stroke-width="2" fill="none"/>
+      </svg>
+    `;
+    img.replaceWith(placeholder);
+  }
+
+  private _renderSizeChips() {
+    if (!this.sizes) return nothing;
+    const labels = this.sizes.split(',').map((s) => s.trim());
+    return html`
+      <div class="size-chips" part="size-chips">
+        ${labels.map(
+          (label, i) => html`
+            <span
+              class="chip ${i === this.activeSize ? 'active' : ''}"
+              part="chip ${i === this.activeSize ? 'chip-active' : ''}"
+            >${label}</span>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private _renderColorDots() {
+    if (!this.colors || this.colors.length === 0) return nothing;
+    return html`
+      <div class="color-dots" part="color-dots">
+        ${this.colors.map(
+          (c) => html`
+            <span
+              class="dot ${c.selected ? 'selected' : ''}"
+              part="dot ${c.selected ? 'dot-selected' : ''}"
+              title=${c.label}
+              style="background: ${c.color}"
+            ></span>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  override render() {
+    return html`
+      <div class="card" part="card">
+        ${
+          this.imageSrc
+            ? html`
+              <img
+                class="image"
+                part="image"
+                src=${this.imageSrc}
+                alt=${this.imageAlt}
+                loading="lazy"
+                @error=${this._handleImageError}
+              />
+            `
+            : html`
+              <div class="image-placeholder" part="image-placeholder">
+                <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="8" y="12" width="48" height="36" rx="4" stroke="currentColor" stroke-width="2"/>
+                  <circle cx="22" cy="26" r="5" stroke="currentColor" stroke-width="2"/>
+                  <path d="M8 40 L24 28 L36 38 L44 32 L56 42" stroke="currentColor" stroke-width="2" fill="none"/>
+                </svg>
+              </div>
+            `
+        }
+        <div class="body" part="body">
+          <h3 class="title" part="title">${this.heading}</h3>
+          ${this.description ? html`<p class="description" part="description">${this.description}</p>` : nothing}
+          ${
+            this.price || this.rating
+              ? html`
+                <div class="price-row" part="price-row">
+                  ${this.price ? html`<span class="price" part="price">${this.price}</span>` : nothing}
+                  ${
+                    this.rating
+                      ? html`<span class="rating" part="rating" aria-label=${this.ratingLabel || ''}>${this.rating}</span>`
+                      : nothing
+                  }
+                </div>
+              `
+              : nothing
+          }
+          ${this._renderSizeChips()}
+          ${this._renderColorDots()}
+          <button class="button" part="button" type="button">${this.buttonLabel}</button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-product-card': ScProductCard;
+  }
+}

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -1,6 +1,8 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import '../components/sc-product-card.js';
+
 export type { PlaygroundBlockConfig } from './playground-config.js';
 
 @customElement('sc-page-playground')
@@ -186,7 +188,7 @@ export class ScPagePlayground extends LitElement {
       font-style: italic;
     }
 
-    /* ── E-commerce product card block (T3) ── */
+    /* ── E-commerce product card grid (T3) ── */
     .product-grid {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
@@ -200,196 +202,86 @@ export class ScPagePlayground extends LitElement {
       }
     }
 
-    .product-card {
-      border-radius: var(--line-radius-3, 8px);
-      overflow: hidden;
-      border: var(--line-border-size-1, 1px) solid;
-      display: flex;
-      flex-direction: column;
-    }
+    /*
+     * Consumer styles for <sc-product-card> via ::part().
+     * All design system tokens (--line-*) are applied HERE, not inside the component.
+     */
 
-    .product-card--slate {
+    /* ── Slate-variant card ── */
+    .product-card-slate::part(card) {
       background: light-dark(var(--line-slate-2), var(--line-slate-11));
       border-color: light-dark(var(--line-slate-6), var(--line-slate-7));
     }
 
-    .product-card--mauve {
-      background: light-dark(var(--line-mauve-2), var(--line-mauve-11));
-      border-color: light-dark(var(--line-mauve-6), var(--line-mauve-7));
-    }
-
-    .product-image {
-      width: 100%;
-      height: 200px;
-      object-fit: cover;
-      display: block;
+    .product-card-slate::part(image),
+    .product-card-slate::part(image-placeholder) {
       background: light-dark(var(--line-slate-3), var(--line-slate-10));
     }
 
-    .product-image-placeholder {
-      width: 100%;
-      height: 200px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: light-dark(var(--line-slate-3), var(--line-slate-10));
-    }
-
-    .product-image-placeholder svg {
-      width: 64px;
-      height: 64px;
-      opacity: 0.4;
-    }
-
-    .card-body {
-      padding: var(--line-size-4, 1.25rem);
-      display: flex;
-      flex-direction: column;
-      gap: var(--line-size-3, 1rem);
-      flex: 1;
-    }
-
-    .product-title {
-      font-size: var(--line-font-size-2, 1rem);
-      font-weight: var(--line-font-weight-7, 700);
-      margin: 0;
-      letter-spacing: -0.01em;
-    }
-
-    .product-card--slate .product-title {
+    .product-card-slate::part(title) {
       color: light-dark(var(--line-slate-12), var(--line-slate-1));
     }
 
-    .product-card--mauve .product-title {
-      color: light-dark(var(--line-mauve-12), var(--line-mauve-1));
-    }
-
-    .product-desc {
-      font-size: var(--line-font-size-1, 0.875rem);
-      line-height: var(--line-line-height-3, 1.6);
-      margin: 0;
-    }
-
-    .product-card--slate .product-desc {
+    .product-card-slate::part(description) {
       color: light-dark(var(--line-slate-11), var(--line-slate-2));
     }
 
-    .product-card--mauve .product-desc {
-      color: light-dark(var(--line-mauve-11), var(--line-mauve-2));
-    }
-
-    .price-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: var(--line-size-2, 0.5rem);
-    }
-
-    .price {
-      font-size: var(--line-font-size-3, 1.25rem);
-      font-weight: var(--line-font-weight-8, 800);
-      color: var(--line-solid-background);
-    }
-
-    .rating {
-      font-size: var(--line-font-size-1, 0.875rem);
-      color: var(--line-warning);
-      letter-spacing: 0.05em;
-    }
-
-    .size-chips {
-      display: flex;
-      gap: var(--line-size-2, 0.5rem);
-      flex-wrap: wrap;
-    }
-
-    .chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 36px;
-      height: 32px;
-      padding: 0 var(--line-size-2, 0.5rem);
-      border-radius: var(--line-radius-2, 4px);
-      font-size: var(--line-font-size-0, 0.75rem);
-      font-weight: var(--line-font-weight-6, 600);
-      cursor: pointer;
-      border: var(--line-border-size-1, 1px) solid;
-      transition: all 150ms ease-in-out;
-    }
-
-    .product-card--slate .chip {
+    .product-card-slate::part(chip) {
       background: light-dark(var(--line-slate-3), var(--line-slate-10));
       color: light-dark(var(--line-slate-11), var(--line-slate-2));
       border-color: light-dark(var(--line-slate-6), var(--line-slate-7));
     }
 
-    .product-card--mauve .chip {
+    /* ── Mauve-variant card ── */
+    .product-card-mauve::part(card) {
+      background: light-dark(var(--line-mauve-2), var(--line-mauve-11));
+      border-color: light-dark(var(--line-mauve-6), var(--line-mauve-7));
+    }
+
+    .product-card-mauve::part(image),
+    .product-card-mauve::part(image-placeholder) {
+      background: light-dark(var(--line-mauve-3), var(--line-mauve-10));
+    }
+
+    .product-card-mauve::part(title) {
+      color: light-dark(var(--line-mauve-12), var(--line-mauve-1));
+    }
+
+    .product-card-mauve::part(description) {
+      color: light-dark(var(--line-mauve-11), var(--line-mauve-2));
+    }
+
+    .product-card-mauve::part(chip) {
       background: light-dark(var(--line-mauve-3), var(--line-mauve-10));
       color: light-dark(var(--line-mauve-11), var(--line-mauve-2));
       border-color: light-dark(var(--line-mauve-6), var(--line-mauve-7));
     }
 
-    .chip.active {
+    /* ── Shared accent styles (both variants) ── */
+    sc-product-card::part(price) {
+      color: var(--line-solid-background);
+    }
+
+    sc-product-card::part(rating) {
+      color: var(--line-warning);
+    }
+
+    sc-product-card::part(chip-active) {
       background: var(--line-solid-background);
       color: var(--line-solid-text, #fff);
       border-color: var(--line-solid-background);
     }
 
-    .color-dots {
-      display: flex;
-      gap: var(--line-size-2, 0.5rem);
-      align-items: center;
-    }
-
-    .dot {
-      width: 20px;
-      height: 20px;
-      border-radius: 50%;
-      cursor: pointer;
-      border: 2px solid transparent;
-      transition: border-color 150ms ease-in-out;
-    }
-
-    .dot.selected {
+    sc-product-card::part(dot-selected) {
       border-color: var(--line-high-contrast, #fff);
     }
 
-    .dot--crimson {
-      background: var(--line-crimson-9);
-    }
-
-    .dot--violet {
-      background: var(--line-violet-9);
-    }
-
-    .dot--slate {
-      background: var(--line-slate-9);
-    }
-
-    .dot--indigo {
-      background: var(--line-indigo-9);
-    }
-
-    .dot--teal {
-      background: var(--line-teal-9);
-    }
-
-    .add-to-cart {
-      width: 100%;
-      padding: var(--line-size-3, 1rem);
-      border: none;
-      border-radius: var(--line-radius-2, 4px);
+    sc-product-card::part(button) {
       background: var(--line-solid-background);
       color: var(--line-solid-text, #fff);
-      font-size: var(--line-font-size-1, 0.875rem);
-      font-weight: var(--line-font-weight-7, 700);
-      cursor: pointer;
-      transition: background 150ms ease-in-out;
-      margin-top: auto;
     }
 
-    .add-to-cart:hover {
+    sc-product-card::part(button):hover {
       background: var(--line-solid-hover);
     }
 
@@ -452,20 +344,6 @@ export class ScPagePlayground extends LitElement {
     }
   `;
 
-  private _handleImageError(event: Event) {
-    const img = event.target as HTMLImageElement;
-    const placeholder = document.createElement('div');
-    placeholder.className = 'product-image-placeholder';
-    placeholder.innerHTML = `
-      <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="8" y="12" width="48" height="36" rx="4" stroke="currentColor" stroke-width="2"/>
-        <circle cx="22" cy="26" r="5" stroke="currentColor" stroke-width="2"/>
-        <path d="M8 40 L24 28 L36 38 L44 32 L56 42" stroke="currentColor" stroke-width="2" fill="none"/>
-      </svg>
-    `;
-    img.replaceWith(placeholder);
-  }
-
   override render() {
     return html`
       <!-- Mobile: collapsed accent bar -->
@@ -518,72 +396,44 @@ export class ScPagePlayground extends LitElement {
           <div class="block-wrapper">
             <div class="product-grid">
               <!-- Card 1: Slate base -->
-              <div class="product-card product-card--slate" part="product-card-1">
-                <img
-                  class="product-image"
-                  src="https://picsum.photos/400/300?random=1"
-                  alt="Classic Sneaker"
-                  loading="lazy"
-                  @error=${this._handleImageError}
-                />
-                <div class="card-body">
-                  <h3 class="product-title">Classic Sneaker</h3>
-                  <p class="product-desc">
-                    Timeless design meets modern comfort. Crafted with premium
-                    materials for everyday wear.
-                  </p>
-                  <div class="price-row">
-                    <span class="price">$89.00</span>
-                    <span class="rating" aria-label="4 out of 5 stars">★★★★☆</span>
-                  </div>
-                  <div class="size-chips">
-                    <span class="chip">S</span>
-                    <span class="chip active">M</span>
-                    <span class="chip">L</span>
-                    <span class="chip">XL</span>
-                  </div>
-                  <div class="color-dots">
-                    <span class="dot dot--crimson" title="Crimson"></span>
-                    <span class="dot dot--violet" title="Violet"></span>
-                    <span class="dot dot--slate selected" title="Slate"></span>
-                  </div>
-                  <button class="add-to-cart" type="button">Add to Cart</button>
-                </div>
-              </div>
+              <sc-product-card
+                class="product-card-slate"
+                heading="Classic Sneaker"
+                description="Timeless design meets modern comfort. Crafted with premium materials for everyday wear."
+                price="$89.00"
+                rating="★★★★☆"
+                rating-label="4 out of 5 stars"
+                image-src="https://picsum.photos/400/300?random=1"
+                image-alt="Classic Sneaker"
+                button-label="Add to Cart"
+                sizes="S,M,L,XL"
+                active-size="1"
+                .colors=${[
+                  { color: 'var(--line-crimson-9)', label: 'Crimson' },
+                  { color: 'var(--line-violet-9)', label: 'Violet' },
+                  { color: 'var(--line-slate-9)', label: 'Slate', selected: true }
+                ]}
+              ></sc-product-card>
 
               <!-- Card 2: Mauve base -->
-              <div class="product-card product-card--mauve" part="product-card-2">
-                <img
-                  class="product-image"
-                  src="https://picsum.photos/400/300?random=2"
-                  alt="Heritage Backpack"
-                  loading="lazy"
-                  @error=${this._handleImageError}
-                />
-                <div class="card-body">
-                  <h3 class="product-title">Heritage Backpack</h3>
-                  <p class="product-desc">
-                    Water-resistant canvas with leather accents. Built to carry
-                    your essentials in style.
-                  </p>
-                  <div class="price-row">
-                    <span class="price">$129.00</span>
-                    <span class="rating" aria-label="5 out of 5 stars">★★★★★</span>
-                  </div>
-                  <div class="size-chips">
-                    <span class="chip active">S</span>
-                    <span class="chip">M</span>
-                    <span class="chip">L</span>
-                    <span class="chip">XL</span>
-                  </div>
-                  <div class="color-dots">
-                    <span class="dot dot--indigo" title="Indigo"></span>
-                    <span class="dot dot--teal selected" title="Teal"></span>
-                    <span class="dot dot--crimson" title="Crimson"></span>
-                  </div>
-                  <button class="add-to-cart" type="button">Add to Cart</button>
-                </div>
-              </div>
+              <sc-product-card
+                class="product-card-mauve"
+                heading="Heritage Backpack"
+                description="Water-resistant canvas with leather accents. Built to carry your essentials in style."
+                price="$129.00"
+                rating="★★★★★"
+                rating-label="5 out of 5 stars"
+                image-src="https://picsum.photos/400/300?random=2"
+                image-alt="Heritage Backpack"
+                button-label="Add to Cart"
+                sizes="S,M,L,XL"
+                active-size="0"
+                .colors=${[
+                  { color: 'var(--line-indigo-9)', label: 'Indigo' },
+                  { color: 'var(--line-teal-9)', label: 'Teal', selected: true },
+                  { color: 'var(--line-crimson-9)', label: 'Crimson' }
+                ]}
+              ></sc-product-card>
             </div>
           </div>
           <div class="block-wrapper">


### PR DESCRIPTION
…rt() API

Refactor the T3 e-commerce product card from inline Shadow DOM styles with hardcoded design tokens into a separate <sc-product-card> custom element that defines structure and layout only. All design system tokens (--line-*) are now applied externally by sc-page-playground via ::part() selectors, establishing the correct headless pattern for all showcase composition blocks.

Resolves: line-ui-m3d.8