### PR TITLE
chore(showcase): batched review cleanup for line-ui-m3d.13 + line-ui-m3d.14

### DIFF
--- a/apps/showcase/src/components/sc-dashboard-block.ts
+++ b/apps/showcase/src/components/sc-dashboard-block.ts
@@ -68,7 +68,9 @@ export interface ScDashboardToggleChangeDetail {
  *    §11). Space/Enter flips state (spec §10) and emits `sc-toggle-change`
  *    with `{ index, on }`. The active toggle carries an additive
  *    `toggle-on` / `toggle-off` part so the accent-reactive "on" state can
- *    be painted independently.
+ *    be painted independently. The accessible name is supplied via
+ *    `aria-labelledby` pointing at the visible `toggle-label` span so the
+ *    a11y name stays in sync with the visible text automatically.
  *
  * @fires sc-toggle-change - User flipped a toggle (click or Space/Enter). Detail: `{ index, on }`.
  */
@@ -108,6 +110,17 @@ export class ScDashboardBlock extends LitElement {
       --toggle-width: 40px;
       --toggle-radius: 999px;
       --toggle-thumb-size: 16px;
+      /*
+       * Focus-ring color for the toggle button. Defaults to currentColor
+       * to preserve the prior behaviour; consumers can override via a
+       * ::part(toggle) rule (or by setting this property on the host) to
+       * supply a contrast-safe color when currentColor resolves close to
+       * the surface background (e.g. sand-1 in the off state).
+       *
+       * Per the headless contract (spec section 0), this is a generic CSS
+       * custom property — NO --line-* token is referenced inside the component.
+       */
+      --toggle-focus-ring-color: currentColor;
 
       display: block;
     }
@@ -264,7 +277,7 @@ export class ScDashboardBlock extends LitElement {
     }
 
     .toggle:focus-visible {
-      outline: 2px solid currentColor;
+      outline: 2px solid var(--toggle-focus-ring-color);
       outline-offset: 2px;
     }
 
