### PR TITLE
feat(sc-dashboard-block): headless dashboard block (T5)

### DIFF
--- a/apps/showcase/src/components/sc-dashboard-block.ts
+++ b/apps/showcase/src/components/sc-dashboard-block.ts
@@ -1,0 +1,444 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+/**
+ * One notification entry consumed by `<sc-dashboard-block>`.
+ *
+ * `kind` selects which fixed-intent part the consumer paints:
+ * `success`, `warning` or `danger`.
+ */
+export interface ScDashboardNotification {
+  kind: 'success' | 'warning' | 'danger';
+  title: string;
+  body: string;
+}
+
+/**
+ * One stat-card entry consumed by `<sc-dashboard-block>`.
+ *
+ * `intent` selects which fixed-intent part the consumer paints
+ * (`info`, `success`, `warning`) — except `accent`, which is the
+ * single accent-reactive stat card and inherits the picker schema.
+ */
+export interface ScDashboardStat {
+  value: string;
+  label: string;
+  intent: 'info' | 'success' | 'warning' | 'accent';
+}
+
+/**
+ * One toggle row consumed by `<sc-dashboard-block>`.
+ */
+export interface ScDashboardToggle {
+  label: string;
+  on: boolean;
+}
+
+/**
+ * Detail payload emitted by `sc-toggle-change`.
+ */
+export interface ScDashboardToggleChangeDetail {
+  index: number;
+  on: boolean;
+}
+
+/**
+ * Headless dashboard / notifications composition block.
+ *
+ * Defines structure and layout only — no design system tokens internally.
+ * Every visual zone is exposed via `::part()` for external styling. Generic
+ * CSS custom properties (without the design system prefix) allow structural
+ * customisation from the consumer.
+ *
+ * Mirrors the headless contract established by `sc-product-card` and
+ * `sc-music-player` (see docs/specs/00-spec-playground.md §0, §8.5, §16 D1).
+ *
+ * Three sections render in order:
+ *
+ * 1. **Notifications** — fixed-intent alerts (success / warning / danger).
+ *    Each notif carries an additive `notif-{kind}` part so the consumer can
+ *    paint with L3 intent aliases (`--line-success`, `--line-warning`,
+ *    `--line-danger`). `success` and `warning` use `role="status"`;
+ *    `danger` uses `role="alert"` per spec §11.
+ * 2. **Stats** — a 4-card grid. Three cards are fixed-intent
+ *    (`info` / `success` / `warning`); the fourth uses the `accent` intent and
+ *    inherits the picker schema via `--line-solid-*`. Each card carries an
+ *    additive `stat-card-{intent}` part.
+ * 3. **Toggles** — real `<button role="switch" aria-checked>` controls (spec
+ *    §11). Space/Enter flips state (spec §10) and emits `sc-toggle-change`
+ *    with `{ index, on }`. The active toggle carries an additive
+ *    `toggle-on` / `toggle-off` part so the accent-reactive "on" state can
+ *    be painted independently.
+ *
+ * @fires sc-toggle-change - User flipped a toggle (click or Space/Enter). Detail: `{ index, on }`.
+ */
+@customElement('sc-dashboard-block')
+export class ScDashboardBlock extends LitElement {
+  /** Fixed-intent alerts. */
+  @property({ type: Array }) notifications: ScDashboardNotification[] = [];
+
+  /** Stat cards; the entry with `intent: 'accent'` reacts to the picker schema. */
+  @property({ type: Array }) stats: ScDashboardStat[] = [];
+
+  /** Settings toggles; flipping mutates the array via re-assignment so Lit re-renders. */
+  @property({ type: Array }) toggles: ScDashboardToggle[] = [];
+
+  static override styles = css`
+    :host {
+      --container-radius: 12px;
+      --container-padding: 1.5rem;
+      --section-gap: 1.5rem;
+
+      --section-title-font-size: 0.75rem;
+      --section-title-font-weight: 700;
+      --section-title-letter-spacing: 0.08em;
+
+      --notif-radius: 8px;
+      --notif-padding: 0.875rem 1rem;
+      --notif-gap: 0.75rem;
+      --notif-border-width: 1px;
+
+      --stat-card-radius: 8px;
+      --stat-card-padding: 1rem;
+      --stat-value-font-size: 1.5rem;
+      --stat-value-font-weight: 800;
+      --stat-label-font-size: 0.75rem;
+
+      --toggle-row-height: 40px;
+      --toggle-width: 40px;
+      --toggle-radius: 999px;
+      --toggle-thumb-size: 16px;
+
+      display: block;
+    }
+
+    /* ── Shell ── */
+    .container {
+      box-sizing: border-box;
+      border-radius: var(--container-radius);
+      padding: var(--container-padding);
+      display: flex;
+      flex-direction: column;
+      gap: var(--section-gap);
+      width: 100%;
+    }
+
+    /* ── Sections ── */
+    .section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .section-title {
+      margin: 0;
+      font-size: var(--section-title-font-size);
+      font-weight: var(--section-title-font-weight);
+      letter-spacing: var(--section-title-letter-spacing);
+      text-transform: uppercase;
+    }
+
+    /* ── Notifications ── */
+    .notif-row {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .notif {
+      box-sizing: border-box;
+      border-radius: var(--notif-radius);
+      padding: var(--notif-padding);
+      display: flex;
+      align-items: flex-start;
+      gap: var(--notif-gap);
+      border: var(--notif-border-width) solid transparent;
+    }
+
+    .notif-icon {
+      flex-shrink: 0;
+      width: 20px;
+      height: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .notif-icon svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    .notif-text {
+      display: flex;
+      flex-direction: column;
+      gap: 0.125rem;
+      min-width: 0;
+    }
+
+    .notif-title {
+      margin: 0;
+      font-size: 0.875rem;
+      font-weight: 700;
+    }
+
+    .notif-body {
+      margin: 0;
+      font-size: 0.8125rem;
+      line-height: 1.4;
+    }
+
+    /* ── Stats ── */
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0.75rem;
+    }
+
+    @media (max-width: 640px) {
+      .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+
+    .stat-card {
+      box-sizing: border-box;
+      border-radius: var(--stat-card-radius);
+      padding: var(--stat-card-padding);
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .stat-value {
+      font-size: var(--stat-value-font-size);
+      font-weight: var(--stat-value-font-weight);
+      font-variant-numeric: tabular-nums;
+      line-height: 1.1;
+    }
+
+    .stat-label {
+      font-size: var(--stat-label-font-size);
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Toggles ── */
+    .toggle-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .toggle-row {
+      box-sizing: border-box;
+      min-height: var(--toggle-row-height);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.25rem 0;
+    }
+
+    .toggle-label {
+      font-size: 0.875rem;
+      font-weight: 500;
+    }
+
+    .toggle {
+      box-sizing: border-box;
+      width: var(--toggle-width);
+      height: calc(var(--toggle-thumb-size) + 6px);
+      border-radius: var(--toggle-radius);
+      border: 1px solid transparent;
+      background: transparent;
+      padding: 2px;
+      cursor: pointer;
+      font-family: inherit;
+      display: inline-flex;
+      align-items: center;
+      position: relative;
+      transition: background 150ms ease-in-out, border-color 150ms ease-in-out;
+    }
+
+    .toggle:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 2px;
+    }
+
+    .toggle::before {
+      content: '';
+      display: block;
+      width: var(--toggle-thumb-size);
+      height: var(--toggle-thumb-size);
+      border-radius: 50%;
+      background: currentColor;
+      transition: transform 150ms ease-in-out;
+    }
+
+    .toggle[aria-checked='true']::before {
+      transform: translateX(calc(var(--toggle-width) - var(--toggle-thumb-size) - 6px));
+    }
+  `;
+
+  private _emitToggle(index: number, on: boolean) {
+    this.dispatchEvent(
+      new CustomEvent<ScDashboardToggleChangeDetail>('sc-toggle-change', {
+        detail: { index, on },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private _flipToggle = (index: number) => {
+    const current = this.toggles[index];
+    if (!current) return;
+    const next = !current.on;
+    // Re-assign the array so Lit picks up the property change and re-renders
+    // (mirrors sc-music-player's playing-reflect-then-emit pattern).
+    this.toggles = this.toggles.map((entry, i) => (i === index ? { ...entry, on: next } : entry));
+    this._emitToggle(index, next);
+  };
+
+  private _onToggleClick = (event: MouseEvent) => {
+    const target = event.currentTarget as HTMLButtonElement;
+    const index = Number(target.dataset.index);
+    if (Number.isNaN(index)) return;
+    this._flipToggle(index);
+  };
+
+  private _onToggleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== ' ' && event.key !== 'Enter') return;
+    event.preventDefault();
+    const target = event.currentTarget as HTMLButtonElement;
+    const index = Number(target.dataset.index);
+    if (Number.isNaN(index)) return;
+    this._flipToggle(index);
+  };
+
+  private _renderNotifIcon(kind: ScDashboardNotification['kind']) {
+    switch (kind) {
+      case 'success':
+        return html`
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
+            <path d="M7 12.5 L10.5 16 L17 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+          </svg>
+        `;
+      case 'warning':
+        return html`
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M12 3 L22 20 L2 20 Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" fill="none"/>
+            <path d="M12 10 V14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            <circle cx="12" cy="17" r="1" fill="currentColor"/>
+          </svg>
+        `;
+      case 'danger':
+        return html`
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
+            <path d="M8 8 L16 16 M16 8 L8 16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        `;
+    }
+  }
+
+  private _renderNotifications() {
+    if (!this.notifications || this.notifications.length === 0) return nothing;
+    return html`
+      <section class="section" part="section">
+        <h4 class="section-title" part="section-title">Notifications</h4>
+        <div class="notif-row" part="notif-row">
+          ${this.notifications.map((entry) => {
+            const partAttr = `notif notif-${entry.kind}`;
+            const role = entry.kind === 'danger' ? 'alert' : 'status';
+            return html`
+              <div class="notif" part=${partAttr} role=${role}>
+                <span class="notif-icon" part="notif-icon" aria-hidden="true">
+                  ${this._renderNotifIcon(entry.kind)}
+                </span>
+                <div class="notif-text">
+                  <p class="notif-title" part="notif-title">${entry.title}</p>
+                  <p class="notif-body" part="notif-body">${entry.body}</p>
+                </div>
+              </div>
+            `;
+          })}
+        </div>
+      </section>
+    `;
+  }
+
+  private _renderStats() {
+    if (!this.stats || this.stats.length === 0) return nothing;
+    return html`
+      <section class="section" part="section">
+        <h4 class="section-title" part="section-title">Stats</h4>
+        <div class="stats-grid" part="stats-grid">
+          ${this.stats.map(
+            (entry) => html`
+              <div class="stat-card" part="stat-card stat-card-${entry.intent}">
+                <span class="stat-value" part="stat-value">${entry.value}</span>
+                <span class="stat-label" part="stat-label">${entry.label}</span>
+              </div>
+            `
+          )}
+        </div>
+      </section>
+    `;
+  }
+
+  private _renderToggles() {
+    if (!this.toggles || this.toggles.length === 0) return nothing;
+    return html`
+      <section class="section" part="section">
+        <h4 class="section-title" part="section-title">Settings</h4>
+        <ul class="toggle-list" part="toggle-list">
+          ${this.toggles.map(
+            (entry, index) => html`
+              <li class="toggle-row" part="toggle-row">
+                <span class="toggle-label" part="toggle-label">${entry.label}</span>
+                <button
+                  class="toggle"
+                  part="toggle ${entry.on ? 'toggle-on' : 'toggle-off'}"
+                  type="button"
+                  role="switch"
+                  aria-checked=${entry.on ? 'true' : 'false'}
+                  aria-label=${entry.label}
+                  data-index=${index}
+                  @click=${this._onToggleClick}
+                  @keydown=${this._onToggleKeydown}
+                ></button>
+              </li>
+            `
+          )}
+        </ul>
+      </section>
+    `;
+  }
+
+  override render() {
+    /*
+     * Tab order follows DOM order: notification icons are non-interactive,
+     * stat cards are non-interactive, toggle buttons are the only focusable
+     * elements. Each toggle is reached via Tab in array order; Space/Enter
+     * flips its state per spec §10.
+     */
+    return html`
+      <div class="container" part="container" role="region" aria-label="Dashboard">
+        ${this._renderNotifications()}
+        ${this._renderStats()}
+        ${this._renderToggles()}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-dashboard-block': ScDashboardBlock;
+  }
+}

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import '../components/sc-dashboard-block.js';
 import '../components/sc-login-block.js';
 import '../components/sc-music-player.js';
 import '../components/sc-product-card.js';
@@ -551,6 +552,154 @@ export class ScPagePlayground extends LitElement {
       border-inline-start-color: var(--line-solid-background);
     }
 
+    /* ── Dashboard / notifications block (T5) ── */
+    /*
+     * <sc-dashboard-block class="dashboard-sand"> is the consumer-applied
+     * instance. The outer container is painted with the sand palette so the
+     * shell stays NEUTRAL and does NOT follow the nav accent picker — matching
+     * the per-variant pattern used by the slate / mauve product cards.
+     *
+     * Intent zones (success / warning / danger / info) consume the L3 alias
+     * tokens (--line-success, --line-warning, --line-danger, --line-info and
+     * their -subtle / -text siblings). These aliases resolve from
+     * aliases.css INDEPENDENT of any schema class (spec §14.4), so they
+     * remain fixed-intent across every nav picker change.
+     *
+     * The two accent-reactive zones — stat-card-accent and toggle-on —
+     * inherit --line-solid-* from body.line-schema-{accent}, so cycling
+     * the nav picker recolors them without re-mounting the block (spec
+     * §14.2 'dashboard' entry).
+     */
+
+    .dashboard-sand {
+      width: 100%;
+      max-width: 640px;
+    }
+
+    /* Sand neutral shell + section titles */
+    .dashboard-sand::part(container) {
+      background: light-dark(var(--line-sand-2), var(--line-sand-11));
+      border: 1px solid light-dark(var(--line-sand-6), var(--line-sand-9));
+      color: light-dark(var(--line-sand-12), var(--line-sand-1));
+    }
+
+    .dashboard-sand::part(section-title) {
+      color: light-dark(var(--line-sand-11), var(--line-sand-3));
+    }
+
+    /* Stat cards / toggle rows: neutral card surface on the sand palette */
+    .dashboard-sand::part(stat-card),
+    .dashboard-sand::part(toggle-row) {
+      background: light-dark(var(--line-sand-1), var(--line-sand-12));
+      border: 1px solid light-dark(var(--line-sand-6), var(--line-sand-9));
+    }
+
+    .dashboard-sand::part(toggle-row) {
+      background: transparent;
+      border: none;
+      border-block-end: 1px solid light-dark(var(--line-sand-6), var(--line-sand-9));
+    }
+
+    .dashboard-sand::part(stat-label),
+    .dashboard-sand::part(toggle-label) {
+      color: light-dark(var(--line-sand-11), var(--line-sand-3));
+    }
+
+    /* Toggle thumb track (off state) — neutral sand surface */
+    .dashboard-sand::part(toggle) {
+      background: light-dark(var(--line-sand-4), var(--line-sand-10));
+      color: light-dark(var(--line-sand-1), var(--line-sand-12));
+      border-color: light-dark(var(--line-sand-6), var(--line-sand-9));
+    }
+
+    /* ── Fixed-intent notifications (success / warning / danger) ── */
+    sc-dashboard-block::part(notif-success) {
+      background: var(--line-success-subtle);
+      border-color: var(--line-success);
+      color: var(--line-success-fg);
+    }
+
+    sc-dashboard-block::part(notif-warning) {
+      background: var(--line-warning-subtle);
+      border-color: var(--line-warning);
+      color: var(--line-warning-fg);
+    }
+
+    sc-dashboard-block::part(notif-danger) {
+      background: var(--line-danger-subtle);
+      border-color: var(--line-danger);
+      color: var(--line-danger-fg);
+    }
+
+    /*
+     * Notif color (set above) is inherited by descendants in the shadow
+     * tree through normal CSS inheritance, so the inline <svg> icon (which
+     * uses stroke=currentColor) and the title / body text all pick up the
+     * intent hue. No extra ::part(notif-icon) rule is needed.
+     */
+    .dashboard-sand::part(notif-title) {
+      font-weight: 700;
+    }
+
+    .dashboard-sand::part(notif-body) {
+      opacity: 0.92;
+    }
+
+    /*
+     * Stat-value color is driven by a private custom property
+     * --_stat-value-color set on the parent stat-card-{intent} part.
+     * CSS custom properties inherit through the shadow DOM via the normal
+     * cascade, so each stat-value resolves the property that was set on its
+     * parent stat-card. This is the same inheritance mechanism that lets
+     * --line-solid-background cross the shadow boundary from <body>
+     * (spec §14.1).
+     *
+     * The fixed-intent values use explicit light-dark(level-11, level-3)
+     * palette tokens rather than the L3 alias (which is level-9 only and
+     * renders too dark on dark surfaces under the inverted Radix scale).
+     * This mirrors the sc-music-player pattern of using explicit per-mode
+     * palette levels for vibrant text on neutral surfaces in both modes.
+     * The accent stat uses --line-solid-background, which is the
+     * picker-reactive equivalent and resolves correctly on dark surfaces.
+     */
+    sc-dashboard-block::part(stat-card-info) {
+      --_stat-value-color: light-dark(var(--line-cyan-11), var(--line-cyan-3));
+    }
+
+    sc-dashboard-block::part(stat-card-success) {
+      --_stat-value-color: light-dark(var(--line-green-11), var(--line-green-3));
+    }
+
+    sc-dashboard-block::part(stat-card-warning) {
+      --_stat-value-color: light-dark(var(--line-amber-11), var(--line-amber-3));
+    }
+
+    sc-dashboard-block::part(stat-card-accent) {
+      --_stat-value-color: var(--line-solid-background);
+    }
+
+    sc-dashboard-block::part(stat-value) {
+      color: var(--_stat-value-color, currentColor);
+    }
+
+    /* Accent-reactive stat card: tint the card border too so the card itself
+       reads as the active accent surface. */
+    .dashboard-sand::part(stat-card-accent) {
+      border-color: var(--line-solid-background);
+      background: light-dark(var(--line-sand-1), var(--line-sand-12));
+    }
+
+    /* ── Accent-reactive toggle (on state) ──
+     * Inherits --line-solid-background / --line-solid-text from
+     * body.line-schema-{accent} and recolors when the nav picker cycles.
+     * Scoped via the .dashboard-sand class so it beats the neutral sand
+     * toggle rule above on specificity. */
+    .dashboard-sand::part(toggle-on) {
+      background: var(--line-solid-background);
+      color: var(--line-solid-text, #fff);
+      border-color: var(--line-solid-background);
+    }
+
     /* ── Mobile: top bar instead of sidebar ── */
     .mobile-bar {
       display: none;
@@ -754,8 +903,56 @@ export class ScPagePlayground extends LitElement {
               ></sc-music-player>
             </div>
           </div>
-          <div class="block-wrapper">
-            <span class="block-placeholder">Dashboard / notifications block (T5)</span>
+          <div class="block-group">
+            <p class="block-note">
+              <strong>Dashboard — fixed intent + accent coexistence.</strong>
+              The outer container, section headings and toggle rows are
+              painted with the <strong>sand</strong> palette so the shell
+              stays neutral and does <em>not</em> follow the nav accent
+              picker. The three notifications and the first three stat cards
+              use the L3 intent aliases — <code>--line-success</code>,
+              <code>--line-warning</code>, <code>--line-danger</code>,
+              <code>--line-info</code> — which resolve from
+              <code>aliases.css</code> independently of any schema class and
+              therefore stay fixed across picker changes. Only the fourth
+              stat card and any toggle in its <em>on</em> state inherit
+              <code>--line-solid-*</code> from the accent schema on
+              <code>document.body</code> and recolor whenever the picker
+              cycles.
+            </p>
+            <div class="block-wrapper">
+              <sc-dashboard-block
+                class="dashboard-sand"
+                .notifications=${[
+                  {
+                    kind: 'success' as const,
+                    title: 'Deployment succeeded',
+                    body: 'Production updated to v2.4.1'
+                  },
+                  {
+                    kind: 'warning' as const,
+                    title: 'High memory usage',
+                    body: 'Server is at 87% capacity'
+                  },
+                  {
+                    kind: 'danger' as const,
+                    title: 'Payment failed',
+                    body: 'Card ending 4242 was declined'
+                  }
+                ]}
+                .stats=${[
+                  { value: '12,450', label: 'Active Users', intent: 'info' as const },
+                  { value: '98.9%', label: 'Uptime', intent: 'success' as const },
+                  { value: '24', label: 'Pending', intent: 'warning' as const },
+                  { value: '+3.2%', label: 'Growth', intent: 'accent' as const }
+                ]}
+                .toggles=${[
+                  { label: 'Notifications', on: true },
+                  { label: 'Auto-deploy', on: false },
+                  { label: 'Dark mode sync', on: true }
+                ]}
+              ></sc-dashboard-block>
+            </div>
           </div>
           <div class="block-wrapper">
             <span class="block-placeholder">Pricing / comparison table block (T6)</span>


### PR DESCRIPTION
## Summary

- Implements **line-ui-m3d.5** — Dashboard / notifications composition block for the multi-schema playground (Epic [line-ui-m3d](https://github.com/), Phase 0).
- New headless `<sc-dashboard-block>` exposes 25 `::part()` zones and structural-only generic `:host` custom properties (no `--line-*` tokens inside the shadow DOM). All colors are applied from outside by `sc-page-playground` via `::part()` selectors.
- Demonstrates fixed-intent colors (success/warning/danger via L3 aliases) sitting alongside accent-reactive zones (`stat-card-accent`, `toggle-on` via `--line-solid-*`) within a neutral sand container that does not follow the picker.

## Files

- `apps/showcase/src/components/sc-dashboard-block.ts` (new, 444 lines)
- `apps/showcase/src/pages/playground.ts` (modified — replaces placeholder, adds consumer `::part()` styles + block-note)

## Verification gates

- **Investigation** (Sherlock) — logged on bead; spec drift doc-only (bead description predates m3d.8 headless refactor, spec §8.5/§14 supersedes).
- **Code review** (Linus) — **APPROVE** (0 critical, 0 warnings, 4 suggestions batched into [line-ui-m3d.13](https://github.com/), 6 acknowledgements).
- **QA** (Quinn) — **PASS** (7/7 acceptance criteria, 25/25 parts, build/lint/typecheck clean on changed files, zero regressions vs `next` baseline).

## Logged deviation

`stat-value` color uses `light-dark(level-11, level-3)` instead of pure level-9. Rationale: inverted Radix scale makes level-9 unreadable on dark surfaces; matches `sc-music-player` volume-fill pattern. The accent stat retains `var(--line-solid-background)` for picker reactivity.

## Test plan

- [x] `bun run build` — workspace-wide green
- [x] `bun x biome check` — 0 issues on changed files
- [x] `bun x tsc --noEmit -p apps/showcase/tsconfig.json` — exit 0
- [x] Runtime dev-server: 3 notifications render with `role="status"` / `role="alert"`; 4 stat cards (3 fixed-intent + 1 accent-reactive); 3 toggles with `role="switch"`, `aria-checked`, Space/Enter, and `sc-toggle-change` event
- [x] Schema picker cycling: stat-card-accent + toggle-on recolor; green/amber/red intent parts stay fixed
- [x] Light & dark mode confirmed
- [x] Sibling blocks (`sc-login-block`, `sc-product-card`, `sc-music-player`) still render correctly
- [x] `apps/showcase/src/pages/playground-config.ts` untouched (T7 territory)

Bead closes on merge — do not auto-close until the PR lands.