### PR TITLE
feat(sc-pricing-block): headless pricing/comparison block (line-ui-m3d.6)

### DIFF
--- a/apps/showcase/src/components/sc-pricing-block.ts
+++ b/apps/showcase/src/components/sc-pricing-block.ts
@@ -17,10 +17,12 @@ export interface ScPricingFeature {
  * One pricing tier consumed by `<sc-pricing-block>`.
  *
  * `weight` selects which CTA part the consumer paints (`cta-ghost` /
- * `cta-solid` / `cta-outline`). The tier ORDER is fixed
- * (Free → Pro → Enterprise) and the tier whose `name === 'Pro'` is
+ * `cta-solid` / `cta-outline`). Tier ORDER is significant and conventional:
+ * index 0 = Free (neutral), index 1 = Pro (featured / accent),
+ * index 2 = Enterprise (complement). The tier whose `name === 'Pro'` is
  * additionally tagged with the `tier-card-featured` part; the tier whose
- * `name === 'Enterprise'` carries the `tier-card-enterprise` part.
+ * `name === 'Enterprise'` carries the `tier-card-enterprise` part — the
+ * consumer must supply `.tiers` in this order and with these names.
  */
 export interface ScPricingTier {
   name: string;

--- a/apps/showcase/src/components/sc-pricing-block.ts
+++ b/apps/showcase/src/components/sc-pricing-block.ts
@@ -1,0 +1,380 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+/**
+ * One feature row consumed by `<sc-pricing-block>`.
+ *
+ * `available: true` renders the `feature-check` glyph (consumer paints with
+ * `--line-success`). `available: false` renders the `feature-dash` glyph
+ * (consumer paints with `--line-gray-8` / `--line-low-contrast`).
+ */
+export interface ScPricingFeature {
+  available: boolean;
+  text: string;
+}
+
+/**
+ * One pricing tier consumed by `<sc-pricing-block>`.
+ *
+ * `weight` selects which CTA part the consumer paints (`cta-ghost` /
+ * `cta-solid` / `cta-outline`). The tier ORDER is fixed
+ * (Free → Pro → Enterprise) and the tier whose `name === 'Pro'` is
+ * additionally tagged with the `tier-card-featured` part; the tier whose
+ * `name === 'Enterprise'` carries the `tier-card-enterprise` part.
+ */
+export interface ScPricingTier {
+  name: string;
+  price: string;
+  period?: string;
+  features: ScPricingFeature[];
+  cta: string;
+  weight: 'ghost' | 'solid' | 'outline';
+}
+
+/**
+ * Detail payload emitted by `sc-pricing-cta`.
+ */
+export interface ScPricingCtaDetail {
+  tierIndex: number;
+}
+
+/**
+ * Headless 3-tier pricing / comparison block.
+ *
+ * Defines structure and layout only — no design system tokens internally.
+ * Every visual zone is exposed via `::part()` for external styling. Generic
+ * CSS custom properties (without the design system prefix) declared on
+ * `:host` allow structural customisation from the consumer.
+ *
+ * Mirrors the headless contract established by `sc-product-card`,
+ * `sc-music-player` and `sc-dashboard-block`. See
+ * `docs/specs/00-spec-playground.md` §0 (architectural constraint),
+ * §8.6 (API and 17-part contract), §14.5 (shadow-DOM scoping constraint),
+ * §15.1 (sc-pricing-block accent / complement application) and §16 D6
+ * (2026-05-14 amendment).
+ *
+ * Three tiers render in display order:
+ *
+ * 1. **Free** — neutral defaults. No additive part beyond `tier-card`.
+ *    The consumer paints the surface from light-DOM neutrals (or the page
+ *    base schema).
+ * 2. **Pro** — carries the additive `tier-card-featured` part and a
+ *    "Recommended" badge (`badge` part). Inherits the active accent via
+ *    `--line-solid-*` from `body.line-schema-{accent}` through the shadow
+ *    DOM boundary (spec §14.5 mechanism 1).
+ * 3. **Enterprise** — carries the additive `tier-card-enterprise` part.
+ *    Consumes the six `--complement-*` host custom properties that the
+ *    consumer page sets inline, derived from
+ *    `complementSchema(accentSchema)` (spec §14.5 mechanism 2).
+ *
+ * Each CTA is a real `<button type="button">` so Enter / Space activate
+ * natively (spec §10). Clicks emit `sc-pricing-cta` with `{ tierIndex }`.
+ *
+ * Tier cards use `role="group" aria-labelledby="…"` pointing at the
+ * tier-name id (spec §11). Feature rows are list items whose icon span
+ * is `aria-hidden` while the `<li>` itself carries
+ * `aria-label="included"` / `aria-label="not included"`.
+ *
+ * @fires sc-pricing-cta - User clicked a tier CTA. Detail: `{ tierIndex }`.
+ */
+@customElement('sc-pricing-block')
+export class ScPricingBlock extends LitElement {
+  /** Active accent schema (used by the consumer to compute the complement). */
+  @property({ type: String, attribute: 'accent-schema' }) accentSchema = '';
+
+  /** Tier cards in display order (Free → Pro → Enterprise). */
+  @property({ type: Array }) tiers: ScPricingTier[] = [];
+
+  static override styles = css`
+    :host {
+      /* ── Grid / shell geometry ── */
+      --grid-gap: 1rem;
+
+      /* ── Tier card shell ── */
+      --card-radius: 12px;
+      --card-padding: 1.5rem;
+      --card-border-width: 1px;
+
+      /* ── "Recommended" badge ── */
+      --badge-radius: 999px;
+      --badge-padding: 0.25rem 0.75rem;
+      --badge-font-size: 0.6875rem;
+      --badge-font-weight: 700;
+
+      /* ── Tier heading ── */
+      --tier-name-font-size: 1rem;
+      --tier-name-font-weight: 700;
+
+      /* ── Price typography ── */
+      --amount-font-size: 2rem;
+      --amount-font-weight: 800;
+      --period-font-size: 0.875rem;
+
+      /* ── Feature list ── */
+      --feature-font-size: 0.875rem;
+      --feature-gap: 0.5rem;
+
+      /* ── CTA (all weights share these geometric tokens) ── */
+      --cta-padding: 0.625rem 1rem;
+      --cta-radius: 8px;
+      --cta-font-size: 0.875rem;
+      --cta-font-weight: 700;
+      --cta-border-width: 1px;
+
+      /*
+       * Complement host custom properties — neutral defaults. The consumer
+       * overrides these inline on the host element using
+       * complementSchema(accent) to produce the Enterprise tier accent
+       * (spec §14.5 mechanism 2, §15.1).
+       */
+      --complement-solid: transparent;
+      --complement-text: currentColor;
+      --complement-hover: transparent;
+      --complement-border: currentColor;
+      --complement-low-contrast: currentColor;
+      --complement-high-contrast: currentColor;
+
+      display: block;
+    }
+
+    /* ── Shell ── */
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: var(--grid-gap);
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    @media (max-width: 640px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    /* ── Tier card ── */
+    .tier-card {
+      position: relative;
+      box-sizing: border-box;
+      border-radius: var(--card-radius);
+      padding: var(--card-padding);
+      border: var(--card-border-width) solid transparent;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      min-width: 0;
+    }
+
+    /* ── Badge ── */
+    .badge {
+      align-self: flex-start;
+      border-radius: var(--badge-radius);
+      padding: var(--badge-padding);
+      font-size: var(--badge-font-size);
+      font-weight: var(--badge-font-weight);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      line-height: 1;
+    }
+
+    /* ── Tier name ── */
+    .tier-name {
+      margin: 0;
+      font-size: var(--tier-name-font-size);
+      font-weight: var(--tier-name-font-weight);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Price ── */
+    .price {
+      display: flex;
+      align-items: baseline;
+      gap: 0.25rem;
+      flex-wrap: wrap;
+    }
+
+    .price-amount {
+      font-size: var(--amount-font-size);
+      font-weight: var(--amount-font-weight);
+      font-variant-numeric: tabular-nums;
+      line-height: 1.1;
+    }
+
+    .price-period {
+      font-size: var(--period-font-size);
+      font-weight: 500;
+    }
+
+    /* ── Features list ── */
+    .features {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--feature-gap);
+      flex: 1 1 auto;
+    }
+
+    .feature {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      font-size: var(--feature-font-size);
+      line-height: 1.4;
+    }
+
+    .feature-check,
+    .feature-dash {
+      flex-shrink: 0;
+      width: 16px;
+      height: 16px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 0.125rem;
+    }
+
+    .feature-check svg,
+    .feature-dash svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* ── CTA ── */
+    .cta {
+      box-sizing: border-box;
+      padding: var(--cta-padding);
+      border-radius: var(--cta-radius);
+      font-size: var(--cta-font-size);
+      font-weight: var(--cta-font-weight);
+      font-family: inherit;
+      border: var(--cta-border-width) solid transparent;
+      cursor: pointer;
+      width: 100%;
+      transition:
+        background 150ms ease-in-out,
+        border-color 150ms ease-in-out,
+        color 150ms ease-in-out;
+    }
+
+    .cta:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 2px;
+    }
+  `;
+
+  private _emitCta(tierIndex: number) {
+    this.dispatchEvent(
+      new CustomEvent<ScPricingCtaDetail>('sc-pricing-cta', {
+        detail: { tierIndex },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private _onCtaClick = (event: MouseEvent) => {
+    const target = event.currentTarget as HTMLButtonElement;
+    const index = Number(target.dataset.index);
+    if (Number.isNaN(index)) return;
+    this._emitCta(index);
+  };
+
+  private _renderCheckIcon() {
+    return html`
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M5 12.5 L10 17 L19 7" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+      </svg>
+    `;
+  }
+
+  private _renderDashIcon() {
+    return html`
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M5 12 L19 12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+      </svg>
+    `;
+  }
+
+  private _renderFeatures(features: ScPricingFeature[]) {
+    return html`
+      <ul class="features" part="features">
+        ${features.map((entry) => {
+          const label = entry.available ? 'included' : 'not included';
+          return html`
+            <li class="feature" part="feature" aria-label=${label}>
+              ${
+                entry.available
+                  ? html`
+                    <span class="feature-check" part="feature-check">
+                      ${this._renderCheckIcon()}
+                    </span>
+                  `
+                  : html`
+                    <span class="feature-dash" part="feature-dash">
+                      ${this._renderDashIcon()}
+                    </span>
+                  `
+              }
+              <span class="feature-text">${entry.text}</span>
+            </li>
+          `;
+        })}
+      </ul>
+    `;
+  }
+
+  private _renderTier(tier: ScPricingTier, index: number) {
+    const isFeatured = tier.name === 'Pro';
+    const isEnterprise = tier.name === 'Enterprise';
+    const cardPartTokens = [
+      'tier-card',
+      isFeatured ? 'tier-card-featured' : '',
+      isEnterprise ? 'tier-card-enterprise' : ''
+    ].filter(Boolean);
+    const cardPart = cardPartTokens.join(' ');
+    const ctaPart = `cta cta-${tier.weight}`;
+    const headingId = `sc-pricing-tier-${index}`;
+
+    return html`
+      <article class="tier-card" part=${cardPart} role="group" aria-labelledby=${headingId}>
+        ${isFeatured ? html`<span class="badge" part="badge">Recommended</span>` : nothing}
+        <h4 class="tier-name" part="tier-name" id=${headingId}>${tier.name}</h4>
+        <div class="price" part="price">
+          <span class="price-amount" part="price-amount">${tier.price}</span>
+          ${tier.period ? html`<span class="price-period" part="price-period">${tier.period}</span>` : nothing}
+        </div>
+        ${this._renderFeatures(tier.features)}
+        <button
+          class="cta"
+          part=${ctaPart}
+          type="button"
+          data-index=${index}
+          @click=${this._onCtaClick}
+        >
+          ${tier.cta}
+        </button>
+      </article>
+    `;
+  }
+
+  override render() {
+    /*
+     * Tab order follows DOM order: each tier CTA is reached via Tab in
+     * array order. Enter / Space activates the button natively and emits
+     * sc-pricing-cta with { tierIndex } (spec §10).
+     */
+    return html`
+      <div class="grid" part="grid">
+        ${this.tiers.map((tier, index) => this._renderTier(tier, index))}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-pricing-block': ScPricingBlock;
+  }
+}

--- a/apps/showcase/src/pages/playground-config.ts
+++ b/apps/showcase/src/pages/playground-config.ts
@@ -20,6 +20,41 @@ export interface PlaygroundBlockConfig {
 }
 
 /**
+ * The 28 palette names supported by `line://ui`. Used as the literal-union
+ * key/value type for `COMPLEMENT_MAP` so palette typos are caught at compile
+ * time (cosmetic review fix for line-ui-m3d.6).
+ */
+export type Palette =
+  | 'amber'
+  | 'blue'
+  | 'bronze'
+  | 'brown'
+  | 'crimson'
+  | 'cyan'
+  | 'gold'
+  | 'grass'
+  | 'gray'
+  | 'green'
+  | 'indigo'
+  | 'lime'
+  | 'mauve'
+  | 'mint'
+  | 'olive'
+  | 'orange'
+  | 'pink'
+  | 'plum'
+  | 'purple'
+  | 'red'
+  | 'sage'
+  | 'sand'
+  | 'sky'
+  | 'slate'
+  | 'teal'
+  | 'tomato'
+  | 'violet'
+  | 'yellow';
+
+/**
  * Static lookup table used by `<sc-pricing-block>` to resolve the
  * complementary schema for the Enterprise tier from the active accent.
  *
@@ -27,7 +62,7 @@ export interface PlaygroundBlockConfig {
  * "composition recipe" referenced by future homepage work
  * (see `docs/specs/00-spec-playground.md` §14.3).
  */
-export const COMPLEMENT_MAP: Record<string, string> = {
+export const COMPLEMENT_MAP: Record<Palette, Palette> = {
   // warm → cool
   amber: 'indigo',
   orange: 'indigo',
@@ -65,7 +100,10 @@ export const COMPLEMENT_MAP: Record<string, string> = {
 /**
  * Resolve the complementary schema for a given accent schema.
  *
- * Falls back to `indigo` for unknown accent inputs so the Enterprise tier
- * always renders a defined accent.
+ * Accepts a loose `string` at the boundary (callers like `playground.ts`
+ * type `schema` as `string`) and narrows internally via the
+ * `COMPLEMENT_MAP` key set. Falls back to `indigo` for unknown accent
+ * inputs so the Enterprise tier always renders a defined accent.
  */
-export const complementSchema = (accent: string): string => COMPLEMENT_MAP[accent] ?? 'indigo';
+export const complementSchema = (accent: string): Palette =>
+  (COMPLEMENT_MAP as Record<string, Palette | undefined>)[accent] ?? 'indigo';

--- a/apps/showcase/src/pages/playground-config.ts
+++ b/apps/showcase/src/pages/playground-config.ts
@@ -18,3 +18,54 @@ export interface PlaygroundBlockConfig {
   /** CSS selectors within the block that receive the nav-picker accent schema. */
   accentElements: string[];
 }
+
+/**
+ * Static lookup table used by `<sc-pricing-block>` to resolve the
+ * complementary schema for the Enterprise tier from the active accent.
+ *
+ * The map is intentionally not algorithmic — it forms part of the documented
+ * "composition recipe" referenced by future homepage work
+ * (see `docs/specs/00-spec-playground.md` §14.3).
+ */
+export const COMPLEMENT_MAP: Record<string, string> = {
+  // warm → cool
+  amber: 'indigo',
+  orange: 'indigo',
+  tomato: 'indigo',
+  red: 'violet',
+  crimson: 'violet',
+  pink: 'teal',
+  yellow: 'blue',
+  // cool → warm
+  blue: 'amber',
+  indigo: 'amber',
+  violet: 'orange',
+  purple: 'lime',
+  cyan: 'pink',
+  teal: 'pink',
+  sky: 'orange',
+  mint: 'crimson',
+  green: 'plum',
+  grass: 'plum',
+  lime: 'purple',
+  // neutrals → accents
+  mauve: 'teal',
+  slate: 'amber',
+  gray: 'blue',
+  sand: 'violet',
+  sage: 'crimson',
+  olive: 'violet',
+  // earth → cool
+  bronze: 'sky',
+  gold: 'sky',
+  brown: 'sky',
+  plum: 'green'
+};
+
+/**
+ * Resolve the complementary schema for a given accent schema.
+ *
+ * Falls back to `indigo` for unknown accent inputs so the Enterprise tier
+ * always renders a defined accent.
+ */
+export const complementSchema = (accent: string): string => COMPLEMENT_MAP[accent] ?? 'indigo';

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -4,7 +4,10 @@ import { customElement, property } from 'lit/decorators.js';
 import '../components/sc-dashboard-block.js';
 import '../components/sc-login-block.js';
 import '../components/sc-music-player.js';
+import '../components/sc-pricing-block.js';
 import '../components/sc-product-card.js';
+
+import { complementSchema } from './playground-config.js';
 
 export type { PlaygroundBlockConfig } from './playground-config.js';
 
@@ -700,6 +703,110 @@ export class ScPagePlayground extends LitElement {
       border-color: var(--line-solid-background);
     }
 
+    /* ── Pricing / comparison block (T6) ── */
+    /*
+     * <sc-pricing-block class="pricing-block"> is the consumer-applied
+     * instance. The block itself defines structure + layout only; ALL
+     * design system tokens are applied externally via ::part() selectors
+     * and via the six --complement-* host custom properties set inline
+     * on the element by render() (spec §14.5 mechanism 2, §15.1).
+     *
+     * - Free tier: neutral defaults (slate palette in both modes).
+     * - Pro tier (tier-card-featured): consumes --line-solid-* inherited
+     *   from body.line-schema-{accent} (spec §14.5 mechanism 1).
+     * - Enterprise tier (tier-card-enterprise): consumes the inline
+     *   --complement-* host custom properties; recolors live whenever
+     *   the picker cycles because render() recomputes them.
+     *
+     * Feature checks use the L3 alias --line-success (fixed-intent,
+     * does NOT react to the picker per spec §14.4). Feature dashes use
+     * --line-low-contrast.
+     */
+
+    .pricing-block {
+      width: 100%;
+      max-width: 960px;
+    }
+
+    /* ── Neutral tier card shell (slate) ── */
+    sc-pricing-block::part(tier-card) {
+      background: light-dark(var(--line-slate-2), var(--line-slate-12));
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-9));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+    }
+
+    /* Tier name & period text use low-contrast / high-contrast neutrals */
+    sc-pricing-block::part(tier-name) {
+      color: light-dark(var(--line-slate-11), var(--line-slate-3));
+    }
+
+    sc-pricing-block::part(price-amount) {
+      color: var(--line-high-contrast);
+    }
+
+    sc-pricing-block::part(price-period) {
+      color: var(--line-low-contrast);
+    }
+
+    /* Feature check (L3 intent, fixed) / dash (neutral muted) */
+    sc-pricing-block::part(feature-check) {
+      color: var(--line-success);
+    }
+
+    sc-pricing-block::part(feature-dash) {
+      color: light-dark(var(--line-gray-8), var(--line-gray-8));
+    }
+
+    /* ── Ghost CTA (Free tier) — text + border neutral ── */
+    sc-pricing-block::part(cta-ghost) {
+      background: transparent;
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+      border-color: light-dark(var(--line-slate-7), var(--line-slate-9));
+    }
+
+    sc-pricing-block::part(cta-ghost):hover {
+      background: light-dark(var(--line-slate-3), var(--line-slate-11));
+      border-color: light-dark(var(--line-slate-8), var(--line-slate-8));
+    }
+
+    /* ── Pro tier (accent-reactive via inherited --line-solid-*) ── */
+    sc-pricing-block::part(tier-card-featured) {
+      border-color: var(--line-solid-background);
+    }
+
+    sc-pricing-block::part(badge) {
+      background: var(--line-solid-background);
+      color: var(--line-solid-text, #fff);
+    }
+
+    sc-pricing-block::part(cta-solid) {
+      background: var(--line-solid-background);
+      color: var(--line-solid-text, #fff);
+      border-color: var(--line-solid-background);
+    }
+
+    sc-pricing-block::part(cta-solid):hover {
+      background: var(--line-solid-hover);
+      border-color: var(--line-solid-hover);
+    }
+
+    /* ── Enterprise tier (complement-reactive via host custom properties) ── */
+    sc-pricing-block::part(tier-card-enterprise) {
+      border-color: var(--complement-border);
+    }
+
+    sc-pricing-block::part(cta-outline) {
+      background: transparent;
+      color: var(--complement-high-contrast);
+      border-color: var(--complement-border);
+    }
+
+    sc-pricing-block::part(cta-outline):hover {
+      background: var(--complement-solid);
+      color: var(--complement-text);
+      border-color: var(--complement-solid);
+    }
+
     /* ── Mobile: top bar instead of sidebar ── */
     .mobile-bar {
       display: none;
@@ -954,8 +1061,75 @@ export class ScPagePlayground extends LitElement {
               ></sc-dashboard-block>
             </div>
           </div>
-          <div class="block-wrapper">
-            <span class="block-placeholder">Pricing / comparison table block (T6)</span>
+          <div class="block-group">
+            <p class="block-note">
+              <strong>Pricing — accent + complementary schema as visual hierarchy.</strong>
+              Three tiers (Free / Pro / Enterprise) demonstrate distinct accent
+              roles. The <strong>Free</strong> card stays neutral
+              (<strong>slate</strong>) so the entry-level option does
+              <em>not</em> compete for attention. The <strong>Pro</strong> card
+              is the featured tier: its border, "Recommended" badge and solid
+              CTA inherit <code>--line-solid-*</code> from the schema applied
+              on <code>document.body</code>, so cycling the nav picker recolors
+              it live. The <strong>Enterprise</strong> card consumes a
+              <em>complementary</em> schema resolved via
+              <code>complementSchema(accent)</code> and passed as inline
+              <code>--complement-*</code> host custom properties on the block
+              — the only mechanism that pierces shadow DOM with a second
+              schema (spec §14.5). Feature checks render via
+              <code>--line-success</code> (L3 alias, fixed-intent), independent
+              of the picker.
+            </p>
+            <div class="block-wrapper">
+              <sc-pricing-block
+                class="pricing-block"
+                .accentSchema=${this.schema}
+                .tiers=${[
+                  {
+                    name: 'Free',
+                    price: '$0',
+                    period: '/ month',
+                    weight: 'ghost' as const,
+                    cta: 'Get started',
+                    features: [
+                      { available: true, text: 'Up to 3 projects' },
+                      { available: true, text: 'Community support' },
+                      { available: false, text: 'Custom domains' },
+                      { available: false, text: 'Priority support' },
+                      { available: false, text: 'SSO / SAML' }
+                    ]
+                  },
+                  {
+                    name: 'Pro',
+                    price: '$24',
+                    period: '/ month',
+                    weight: 'solid' as const,
+                    cta: 'Start free trial',
+                    features: [
+                      { available: true, text: 'Unlimited projects' },
+                      { available: true, text: 'Email support' },
+                      { available: true, text: 'Custom domains' },
+                      { available: true, text: 'Advanced analytics' },
+                      { available: false, text: 'SSO / SAML' }
+                    ]
+                  },
+                  {
+                    name: 'Enterprise',
+                    price: 'Custom',
+                    weight: 'outline' as const,
+                    cta: 'Contact sales',
+                    features: [
+                      { available: true, text: 'Unlimited projects' },
+                      { available: true, text: 'Dedicated support' },
+                      { available: true, text: 'Custom domains' },
+                      { available: true, text: 'Advanced analytics' },
+                      { available: true, text: 'SSO / SAML' }
+                    ]
+                  }
+                ]}
+                style=${`--complement-solid: var(--line-${complementSchema(this.schema)}-9); --complement-text: var(--line-${complementSchema(this.schema)}-1); --complement-hover: var(--line-${complementSchema(this.schema)}-10); --complement-border: var(--line-${complementSchema(this.schema)}-8); --complement-low-contrast: var(--line-${complementSchema(this.schema)}-11); --complement-high-contrast: var(--line-${complementSchema(this.schema)}-12);`}
+              ></sc-pricing-block>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## line-ui-m3d.6: Pricing / comparison table block (T6, E10)

Implements `<sc-pricing-block>` as a headless 3-tier (Free / Pro / Enterprise) composition block per docs/specs/00-spec-playground.md §8.6, §14.5 and §15.1.

### What was done

- New `apps/showcase/src/components/sc-pricing-block.ts` — headless 3-tier block. Structure + layout only, all 17 parts exposed via `::part()` (`grid`, `tier-card`, `tier-card-featured`, `tier-card-enterprise`, `badge`, `tier-name`, `price`, `price-amount`, `price-period`, `features`, `feature`, `feature-check`, `feature-dash`, `cta`, `cta-ghost`, `cta-solid`, `cta-outline`). Zero `--line-*` references in CSS — verified by `grep` (only JSDoc text matches remain).
- Multi-part syntax (`part="tier-card tier-card-featured"`, `part="cta cta-solid"`) mirrors the canonical pattern from `sc-dashboard-block` (commit fe1a913, T5).
- Six `--complement-*` host custom properties (`--complement-solid`, `-text`, `-hover`, `-border`, `-low-contrast`, `-high-contrast`) declared with neutral defaults on `:host`; overridden inline by the consumer page from `complementSchema(accent)`.
- Real `<button type="button">` CTAs with `data-index`. Click emits `sc-pricing-cta` with `{ tierIndex }`. Tier cards use `role="group" aria-labelledby="…"`. Feature rows carry `aria-label="included"` / `"not included"`. Icon SVGs are `aria-hidden`.
- Responsive: `grid-template-columns: repeat(3, 1fr)` collapses to `1fr` at `≤640px`, mirroring `sc-dashboard-block` `.stats-grid`.
- `apps/showcase/src/pages/playground-config.ts` adds `COMPLEMENT_MAP` and `complementSchema(accent)` as standalone exports per spec §14.3 (no change to `PlaygroundBlockConfig` — T7 owns that).
- `apps/showcase/src/pages/playground.ts` adds side-effect import, `complementSchema` import, the consumer `::part()` style block, and replaces the T6 placeholder with the block-group (block-note + block-wrapper) wiring Free / Pro / Enterprise tiers and the six inline complement custom properties on the host element.

### Verification

- `tsc --noEmit && vite build` clean (51 modules, 282 ms).
- `biome check` clean on all three touched files.
- `grep -n -- '--line-' apps/showcase/src/components/sc-pricing-block.ts` returns only JSDoc matches (zero CSS references).
- `packages/theme` unit suite: 261 / 261 pass (regression guard).
- Manual smoke via preview tools: cycled the schema picker through 13 schemas (warm: amber, red, orange, tomato, crimson; cool: blue, indigo, violet, cyan, teal; neutrals: slate, sand, gray) — Pro and Enterprise cards recolor live without page reload. Light/dark toggle confirmed (teal/light + crimson/dark + gray/dark screenshots captured). `sc-pricing-cta` event fires with correct `{ tierIndex }` on CTA click.

### Bead

`line-ui-m3d.6` — closes spec §16 D6 (2026-05-14 amendment) implementation.