### PR TITLE
line-ui-7qm.2.2: B2 — Wire cross-package workspace dependencies per layer graph

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -8,5 +8,15 @@
     "dev": "echo 'dev TBD — implemented in B4 (line-ui-7qm.2.4)'",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@websublime/line-colors": "workspace:^",
+    "@websublime/line-components": "workspace:^",
+    "@websublime/line-core": "workspace:^",
+    "@websublime/line-icons": "workspace:^",
+    "@websublime/line-schemas": "workspace:^",
+    "@websublime/line-themes": "workspace:^",
+    "@websublime/line-tokens": "workspace:^",
+    "@websublime/line-utils": "workspace:^"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,16 @@
     "apps/storybook": {
       "name": "@websublime/line-storybook",
       "version": "0.0.0",
+      "devDependencies": {
+        "@websublime/line-colors": "workspace:^",
+        "@websublime/line-components": "workspace:^",
+        "@websublime/line-core": "workspace:^",
+        "@websublime/line-icons": "workspace:^",
+        "@websublime/line-schemas": "workspace:^",
+        "@websublime/line-themes": "workspace:^",
+        "@websublime/line-tokens": "workspace:^",
+        "@websublime/line-utils": "workspace:^",
+      },
     },
     "packages/line-colors": {
       "name": "@websublime/line-colors",
@@ -50,14 +60,28 @@
     "packages/line-components": {
       "name": "@websublime/line-components",
       "version": "0.0.0",
+      "dependencies": {
+        "@websublime/line-core": "workspace:^",
+        "@websublime/line-themes": "workspace:^",
+        "@websublime/line-tokens": "workspace:^",
+        "@websublime/line-utils": "workspace:^",
+      },
     },
     "packages/line-core": {
       "name": "@websublime/line-core",
       "version": "0.0.0",
+      "dependencies": {
+        "@zag-js/core": "^1.40.0",
+        "@zag-js/vanilla": "^1.40.0",
+        "lit": "^3.3.3",
+      },
     },
     "packages/line-icons": {
       "name": "@websublime/line-icons",
       "version": "0.0.0",
+      "dependencies": {
+        "@websublime/line-tokens": "workspace:^",
+      },
     },
     "packages/line-schemas": {
       "name": "@websublime/line-schemas",
@@ -66,6 +90,10 @@
     "packages/line-themes": {
       "name": "@websublime/line-themes",
       "version": "0.0.0",
+      "dependencies": {
+        "@websublime/line-colors": "workspace:^",
+        "@websublime/line-schemas": "workspace:^",
+      },
     },
     "packages/line-tokens": {
       "name": "@websublime/line-tokens",
@@ -74,6 +102,9 @@
     "packages/line-utils": {
       "name": "@websublime/line-utils",
       "version": "0.0.0",
+      "dependencies": {
+        "@websublime/line-schemas": "workspace:^",
+      },
     },
   },
   "packages": {

--- a/packages/line-components/package.json
+++ b/packages/line-components/package.json
@@ -12,6 +12,12 @@
       "import": "./dist/index.js"
     }
   },
+  "dependencies": {
+    "@websublime/line-core": "workspace:^",
+    "@websublime/line-themes": "workspace:^",
+    "@websublime/line-tokens": "workspace:^",
+    "@websublime/line-utils": "workspace:^"
+  },
   "scripts": {
     "build": "echo 'build TBD — implemented in B4 (line-ui-7qm.2.4)'",
     "dev": "echo 'dev TBD — implemented in B4 (line-ui-7qm.2.4)'",

--- a/packages/line-core/package.json
+++ b/packages/line-core/package.json
@@ -24,6 +24,11 @@
       "import": "./dist/mixins/*.js"
     }
   },
+  "dependencies": {
+    "@zag-js/core": "^1.40.0",
+    "@zag-js/vanilla": "^1.40.0",
+    "lit": "^3.3.3"
+  },
   "scripts": {
     "build": "echo 'build TBD — implemented in B4 (line-ui-7qm.2.4)'",
     "dev": "echo 'dev TBD — implemented in B4 (line-ui-7qm.2.4)'",

--- a/packages/line-icons/package.json
+++ b/packages/line-icons/package.json
@@ -12,6 +12,9 @@
       "import": "./dist/index.js"
     }
   },