@@ -397,24 +410,25 @@ export class ScDashboardBlock extends LitElement {
       <section class="section" part="section">
         <h4 class="section-title" part="section-title">Settings</h4>
         <ul class="toggle-list" part="toggle-list">
-          ${this.toggles.map(
-            (entry, index) => html`
+          ${this.toggles.map((entry, index) => {
+            const labelId = `sc-dashboard-toggle-label-${index}`;
+            return html`
               <li class="toggle-row" part="toggle-row">
-                <span class="toggle-label" part="toggle-label">${entry.label}</span>
+                <span class="toggle-label" part="toggle-label" id=${labelId}>${entry.label}</span>
                 <button
                   class="toggle"
                   part="toggle ${entry.on ? 'toggle-on' : 'toggle-off'}"
                   type="button"
                   role="switch"
                   aria-checked=${entry.on ? 'true' : 'false'}
-                  aria-label=${entry.label}
+                  aria-labelledby=${labelId}
                   data-index=${index}
                   @click=${this._onToggleClick}
                   @keydown=${this._onToggleKeydown}
                 ></button>
               </li>
-            `
-          )}
+            `;
+          })}
         </ul>
       </section>
     `;

--- a/apps/showcase/src/components/sc-pricing-block.ts
+++ b/apps/showcase/src/components/sc-pricing-block.ts
@@ -14,15 +14,31 @@ export interface ScPricingFeature {
 }
 
 /**
+ * Semantic role of a pricing tier.
+ *
+ * - `'free'` — neutral baseline (no additive card part beyond `tier-card`).
+ * - `'featured'` — the "Recommended" / accent-reactive tier; carries the
+ *   additive `tier-card-featured` part and a `badge` part.
+ * - `'enterprise'` — the complement-schema tier; carries the additive
+ *   `tier-card-enterprise` part.
+ *
+ * Explicit `role` replaces the prior name-based detection so display strings
+ * (e.g. localisation) do not couple to which card part is painted.
+ */
+export type ScPricingTierRole = 'free' | 'featured' | 'enterprise';
+
+/**
  * One pricing tier consumed by `<sc-pricing-block>`.
  *
  * `weight` selects which CTA part the consumer paints (`cta-ghost` /
- * `cta-solid` / `cta-outline`). Tier ORDER is significant and conventional:
- * index 0 = Free (neutral), index 1 = Pro (featured / accent),
- * index 2 = Enterprise (complement). The tier whose `name === 'Pro'` is
- * additionally tagged with the `tier-card-featured` part; the tier whose
- * `name === 'Enterprise'` carries the `tier-card-enterprise` part — the
- * consumer must supply `.tiers` in this order and with these names.
+ * `cta-solid` / `cta-outline`).
+ *
+ * `role` is the SEMANTIC tier identifier (see {@link ScPricingTierRole}).
+ * It is optional for backwards compatibility — when omitted, the role is
+ * derived from `name` (`'Pro'` → `'featured'`, `'Enterprise'` → `'enterprise'`,
+ * everything else → `'free'`). New call sites should always pass `role`
+ * explicitly so display strings remain free to change without breaking which
+ * additive card part is painted.
  */
 export interface ScPricingTier {
   name: string;
@@ -31,6 +47,12 @@ export interface ScPricingTier {
   features: ScPricingFeature[];
   cta: string;
   weight: 'ghost' | 'solid' | 'outline';
+  /**
+   * Semantic tier role. If omitted, falls back to name-based detection for
+   * backwards compatibility (`'Pro'` → `'featured'`, `'Enterprise'` →
+   * `'enterprise'`, otherwise `'free'`).
+   */
+  role?: ScPricingTierRole;
 }
 
 /**
@@ -328,8 +350,15 @@ export class ScPricingBlock extends LitElement {
   }
 
   private _renderTier(tier: ScPricingTier, index: number) {
-    const isFeatured = tier.name === 'Pro';
-    const isEnterprise = tier.name === 'Enterprise';
+    /*
+     * Prefer the explicit `role` field; fall back to legacy name-based
+     * detection for backwards compatibility with consumers that have not
+     * yet been updated.
+     */
+    const role: ScPricingTierRole =
+      tier.role ?? (tier.name === 'Pro' ? 'featured' : tier.name === 'Enterprise' ? 'enterprise' : 'free');
+    const isFeatured = role === 'featured';
+    const isEnterprise = role === 'enterprise';
     const cardPartTokens = [
       'tier-card',
       isFeatured ? 'tier-card-featured' : '',

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -1418,6 +1418,7 @@ export class ScPagePlayground extends LitElement {
                     .tiers=${[
                       {
                         name: 'Free',
+                        role: 'free' as const,
                         price: '$0',
                         period: '/ month',
                         weight: 'ghost' as const,
@@ -1432,6 +1433,7 @@ export class ScPagePlayground extends LitElement {
                       },
                       {
                         name: 'Pro',
+                        role: 'featured' as const,
                         price: '$24',
                         period: '/ month',
                         weight: 'solid' as const,
@@ -1446,6 +1448,7 @@ export class ScPagePlayground extends LitElement {
                       },
                       {
                         name: 'Enterprise',
+                        role: 'enterprise' as const,
                         price: 'Custom',
                         weight: 'outline' as const,
                         cta: 'Contact sales',

--- a/apps/showcase/src/pages/playground.ts
+++ b/apps/showcase/src/pages/playground.ts
@@ -797,13 +797,13 @@ export class ScPagePlayground extends LitElement {
       color: light-dark(var(--line-sand-11), var(--line-sand-3));
     }
 
-    /* Stat cards / toggle rows: neutral card surface on the sand palette */
-    .dashboard-sand::part(stat-card),
-    .dashboard-sand::part(toggle-row) {
+    /* Stat cards: neutral card surface on the sand palette */
+    .dashboard-sand::part(stat-card) {
       background: light-dark(var(--line-sand-1), var(--line-sand-12));
       border: 1px solid light-dark(var(--line-sand-6), var(--line-sand-9));
     }
 
+    /* Toggle rows: transparent surface with a bottom divider on sand */
     .dashboard-sand::part(toggle-row) {
       background: transparent;
       border: none;
@@ -893,10 +893,10 @@ export class ScPagePlayground extends LitElement {
     }
 
     /* Accent-reactive stat card: tint the card border too so the card itself
-       reads as the active accent surface. */
+       reads as the active accent surface. The background is inherited from
+       the base .dashboard-sand::part(stat-card) rule above. */
     .dashboard-sand::part(stat-card-accent) {
       border-color: var(--line-solid-background);
-      background: light-dark(var(--line-sand-1), var(--line-sand-12));
     }
 
     /* ── Accent-reactive toggle (on state) ──


### PR DESCRIPTION
## Summary

Batched [semantic] review-cleanup for two child beads of epic `line-ui-m3d` (Multi-Schema Playground):

- **line-ui-m3d.13** — T5 sc-dashboard-block review findings (4 items)
- **line-ui-m3d.14** — T6 sc-pricing-block review findings (2 items)

Both scopes are disjoint (dashboard vs pricing); no merge conflict inside `playground.ts`.

## line-ui-m3d.13 — Dashboard cleanups

1. **Split combined ::part() rule** — `.dashboard-sand::part(stat-card),::part(toggle-row)` was followed by a `toggle-row`-only override that made every `toggle-row` declaration in the combined rule dead code. Split into two independent rules.
2. **Drop redundant background** on `.dashboard-sand::part(stat-card-accent)` — restated the same value already supplied by the base `stat-card` rule. Only `border-color` was novel.
3. **Replace aria-label with aria-labelledby** on the toggle button — the visible `.toggle-label` span now carries a stable per-index id and the button references it via `aria-labelledby`. Keeps the accessible name in sync with the visible text automatically.
4. **Expose `--toggle-focus-ring-color`** host custom property (default `currentColor`) consumed by `.toggle:focus-visible`. Honors the headless contract — NO `--line-*` token referenced inside the component; consumers paint via `::part(toggle)` from outside if a contrast-safe color is needed.

## line-ui-m3d.14 — Pricing cleanups

1. **Promote `role: 'free' | 'featured' | 'enterprise'`** as an explicit field on `ScPricingTier` so the additive card part (`tier-card-featured` / `tier-card-enterprise`) and the "Recommended" badge no longer depend on string-equality against the display name. `role` is optional with a backwards-compatible name-based fallback so existing consumers continue to work without changes. The new `ScPricingTierRole` type union is exported. All three playground tier definitions pass `role` explicitly.
2. **(no-op)** — Hoist `complementSchema(this.schema)` was already addressed in commit 4da7972 (T7 schema-mapper feature). `playground.ts:1159` already declares `const complement = complementSchema(this.schema);` used by all six `--complement-*` string interpolations. The bead description's line refs were stale from before T7 landed.

## Verification

- `bun x tsc --noEmit -p apps/showcase/tsconfig.json` → clean
- `bun x biome check` on the 3 changed files → clean
- `bun run build` in `packages/core` → clean (API extractor warnings are pre-existing, unrelated to this PR)
- `bun run build` in `apps/showcase` → clean (`vite build` 414ms, 316KB JS / 191KB CSS)

## Test plan

- [ ] Manual Vite preview on the playground page — Dashboard toggles still flip with Space/Enter and reflect aria-checked correctly; the accessible name announced by VoiceOver matches the visible label.
- [ ] Manual Vite preview on the playground page — Pricing block still highlights the Pro card (`tier-card-featured`, Recommended badge) and the Enterprise card (`tier-card-enterprise`, complement-schema) correctly when the nav schema picker is cycled.
- [ ] Verify the toggle focus ring is visible on `.dashboard-sand` surface in both light and dark mode (currentColor default — bead suggestion #4 leaves the override hook in place for a future contrast-safe consumer rule).

Refs: `bd show line-ui-m3d.13` · `bd show line-ui-m3d.14`