### PR TITLE
line-ui-m3d.7: T7 — sc-schema-mapper + per-zone accent reactivity

### DIFF
--- a/apps/showcase/src/components/sc-schema-mapper.ts
+++ b/apps/showcase/src/components/sc-schema-mapper.ts
@@ -1,0 +1,271 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import type { PlaygroundBlockConfig } from '../pages/playground-config.js';
+
+/**
+ * Detail payload emitted by `sc-config-change`.
+ *
+ * Mirrors the public contract documented in
+ * `docs/specs/00-spec-playground.md` §8.7.
+ */
+export interface ScConfigChangeDetail {
+  blockId: string;
+  selector: string;
+  accentReactive: boolean;
+}
+
+/**
+ * Headless sidebar editor that lets the user toggle per-zone accent
+ * reactivity for every block on `<sc-page-playground>`.
+ *
+ * Defines structure and layout only — NO design system tokens internally.
+ * Every visual zone is exposed via `::part()` for external styling, and
+ * generic CSS custom properties (without the design system prefix) allow
+ * structural customisation from the consumer. Mirrors the headless contract
+ * established by `sc-product-card`, `sc-login-block`, `sc-music-player`,
+ * `sc-dashboard-block` and `sc-pricing-block` (spec §0, §8.7, §16 D1).
+ *
+ * The component is a **mirror** of `sc-page-playground._configs`: each
+ * toggle flip emits `sc-config-change` with the originating `blockId`,
+ * `selector` and the new `accentReactive` value. The page replaces its
+ * `_configs` array (immutable update) and pushes the new value back via
+ * the `configs` property — the component itself never mutates the prop.
+ *
+ * Per spec §14, baseSchema chips are **read-only this iteration**:
+ * the `base-chip` part renders as a non-interactive `<span>`.
+ *
+ * @fires sc-config-change - User flipped a toggle (click or Space/Enter). Detail: `{ blockId, selector, accentReactive }`.
+ */
+@customElement('sc-schema-mapper')
+export class ScSchemaMapper extends LitElement {
+  /**
+   * Block configs to render. Mirrors `sc-page-playground._configs`.
+   *
+   * The component does NOT mutate this prop; flips emit `sc-config-change`
+   * and the parent is expected to recompute the array immutably and push
+   * the new value back.
+   */
+  @property({ type: Array }) configs: PlaygroundBlockConfig[] = [];
+
+  static override styles = css`
+    :host {
+      /* Shell geometry */
+      --mapper-gap: 0.875rem;
+      --block-padding: 0.875rem;
+      --block-radius: 8px;
+
+      /* Block heading */
+      --block-title-font-size: 0.75rem;
+      --block-title-font-weight: 700;
+
+      /* Read-only base schema chip */
+      --base-chip-radius: 999px;
+      --base-chip-padding: 0.125rem 0.5rem;
+      --base-chip-font-size: 0.6875rem;
+
+      /* Toggle row geometry */
+      --row-height: 32px;
+      --row-gap: 0.5rem;
+
+      /* Toggle geometry */
+      --toggle-width: 32px;
+      --toggle-height: 18px;
+      --toggle-thumb-size: 12px;
+      --toggle-radius: 999px;
+
+      display: block;
+    }
+
+    .mapper {
+      display: flex;
+      flex-direction: column;
+      gap: var(--mapper-gap);
+    }
+
+    .block {
+      box-sizing: border-box;
+      border-radius: var(--block-radius);
+      padding: var(--block-padding);
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .block-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .block-title {
+      margin: 0;
+      font-size: var(--block-title-font-size);
+      font-weight: var(--block-title-font-weight);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .base-chip {
+      display: inline-flex;
+      align-items: center;
+      border-radius: var(--base-chip-radius);
+      padding: var(--base-chip-padding);
+      font-size: var(--base-chip-font-size);
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: capitalize;
+      /* Non-interactive — base schemas are read-only this iteration (spec §14). */
+      user-select: none;
+    }
+
+    .element-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .element-row {
+      box-sizing: border-box;
+      min-height: var(--row-height);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--row-gap);
+    }
+
+    .element-label {
+      font-size: 0.8125rem;
+      font-weight: 500;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .element-toggle {
+      box-sizing: border-box;
+      width: var(--toggle-width);
+      height: var(--toggle-height);
+      border-radius: var(--toggle-radius);
+      border: 1px solid transparent;
+      background: transparent;
+      padding: 2px;
+      cursor: pointer;
+      font-family: inherit;
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      position: relative;
+      transition:
+        background 150ms ease-in-out,
+        border-color 150ms ease-in-out;
+    }
+
+    .element-toggle:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 2px;
+    }
+
+    .element-toggle::before {
+      content: '';
+      display: block;
+      width: var(--toggle-thumb-size);
+      height: var(--toggle-thumb-size);
+      border-radius: 50%;
+      background: currentColor;
+      transition: transform 150ms ease-in-out;
+    }
+
+    .element-toggle[aria-checked='true']::before {
+      transform: translateX(
+        calc(var(--toggle-width) - var(--toggle-thumb-size) - 6px)
+      );
+    }
+  `;
+
+  private _emitChange(blockId: string, selector: string, accentReactive: boolean) {
+    this.dispatchEvent(
+      new CustomEvent<ScConfigChangeDetail>('sc-config-change', {
+        detail: { blockId, selector, accentReactive },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private _flip = (blockId: string, selector: string, current: boolean) => {
+    this._emitChange(blockId, selector, !current);
+  };
+
+  private _onToggleClick = (event: MouseEvent) => {
+    const target = event.currentTarget as HTMLButtonElement;
+    const blockId = target.dataset.blockId;
+    const selector = target.dataset.selector;
+    const current = target.getAttribute('aria-checked') === 'true';
+    if (!(blockId && selector)) return;
+    this._flip(blockId, selector, current);
+  };
+
+  private _onToggleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== ' ' && event.key !== 'Enter') return;
+    event.preventDefault();
+    const target = event.currentTarget as HTMLButtonElement;
+    const blockId = target.dataset.blockId;
+    const selector = target.dataset.selector;
+    const current = target.getAttribute('aria-checked') === 'true';
+    if (!(blockId && selector)) return;
+    this._flip(blockId, selector, current);
+  };
+
+  private _renderBlock(block: PlaygroundBlockConfig) {
+    return html`
+      <section class="block" part="block" aria-label=${block.title}>
+        <div class="block-head">
+          <h4 class="block-title" part="block-title">${block.title}</h4>
+          ${block.baseSchema ? html`<span class="base-chip" part="base-chip">${block.baseSchema}</span>` : nothing}
+        </div>
+        <ul class="element-list">
+          ${block.elements.map((entry) => {
+            const toggleParts = `element-toggle ${entry.accentReactive ? 'element-toggle-on' : 'element-toggle-off'}`;
+            return html`
+              <li class="element-row" part="element-row">
+                <span class="element-label" part="element-label">${entry.label}</span>
+                <button
+                  class="element-toggle"
+                  part=${toggleParts}
+                  type="button"
+                  role="switch"
+                  aria-checked=${entry.accentReactive ? 'true' : 'false'}
+                  aria-label=${`${block.title} — ${entry.label}`}
+                  data-block-id=${block.id}
+                  data-selector=${entry.selector}
+                  @click=${this._onToggleClick}
+                  @keydown=${this._onToggleKeydown}
+                ></button>
+              </li>
+            `;
+          })}
+        </ul>
+      </section>
+    `;
+  }
+
+  override render() {
+    if (!this.configs || this.configs.length === 0) return nothing;
+    return html`
+      <div class="mapper" part="mapper">
+        ${this.configs.map((block) => this._renderBlock(block))}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sc-schema-mapper': ScSchemaMapper;
+  }
+}

--- a/apps/showcase/src/pages/playground-config.ts
+++ b/apps/showcase/src/pages/playground-config.ts
@@ -1,23 +1,118 @@
 /**
- * Configuration interface for a composition block within the playground page.
+ * One styleable zone inside a block that can be toggled accent-reactive.
  *
- * Each block is a self-contained visual composition that can receive its own
- * `.line-schema-*` class independently from the page base. The accent schema
- * from the nav picker is applied to elements listed in `accentElements`.
+ * The `selector` is a DASH-form identifier that maps either to a real
+ * `::part()` name on the block (e.g. `btn-submit`, `chip-active`) or to a
+ * LOGICAL identifier translated by `sc-page-playground` into a concrete
+ * `::part()` rule (e.g. `input-focus` → `::part(input):focus-visible`).
  *
- * This interface is intentionally minimal — T7 will expand it with the full
- * schema mapping and accent reactivity system.
+ * See `docs/specs/00-spec-playground.md` §14.2.
+ */
+export interface BlockElementConfig {
+  /** CSS selector fragment (without the leading dot) applied to the zone. */
+  selector: string;
+  /** Human label shown in sc-schema-mapper. */
+  label: string;
+  /** Whether the zone currently inherits the picker accent. */
+  accentReactive: boolean;
+}
+
+/**
+ * One composition block's accent-reactivity configuration.
+ *
+ * Each block carries a `baseSchema` (palette name applied to its neutral
+ * surfaces — does NOT react to the picker) and a list of accent-reactive
+ * `elements` whose participation can be toggled at runtime via
+ * `<sc-schema-mapper>`.
+ *
+ * The optional `complementSchema` is only relevant for `<sc-pricing-block>`:
+ * it is consumed by `sc-page-playground` to derive the inline
+ * `--complement-*` host custom properties (spec §14.5 mechanism 2).
+ *
+ * See `docs/specs/00-spec-playground.md` §14.2.
  */
 export interface PlaygroundBlockConfig {
-  /** Unique identifier for this block (e.g., 'login', 'ecommerce', 'music'). */
+  /** Unique block identifier ('login' | 'product' | 'player' | 'dashboard' | 'pricing'). */
   id: string;
-
-  /** Schema class to apply to the block wrapper, or null for neutral defaults. */
+  /** Sidebar title. */
+  title: string;
+  /** Schema applied to the block root wrapper. null = neutral defaults. */
   baseSchema: string | null;
-
-  /** CSS selectors within the block that receive the nav-picker accent schema. */
-  accentElements: string[];
+  /** Complementary schema (only relevant for sc-pricing-block). */
+  complementSchema?: string;
+  /** Zones within the block whose accent reactivity can be toggled. */
+  elements: BlockElementConfig[];
 }
+
+/**
+ * Default composition-block configuration consumed by `sc-page-playground`
+ * on mount. The constant MUST be deep-cloned (`structuredClone`) before being
+ * stored as page state so toggles do not mutate this exported reference —
+ * page reload then guarantees a fresh default set (spec §14, acceptance:
+ * "_configs is reset to DEFAULT_BLOCK_CONFIGS on page reload").
+ *
+ * Selectors use the DASH-form `::part()` names exposed by the existing block
+ * components, except for two LOGICAL identifiers:
+ *   - `input-focus` (login) → no real part, gates the consumer rule
+ *     `::part(input):focus-visible`.
+ *   - `add-to-cart` (product) → maps to the real part `button`.
+ *
+ * Translation is performed at the consumer side (`sc-page-playground`).
+ */
+export const DEFAULT_BLOCK_CONFIGS: PlaygroundBlockConfig[] = [
+  {
+    id: 'login',
+    title: 'Login / Sign-up',
+    baseSchema: 'slate',
+    elements: [
+      { selector: 'btn-submit', label: 'Submit button', accentReactive: true },
+      { selector: 'input-focus', label: 'Input focus ring', accentReactive: true }
+    ]
+  },
+  {
+    id: 'product',
+    title: 'Product Card',
+    baseSchema: 'slate',
+    elements: [
+      { selector: 'price', label: 'Price badge', accentReactive: true },
+      { selector: 'add-to-cart', label: 'Add to Cart button', accentReactive: true },
+      { selector: 'chip-active', label: 'Active size chip', accentReactive: true }
+    ]
+  },
+  {
+    id: 'player',
+    title: 'Music Player',
+    baseSchema: 'gray',
+    elements: [
+      { selector: 'progress-fill', label: 'Progress bar', accentReactive: true },
+      { selector: 'ctrl-play', label: 'Play button', accentReactive: true },
+      { selector: 'playlist-item-active', label: 'Active playlist row', accentReactive: true }
+    ]
+  },
+  {
+    id: 'dashboard',
+    title: 'Dashboard',
+    baseSchema: 'sand',
+    elements: [
+      { selector: 'stat-card-accent', label: 'Accent stat card', accentReactive: true },
+      { selector: 'toggle-on', label: 'Toggle (on)', accentReactive: true }
+    ]
+  },
+  {
+    id: 'pricing',
+    title: 'Pricing Table',
+    baseSchema: null,
+    elements: [
+      { selector: 'tier-card-featured', label: 'Pro tier card', accentReactive: true },
+      {
+        selector: 'tier-card-enterprise',
+        label: 'Enterprise tier (complement)',
+        accentReactive: false
+      },
+      { selector: 'cta-solid', label: 'Pro CTA button', accentReactive: true }
+    ]
+  }
+];
 
 /**
  * The 28 palette names supported by `line://ui`. Used as the literal-union

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -1242,7 +1242,7 @@ export class ScPagePlayground extends LitElement {
           </div>
           <div class="block-wrapper">
             <div class="product-grid">
-              <!-- Card 1: Slate base -->
+              <!-- Card 1: Slate base. keyed() compares its key per template slot, so sibling cards keyed on the same value don't alias. -->
               ${keyed(
                 productDisabled,
                 html`

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -1,20 +1,106 @@
 import { css, html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
+import { keyed } from 'lit/directives/keyed.js';
 
 import '../components/sc-dashboard-block.js';
 import '../components/sc-login-block.js';
 import '../components/sc-music-player.js';
 import '../components/sc-pricing-block.js';
 import '../components/sc-product-card.js';
+import '../components/sc-schema-mapper.js';
 
-import { complementSchema } from './playground-config.js';
+import type { ScConfigChangeDetail } from '../components/sc-schema-mapper.js';
+
+import { complementSchema, DEFAULT_BLOCK_CONFIGS, type PlaygroundBlockConfig } from './playground-config.js';
 
 export type { PlaygroundBlockConfig } from './playground-config.js';
+
+/**
+ * Per-block accent-zone gating.
+ *
+ * For each disabled zone, the page adds a `zone-off-{selector}` class on
+ * the block host. Higher-specificity `.zone-off-{selector}::part(...)`
+ * rules in the page's static styles repaint that zone with neutral
+ * base-palette tokens, overriding the accent rule above them.
+ *
+ * Mechanism choice (NORMATIVE rationale): per spec §14.5,
+ * `.line-schema-*` classes cannot pierce shadow DOM. We initially
+ * attempted both `:not([data-disabled-zones~='<sel>'])` attribute filters
+ * and `var(--_zone-*, var(--line-solid-*))` host-custom-property
+ * indirection. Both approaches expose a Chromium 146 invalidation bug
+ * where `::part()` rules with host attribute / custom-property filters
+ * do not re-evaluate after first paint when the host attribute changes
+ * (verified manually in the showcase preview). The current approach
+ * uses Lit's `keyed()` directive to force the block element to be
+ * REPLACED (new identity) whenever its class set changes, so the
+ * `zone-off-*` rules are matched on first paint and Chromium correctly
+ * resolves the cascade. Re-mount only fires on toggle (not on schema
+ * change), so schema reactivity remains a pure cascade-of-inherited
+ * tokens via `body.line-schema-{accent}` — the baseline mechanism.
+ *
+ * Logical selectors translated by the consumer:
+ *   - `input-focus` (login) has no real ::part(); the override gates
+ *     the page's `::part(input):focus-visible` outline rule.
+ *   - `add-to-cart` (product) maps to the real part `button`.
+ */
+const classListFor = (config: PlaygroundBlockConfig | undefined): string =>
+  (config?.elements ?? [])
+    .filter((entry) => !entry.accentReactive)
+    .map((entry) => `zone-off-${entry.selector}`)
+    .join(' ');
+
+/**
+ * Compose the static base class and the dynamic `zone-off-*` classes for
+ * a block. The base class typically encodes the block's per-instance
+ * scope (e.g. `login-block-slate`).
+ */
+const composeClass = (base: string, config: PlaygroundBlockConfig | undefined): string => {
+  const off = classListFor(config);
+  return off ? `${base} ${off}` : base;
+};
+
+const findConfig = (configs: PlaygroundBlockConfig[], id: string): PlaygroundBlockConfig | undefined =>
+  configs.find((entry) => entry.id === id);
+
+/**
+ * Per-block `data-disabled-zones` derivation — retained as a debugging
+ * aid alongside the functional `zone-off-*` class list. The attribute is
+ * reflected on each block host so DevTools / agents can trace which
+ * zones are currently disabled.
+ */
+const disabledZonesFor = (config: PlaygroundBlockConfig | undefined): string =>
+  (config?.elements ?? [])
+    .filter((entry) => !entry.accentReactive)
+    .map((entry) => entry.selector)
+    .join(' ');
 
 @customElement('sc-page-playground')
 export class ScPagePlayground extends LitElement {
   @property({ type: Boolean, reflect: true }) light = false;
   @property({ type: String }) schema = 'violet';
+
+  /**
+   * Mirror of `DEFAULT_BLOCK_CONFIGS`, deep-cloned on construction so toggles
+   * do not mutate the exported constant. Page reload re-runs the constructor
+   * and resets state to defaults (acceptance: "_configs is reset to
+   * DEFAULT_BLOCK_CONFIGS on page reload").
+   */
+  @state() private _configs: PlaygroundBlockConfig[] = structuredClone(DEFAULT_BLOCK_CONFIGS);
+
+  /**
+   * Immutable update — replaces the array reference so Lit picks up the
+   * change (mutating in place would not trigger a re-render).
+   */
+  private _onConfigChange = (event: CustomEvent<ScConfigChangeDetail>) => {
+    const { blockId, selector, accentReactive } = event.detail;
+    this._configs = this._configs.map((block) => {
+      if (block.id !== blockId) return block;
+      return {
+        ...block,
+        elements: block.elements.map((entry) => (entry.selector === selector ? { ...entry, accentReactive } : entry))
+      };
+    });
+  };
 
   static override styles = css`
     :host {
@@ -163,6 +249,48 @@ export class ScPagePlayground extends LitElement {
       background: var(--line-ui-active-background, #ccc);
     }
 
+    /* ── Schema mapper (T7 — sc-schema-mapper) ──
+     * Consumer styling for the headless sidebar editor. NO --line-* tokens
+     * are used INSIDE sc-schema-mapper — every visual property is applied
+     * here via ::part() and via host custom properties. The toggle-on part
+     * is intentionally tinted with --line-solid-background so the toggle
+     * itself recolors when the nav schema picker cycles (a meta-demo of
+     * the very system this editor configures).
+     */
+    sc-schema-mapper::part(block) {
+      background: light-dark(var(--line-slate-2), var(--line-slate-12));
+      border: var(--line-border-size-1, 1px) solid
+        light-dark(var(--line-slate-5), var(--line-slate-10));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+    }
+
+    sc-schema-mapper::part(block-title) {
+      color: light-dark(var(--line-slate-11), var(--line-slate-3));
+    }
+
+    sc-schema-mapper::part(base-chip) {
+      background: light-dark(var(--line-slate-4), var(--line-slate-10));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+    }
+
+    sc-schema-mapper::part(element-label) {
+      color: light-dark(var(--line-slate-11), var(--line-slate-3));
+    }
+
+    /* Toggle (off) — neutral slate surface */
+    sc-schema-mapper::part(element-toggle) {
+      background: light-dark(var(--line-slate-4), var(--line-slate-10));
+      color: light-dark(var(--line-slate-1), var(--line-slate-12));
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-9));
+    }
+
+    /* Toggle (on) — accent-reactive, inherits from body.line-schema-{accent} */
+    sc-schema-mapper::part(element-toggle-on) {
+      background: var(--line-solid-background);
+      color: var(--line-solid-text, #fff);
+      border-color: var(--line-solid-background);
+    }
+
     /* ── Content column ── */
     .content {
       flex: 1;
@@ -303,6 +431,23 @@ export class ScPagePlayground extends LitElement {
     }
 
     /* ── Shared accent styles (both variants) ── */
+    /*
+     * Each accent rule reads var(--line-solid-*) inherited from
+     * body.line-schema-(accent). Disabling a zone is implemented by adding
+     * a higher-specificity .zone-off-(selector) rule on the host (see
+     * "Zone-off overrides" below). Per spec §14.5 NORMATIVE, .line-schema-*
+     * classes do not pierce shadow DOM, so we rely on the consumer-side
+     * class+::part() selector to scope the override.
+     *
+     * The page wraps each block with Lit's keyed() directive so the host
+     * element is replaced (not just re-attributed) whenever its class set
+     * changes. This works around a Chromium 146 invalidation bug where
+     * ::part() rules with host attribute/class filters do not re-evaluate
+     * after first paint when the host attribute changes.
+     *
+     * Note: 'add-to-cart' is the LOGICAL identifier in PlaygroundBlockConfig
+     * that maps to the real part 'button' on sc-product-card.
+     */
     sc-product-card::part(price) {
       color: var(--line-solid-background);
     }
@@ -328,6 +473,29 @@ export class ScPagePlayground extends LitElement {
 
     sc-product-card::part(button):hover {
       background: var(--line-solid-hover);
+    }
+
+    /* Zone-off overrides (product) — higher-specificity rules win over the
+     * accent rules above whenever the host carries the matching class. The
+     * block is keyed() to force re-mount, so the class is present at first
+     * paint and Chromium correctly resolves the cascade. */
+    sc-product-card.zone-off-price::part(price) {
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+    }
+
+    sc-product-card.zone-off-chip-active::part(chip-active) {
+      background: light-dark(var(--line-slate-3), var(--line-slate-10));
+      color: light-dark(var(--line-slate-11), var(--line-slate-2));
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-7));
+    }
+
+    sc-product-card.zone-off-add-to-cart::part(button) {
+      background: light-dark(var(--line-slate-3), var(--line-slate-10));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+    }
+
+    sc-product-card.zone-off-add-to-cart::part(button):hover {
+      background: light-dark(var(--line-slate-4), var(--line-slate-9));
     }
 
     /* ── Login / Sign-up block (T2) ── */
@@ -392,7 +560,9 @@ export class ScPagePlayground extends LitElement {
       color: light-dark(var(--line-slate-11), var(--line-slate-3));
     }
 
-    /* Shared accent zones — react to nav schema picker through body.line-schema-{accent} */
+    /* Shared accent zones — see top-of-section comment for gating mechanism.
+     * The 'input-focus' selector is a LOGICAL identifier (no real part);
+     * toggling it gates the consumer-side focus-ring rule below. */
     sc-login-block::part(btn-submit) {
       background: var(--line-solid-background);
       color: var(--line-solid-text, #fff);
@@ -410,6 +580,21 @@ export class ScPagePlayground extends LitElement {
 
     sc-login-block::part(footer-link-anchor) {
       color: var(--line-solid-background);
+    }
+
+    /* Zone-off overrides (login) — see top-of-section comment for keyed() rationale. */
+    sc-login-block.zone-off-btn-submit::part(btn-submit) {
+      background: light-dark(var(--line-slate-3), var(--line-slate-10));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-7));
+    }
+
+    sc-login-block.zone-off-btn-submit::part(btn-submit):hover {
+      background: light-dark(var(--line-slate-4), var(--line-slate-9));
+    }
+
+    sc-login-block.zone-off-input-focus::part(input):focus-visible {
+      outline-color: light-dark(var(--line-slate-7), var(--line-slate-6));
     }
 
     /*
@@ -553,6 +738,28 @@ export class ScPagePlayground extends LitElement {
       background: var(--line-solid-background);
       color: var(--line-solid-text, #fff);
       border-inline-start-color: var(--line-solid-background);
+    }
+
+    /* Zone-off overrides (player) — see top-of-section comment for keyed() rationale. */
+    sc-music-player.zone-off-progress-fill::part(progress-fill) {
+      background: light-dark(var(--line-gray-7), var(--line-gray-6));
+    }
+
+    sc-music-player.zone-off-ctrl-play::part(ctrl-play) {
+      background: transparent;
+      color: light-dark(var(--line-gray-12), var(--line-gray-1));
+      border-color: light-dark(var(--line-gray-7), var(--line-gray-9));
+    }
+
+    sc-music-player.zone-off-ctrl-play::part(ctrl-play):hover {
+      background: light-dark(var(--line-gray-3), var(--line-gray-10));
+      border-color: light-dark(var(--line-gray-7), var(--line-gray-9));
+    }
+
+    sc-music-player.zone-off-playlist-item-active::part(playlist-item-active) {
+      background: light-dark(var(--line-gray-3), var(--line-gray-11));
+      color: light-dark(var(--line-gray-12), var(--line-gray-1));
+      border-inline-start-color: light-dark(var(--line-gray-7), var(--line-gray-9));
     }
 
     /* ── Dashboard / notifications block (T5) ── */
@@ -703,6 +910,18 @@ export class ScPagePlayground extends LitElement {
       border-color: var(--line-solid-background);
     }
 
+    /* Zone-off overrides (dashboard) — see top-of-section comment for keyed() rationale. */
+    sc-dashboard-block.zone-off-stat-card-accent::part(stat-card-accent) {
+      --_stat-value-color: light-dark(var(--line-sand-11), var(--line-sand-3));
+      border-color: light-dark(var(--line-sand-6), var(--line-sand-9));
+    }
+
+    sc-dashboard-block.zone-off-toggle-on::part(toggle-on) {
+      background: light-dark(var(--line-sand-4), var(--line-sand-10));
+      color: light-dark(var(--line-sand-1), var(--line-sand-12));
+      border-color: light-dark(var(--line-sand-6), var(--line-sand-9));
+    }
+
     /* ── Pricing / comparison block (T6) ── */
     /*
      * <sc-pricing-block class="pricing-block"> is the consumer-applied
@@ -807,6 +1026,43 @@ export class ScPagePlayground extends LitElement {
       border-color: var(--complement-solid);
     }
 
+    /* Zone-off overrides (pricing) — see top-of-section comment for keyed() rationale. */
+    sc-pricing-block.zone-off-tier-card-featured::part(tier-card-featured) {
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-9));
+    }
+
+    sc-pricing-block.zone-off-tier-card-featured::part(badge) {
+      background: light-dark(var(--line-slate-6), var(--line-slate-9));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+    }
+
+    sc-pricing-block.zone-off-cta-solid::part(cta-solid) {
+      background: light-dark(var(--line-slate-3), var(--line-slate-10));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-7));
+    }
+
+    sc-pricing-block.zone-off-cta-solid::part(cta-solid):hover {
+      background: light-dark(var(--line-slate-4), var(--line-slate-9));
+      border-color: light-dark(var(--line-slate-7), var(--line-slate-7));
+    }
+
+    sc-pricing-block.zone-off-tier-card-enterprise::part(tier-card-enterprise) {
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-9));
+    }
+
+    sc-pricing-block.zone-off-tier-card-enterprise::part(cta-outline) {
+      background: transparent;
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+      border-color: light-dark(var(--line-slate-6), var(--line-slate-9));
+    }
+
+    sc-pricing-block.zone-off-tier-card-enterprise::part(cta-outline):hover {
+      background: light-dark(var(--line-slate-3), var(--line-slate-10));
+      color: light-dark(var(--line-slate-12), var(--line-slate-1));
+      border-color: light-dark(var(--line-slate-7), var(--line-slate-7));
+    }
+
     /* ── Mobile: top bar instead of sidebar ── */
     .mobile-bar {
       display: none;
@@ -867,6 +1123,48 @@ export class ScPagePlayground extends LitElement {
   `;
 
   override render() {
+    /*
+     * Pre-compute per-block configuration, the class lists carrying the
+     * `zone-off-*` markers, and the debugging `data-disabled-zones`
+     * reflection from the current _configs state. Each block is rendered
+     * inside Lit's `keyed()` directive — keyed on its disabled-zone
+     * fingerprint so the host element is REPLACED (new identity) every
+     * time a toggle flips. The replacement makes the `zone-off-*` rule
+     * match on first paint and works around a Chromium 146 ::part()
+     * invalidation bug observed when host attribute filters are used
+     * with :not(). Schema changes do NOT alter the key, so block state
+     * survives picker cycling; the active accent reaches every block via
+     * `body.line-schema-{accent}` and inherited custom properties.
+     */
+    const loginConfig = findConfig(this._configs, 'login');
+    const productConfig = findConfig(this._configs, 'product');
+    const playerConfig = findConfig(this._configs, 'player');
+    const dashboardConfig = findConfig(this._configs, 'dashboard');
+    const pricingConfig = findConfig(this._configs, 'pricing');
+
+    const loginDisabled = disabledZonesFor(loginConfig);
+    const productDisabled = disabledZonesFor(productConfig);
+    const playerDisabled = disabledZonesFor(playerConfig);
+    const dashboardDisabled = disabledZonesFor(dashboardConfig);
+    const pricingDisabled = disabledZonesFor(pricingConfig);
+
+    const loginClass = composeClass('login-block-slate', loginConfig);
+    const productClass = (base: string) => composeClass(base, productConfig);
+    const playerClass = composeClass('music-player-dark', playerConfig);
+    const dashboardClass = composeClass('dashboard-sand', dashboardConfig);
+    const pricingClass = composeClass('pricing-block', pricingConfig);
+
+    // Pricing complement style — recomputed every render so the picker
+    // recolors the Enterprise tier live (spec §15.1).
+    const complement = complementSchema(this.schema);
+    const pricingComplement =
+      `--complement-solid: var(--line-${complement}-9); ` +
+      `--complement-text: var(--line-${complement}-1); ` +
+      `--complement-hover: var(--line-${complement}-10); ` +
+      `--complement-border: var(--line-${complement}-8); ` +
+      `--complement-low-contrast: var(--line-${complement}-11); ` +
+      `--complement-high-contrast: var(--line-${complement}-12);`;
+
     return html`
       <!-- Mobile: collapsed accent bar -->
       <div class="mobile-bar">
@@ -902,11 +1200,10 @@ export class ScPagePlayground extends LitElement {
 
           <div class="sidebar-block-list">
             <div class="sidebar-block-list-title">Composition blocks</div>
-            <div class="sidebar-block-item">Login / Sign-up</div>
-            <div class="sidebar-block-item">E-commerce product card</div>
-            <div class="sidebar-block-item">Music player / media</div>
-            <div class="sidebar-block-item">Dashboard / notifications</div>
-            <div class="sidebar-block-item">Pricing / comparison</div>
+            <sc-schema-mapper
+              .configs=${this._configs}
+              @sc-config-change=${this._onConfigChange}
+            ></sc-schema-mapper>
           </div>
         </aside>
 
@@ -926,58 +1223,76 @@ export class ScPagePlayground extends LitElement {
               independently of both.
             </p>
             <div class="block-wrapper">
-              <sc-login-block
-                class="login-block-slate"
-                heading="Sign in"
-                subtitle="Welcome back. Enter your credentials to continue."
-                submit-label="Sign in"
-                sso-label="GitHub"
-                .errorField=${'password' as const}
-                error-message="Incorrect password."
-              ></sc-login-block>
+              ${keyed(
+                loginDisabled,
+                html`
+                  <sc-login-block
+                    class=${loginClass}
+                    data-disabled-zones=${loginDisabled}
+                    heading="Sign in"
+                    subtitle="Welcome back. Enter your credentials to continue."
+                    submit-label="Sign in"
+                    sso-label="GitHub"
+                    .errorField=${'password' as const}
+                    error-message="Incorrect password."
+                  ></sc-login-block>
+                `
+              )}
             </div>
           </div>
           <div class="block-wrapper">
             <div class="product-grid">
               <!-- Card 1: Slate base -->
-              <sc-product-card
-                class="product-card-slate"
-                heading="Classic Sneaker"
-                description="Timeless design meets modern comfort. Crafted with premium materials for everyday wear."
-                price="$89.00"
-                rating="★★★★☆"
-                rating-label="4 out of 5 stars"
-                image-src="https://picsum.photos/400/300?random=1"
-                image-alt="Classic Sneaker"
-                button-label="Add to Cart"
-                sizes="S,M,L,XL"
-                active-size="1"
-                .colors=${[
-                  { color: 'var(--line-crimson-9)', label: 'Crimson' },
-                  { color: 'var(--line-violet-9)', label: 'Violet' },
-                  { color: 'var(--line-slate-9)', label: 'Slate', selected: true }
-                ]}
-              ></sc-product-card>
+              ${keyed(
+                productDisabled,
+                html`
+                  <sc-product-card
+                    class=${productClass('product-card-slate')}
+                    data-disabled-zones=${productDisabled}
+                    heading="Classic Sneaker"
+                    description="Timeless design meets modern comfort. Crafted with premium materials for everyday wear."
+                    price="$89.00"
+                    rating="★★★★☆"
+                    rating-label="4 out of 5 stars"
+                    image-src="https://picsum.photos/400/300?random=1"
+                    image-alt="Classic Sneaker"
+                    button-label="Add to Cart"
+                    sizes="S,M,L,XL"
+                    active-size="1"
+                    .colors=${[
+                      { color: 'var(--line-crimson-9)', label: 'Crimson' },
+                      { color: 'var(--line-violet-9)', label: 'Violet' },
+                      { color: 'var(--line-slate-9)', label: 'Slate', selected: true }
+                    ]}
+                  ></sc-product-card>
+                `
+              )}
 
               <!-- Card 2: Mauve base -->
-              <sc-product-card
-                class="product-card-mauve"
-                heading="Heritage Backpack"
-                description="Water-resistant canvas with leather accents. Built to carry your essentials in style."
-                price="$129.00"
-                rating="★★★★★"
-                rating-label="5 out of 5 stars"
-                image-src="https://picsum.photos/400/300?random=2"
-                image-alt="Heritage Backpack"
-                button-label="Add to Cart"
-                sizes="S,M,L,XL"
-                active-size="0"
-                .colors=${[
-                  { color: 'var(--line-indigo-9)', label: 'Indigo' },
-                  { color: 'var(--line-teal-9)', label: 'Teal', selected: true },
-                  { color: 'var(--line-crimson-9)', label: 'Crimson' }
-                ]}
-              ></sc-product-card>
+              ${keyed(
+                productDisabled,
+                html`
+                  <sc-product-card
+                    class=${productClass('product-card-mauve')}
+                    data-disabled-zones=${productDisabled}
+                    heading="Heritage Backpack"
+                    description="Water-resistant canvas with leather accents. Built to carry your essentials in style."
+                    price="$129.00"
+                    rating="★★★★★"
+                    rating-label="5 out of 5 stars"
+                    image-src="https://picsum.photos/400/300?random=2"
+                    image-alt="Heritage Backpack"
+                    button-label="Add to Cart"
+                    sizes="S,M,L,XL"
+                    active-size="0"
+                    .colors=${[
+                      { color: 'var(--line-indigo-9)', label: 'Indigo' },
+                      { color: 'var(--line-teal-9)', label: 'Teal', selected: true },
+                      { color: 'var(--line-crimson-9)', label: 'Crimson' }
+                    ]}
+                  ></sc-product-card>
+                `
+              )}
             </div>
           </div>
           <div class="block-group">
@@ -994,20 +1309,26 @@ export class ScPagePlayground extends LitElement {
               them without re-mounting the block.
             </p>
             <div class="block-wrapper">
-              <sc-music-player
-                class="music-player-dark"
-                track-title="Midnight Ocean"
-                artist="Aurora Skies"
-                progress="38"
-                volume="65"
-                .duration=${238}
-                .playlist=${[
-                  { title: 'Midnight Ocean', artist: 'Aurora Skies', active: true },
-                  { title: 'Glass Horizon', artist: 'Pale Wing' },
-                  { title: 'Soft Static', artist: 'Field Notes' },
-                  { title: 'Night Drive', artist: 'Aurora Skies' }
-                ]}
-              ></sc-music-player>
+              ${keyed(
+                playerDisabled,
+                html`
+                  <sc-music-player
+                    class=${playerClass}
+                    data-disabled-zones=${playerDisabled}
+                    track-title="Midnight Ocean"
+                    artist="Aurora Skies"
+                    progress="38"
+                    volume="65"
+                    .duration=${238}
+                    .playlist=${[
+                      { title: 'Midnight Ocean', artist: 'Aurora Skies', active: true },
+                      { title: 'Glass Horizon', artist: 'Pale Wing' },
+                      { title: 'Soft Static', artist: 'Field Notes' },
+                      { title: 'Night Drive', artist: 'Aurora Skies' }
+                    ]}
+                  ></sc-music-player>
+                `
+              )}
             </div>
           </div>
           <div class="block-group">
@@ -1028,37 +1349,43 @@ export class ScPagePlayground extends LitElement {
               cycles.
             </p>
             <div class="block-wrapper">
-              <sc-dashboard-block
-                class="dashboard-sand"
-                .notifications=${[
-                  {
-                    kind: 'success' as const,
-                    title: 'Deployment succeeded',
-                    body: 'Production updated to v2.4.1'
-                  },
-                  {
-                    kind: 'warning' as const,
-                    title: 'High memory usage',
-                    body: 'Server is at 87% capacity'
-                  },
-                  {
-                    kind: 'danger' as const,
-                    title: 'Payment failed',
-                    body: 'Card ending 4242 was declined'
-                  }
-                ]}
-                .stats=${[
-                  { value: '12,450', label: 'Active Users', intent: 'info' as const },
-                  { value: '98.9%', label: 'Uptime', intent: 'success' as const },
-                  { value: '24', label: 'Pending', intent: 'warning' as const },
-                  { value: '+3.2%', label: 'Growth', intent: 'accent' as const }
-                ]}
-                .toggles=${[
-                  { label: 'Notifications', on: true },
-                  { label: 'Auto-deploy', on: false },
-                  { label: 'Dark mode sync', on: true }
-                ]}
-              ></sc-dashboard-block>
+              ${keyed(
+                dashboardDisabled,
+                html`
+                  <sc-dashboard-block
+                    class=${dashboardClass}
+                    data-disabled-zones=${dashboardDisabled}
+                    .notifications=${[
+                      {
+                        kind: 'success' as const,
+                        title: 'Deployment succeeded',
+                        body: 'Production updated to v2.4.1'
+                      },
+                      {
+                        kind: 'warning' as const,
+                        title: 'High memory usage',
+                        body: 'Server is at 87% capacity'
+                      },
+                      {
+                        kind: 'danger' as const,
+                        title: 'Payment failed',
+                        body: 'Card ending 4242 was declined'
+                      }
+                    ]}
+                    .stats=${[
+                      { value: '12,450', label: 'Active Users', intent: 'info' as const },
+                      { value: '98.9%', label: 'Uptime', intent: 'success' as const },
+                      { value: '24', label: 'Pending', intent: 'warning' as const },
+                      { value: '+3.2%', label: 'Growth', intent: 'accent' as const }
+                    ]}
+                    .toggles=${[
+                      { label: 'Notifications', on: true },
+                      { label: 'Auto-deploy', on: false },
+                      { label: 'Dark mode sync', on: true }
+                    ]}
+                  ></sc-dashboard-block>
+                `
+              )}
             </div>
           </div>
           <div class="block-group">
@@ -1081,54 +1408,60 @@ export class ScPagePlayground extends LitElement {
               of the picker.
             </p>
             <div class="block-wrapper">
-              <sc-pricing-block
-                class="pricing-block"
-                .accentSchema=${this.schema}
-                .tiers=${[
-                  {
-                    name: 'Free',
-                    price: '$0',
-                    period: '/ month',
-                    weight: 'ghost' as const,
-                    cta: 'Get started',
-                    features: [
-                      { available: true, text: 'Up to 3 projects' },
-                      { available: true, text: 'Community support' },
-                      { available: false, text: 'Custom domains' },
-                      { available: false, text: 'Priority support' },
-                      { available: false, text: 'SSO / SAML' }
-                    ]
-                  },
-                  {
-                    name: 'Pro',
-                    price: '$24',
-                    period: '/ month',
-                    weight: 'solid' as const,
-                    cta: 'Start free trial',
-                    features: [
-                      { available: true, text: 'Unlimited projects' },
-                      { available: true, text: 'Email support' },
-                      { available: true, text: 'Custom domains' },
-                      { available: true, text: 'Advanced analytics' },
-                      { available: false, text: 'SSO / SAML' }
-                    ]
-                  },
-                  {
-                    name: 'Enterprise',
-                    price: 'Custom',
-                    weight: 'outline' as const,
-                    cta: 'Contact sales',
-                    features: [
-                      { available: true, text: 'Unlimited projects' },
-                      { available: true, text: 'Dedicated support' },
-                      { available: true, text: 'Custom domains' },
-                      { available: true, text: 'Advanced analytics' },
-                      { available: true, text: 'SSO / SAML' }
-                    ]
-                  }
-                ]}
-                style=${`--complement-solid: var(--line-${complementSchema(this.schema)}-9); --complement-text: var(--line-${complementSchema(this.schema)}-1); --complement-hover: var(--line-${complementSchema(this.schema)}-10); --complement-border: var(--line-${complementSchema(this.schema)}-8); --complement-low-contrast: var(--line-${complementSchema(this.schema)}-11); --complement-high-contrast: var(--line-${complementSchema(this.schema)}-12);`}
-              ></sc-pricing-block>
+              ${keyed(
+                pricingDisabled,
+                html`
+                  <sc-pricing-block
+                    class=${pricingClass}
+                    data-disabled-zones=${pricingDisabled}
+                    .accentSchema=${this.schema}
+                    .tiers=${[
+                      {
+                        name: 'Free',
+                        price: '$0',
+                        period: '/ month',
+                        weight: 'ghost' as const,
+                        cta: 'Get started',
+                        features: [
+                          { available: true, text: 'Up to 3 projects' },
+                          { available: true, text: 'Community support' },
+                          { available: false, text: 'Custom domains' },
+                          { available: false, text: 'Priority support' },
+                          { available: false, text: 'SSO / SAML' }
+                        ]
+                      },
+                      {
+                        name: 'Pro',
+                        price: '$24',
+                        period: '/ month',
+                        weight: 'solid' as const,
+                        cta: 'Start free trial',
+                        features: [
+                          { available: true, text: 'Unlimited projects' },
+                          { available: true, text: 'Email support' },
+                          { available: true, text: 'Custom domains' },
+                          { available: true, text: 'Advanced analytics' },
+                          { available: false, text: 'SSO / SAML' }
+                        ]
+                      },
+                      {
+                        name: 'Enterprise',
+                        price: 'Custom',
+                        weight: 'outline' as const,
+                        cta: 'Contact sales',
+                        features: [
+                          { available: true, text: 'Unlimited projects' },
+                          { available: true, text: 'Dedicated support' },
+                          { available: true, text: 'Custom domains' },
+                          { available: true, text: 'Advanced analytics' },
+                          { available: true, text: 'SSO / SAML' }
+                        ]
+                      }
+                    ]}
+                    style=${pricingComplement}
+                  ></sc-pricing-block>
+                `
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## line-ui-m3d.7: T7 — Schema mapping configuration and accent reactivity system

Implements the T7 schema-mapping configuration and per-zone accent reactivity for the showcase playground page. Adds a new headless `<sc-schema-mapper>` sidebar editor, replaces the T1 stub `PlaygroundBlockConfig` with the final spec §14.2 shape, and wires a runtime per-zone "accent on/off" mechanism that survives picker cycling.

### What was done
- Replaced T1's `PlaygroundBlockConfig` stub with the final spec §14.2 shape: added `BlockElementConfig`, optional `complementSchema`. Added `DEFAULT_BLOCK_CONFIGS` with DASH-form selectors matching the real `::part()` names on each block.
- New headless `<sc-schema-mapper>` (`apps/showcase/src/components/sc-schema-mapper.ts`): spec §8.7 contract — 9 named parts, 8 host custom-property groups, `sc-config-change` event, real `<button role="switch" aria-checked aria-label>` toggles, Space/Enter activation, non-interactive base-chip.
- `sc-page-playground` carries `@state _configs = structuredClone(DEFAULT_BLOCK_CONFIGS)`; toggles replace the array reference immutably so Lit re-renders without mutating the exported constant.
- Per-zone gating: `.zone-off-{selector}` classes on each block host with higher-specificity `::part()` overrides; each block is wrapped with Lit's `keyed()` directive so the host element is replaced on toggle (Chromium 146 has a `::part()` invalidation bug with attribute filters — `keyed()` re-mount sidesteps it).
- `data-disabled-zones` is reflected on each block host for debugging.
- Schema reactivity stays via `body.line-schema-{accent}` → inherited `--line-solid-*` cascade (unchanged from baseline).

### Files changed
- `apps/showcase/src/pages/playground-config.ts` — refactored interface + added `DEFAULT_BLOCK_CONFIGS`.
- `apps/showcase/src/pages/playground.ts` — `@state _configs`, mapper integration, per-zone overrides, `keyed()` wrappers.
- `apps/showcase/src/components/sc-schema-mapper.ts` — NEW headless element.

### Decisions / Deviations
- **DECISION** logged on the bead: chose `.zone-off-*` class + `keyed()` over the bead's suggested `data-disabled-zones` attribute filter because Chromium 146 has a `::part()` invalidation bug with `:not([attr~='...'])::part()` host filters (verified manually in the preview tool). Same bug also affects `var(--_zone-*, var(--line-solid-*))` indirection inside `::part()` rules.
- **DEVIATION** logged on the bead: mechanism differs from the bead's suggested attribute-based filter but satisfies the spec §14.5 functional contract (`accentReactive=false` ⇒ zone falls back to base palette; `accentReactive=true` ⇒ active accent).

### Test plan
- [x] `bun x tsc --noEmit` on `apps/showcase` passes.
- [x] `bun x biome check` on the 3 changed files passes.
- [x] `bun run build` on `packages/core` succeeds (no theme/core changes).
- [x] Manual functional verification in Vite dev server: initial paint accent rendering, toggle off → zone neutralised, toggle on → accent restored, Space/Enter keyboard activation, 9 parts present, real `role="switch"` toggles.
- [x] Mobile <768px sidebar (and mapper) collapses; nav-bar picker still works.
- [ ] Visual regression review: cycle the picker through several palettes with selected combinations of zones toggled off — confirm UX read as intended.