+  "dependencies": {
+    "@websublime/line-tokens": "workspace:^"
+  },
   "scripts": {
     "build": "echo 'build TBD — implemented in B4 (line-ui-7qm.2.4)'",
     "dev": "echo 'dev TBD — implemented in B4 (line-ui-7qm.2.4)'",

--- a/packages/line-themes/package.json
+++ b/packages/line-themes/package.json
@@ -16,6 +16,10 @@
     "./aliases": "./dist/aliases.css",
     "./defaults": "./dist/defaults.css"
   },
+  "dependencies": {
+    "@websublime/line-colors": "workspace:^",
+    "@websublime/line-schemas": "workspace:^"
+  },
   "scripts": {
     "build": "echo 'build TBD — implemented in B4 (line-ui-7qm.2.4)'",
     "dev": "echo 'dev TBD — implemented in B4 (line-ui-7qm.2.4)'",

--- a/packages/line-utils/package.json
+++ b/packages/line-utils/package.json
@@ -20,6 +20,9 @@
       "import": "./dist/mix.js"
     }
   },
+  "dependencies": {
+    "@websublime/line-schemas": "workspace:^"
+  },
   "scripts": {
     "build": "echo 'build TBD — implemented in B4 (line-ui-7qm.2.4)'",
     "dev": "echo 'dev TBD — implemented in B4 (line-ui-7qm.2.4)'",


### PR DESCRIPTION
## line-ui-7qm.2.2: B2 — Wire cross-package workspace dependencies per layer graph

Add `workspace:^` references between packages per the downward-only layer graph fixed in spec §6.B (Allowed edges) and §3 Architecture Summary as amended by AM-004. Pure manifest-wiring task — no code, no tsconfig, no scripts.

### What was done

Wired cross-package `workspace:^` dependencies across 6 package.json files plus `apps/storybook` devDependencies, exactly matching the spec §6.B "Allowed edges" table. `bun install` resolves all 10 workspaces cleanly; no circular dependencies; manual edge audit confirms zero upward/sideways leakage.

Per-package edges added:
- `line-themes` → `line-colors`, `line-schemas`
- `line-utils` → `line-schemas`
- `line-core` → `lit ^3.3.3`, `@zag-js/core ^1.40.0`, `@zag-js/vanilla ^1.40.0` (no `@websublime/*` deps in Phase 00 per spec §6.B line 458)
- `line-components` → `line-core`, `line-tokens`, `line-themes`, `line-utils` (utils included per AM-004)
- `line-icons` → `line-tokens` (workspace edge for build-order per AM-003; consumption is CSS/runtime)
- `apps/storybook` devDependencies → all 8 `@websublime/line-*` packages (private:true, never published)

Leaves (`line-tokens`, `line-colors`, `line-schemas`) and `apps/site` retain zero `@websublime/*` deps per spec.

### Files changed

- `packages/line-themes/package.json`
- `packages/line-utils/package.json`
- `packages/line-core/package.json`
- `packages/line-components/package.json`
- `packages/line-icons/package.json`
- `apps/storybook/package.json`
- `bun.lock`

### Decisions

None — followed spec §6.B verbatim. AM-004 (landed on `main` as 7671819 before implementation) had already resolved the only ambiguity (DRIFT-arch-summary-vs-B2-table flagged in pre-implementation investigation).

### Deviations

None — implemented as spec.

### Verification

- `bun install` exited 0 with `Saved lockfile`
- `bun pm ls` confirms all 10 `@websublime` workspaces present as `workspace:` refs
- Manual per-package audit of `dependencies` + `peerDependencies` matches §6.B exactly
- `bunx biome check --write` on all touched files produced no changes (manifests already conforming)
- `bun.lock` diff reflects every workspace edge added

Refs: `docs/specs/00-spec-design-system.md` §3 (AM-004), §6.B, §6.A.3, AM-003 (line-icons rationale).