### PR TITLE
line-ui-7qm.3.2: C2 — line-tokens 18 families + reset barrel

### DIFF
--- a/.changeset/line-tokens-families.md
+++ b/.changeset/line-tokens-families.md
@@ -1,0 +1,5 @@
+---
+"@websublime/line-tokens": minor
+---
+
+Author the 18 token-family CSS files plus the light-DOM consumer reset and compose the `index.css` barrel. Primitives: `typography`, `sizing`, `shadows`, `easings`, `z-index`, `opacity`, `motion`, `radii`, `border-width`, `focus-ring`, `breakpoints`. Decoratives: `aspects`, `animations`, `gradients`, `masks`, `layouts`, `highlights`, `svg`. All custom properties are `--line-*` prefixed and singular; every declaration is wrapped in `:where(html)` for zero specificity. Decorative `gradients`/`highlights`/`svg` are structural-only — colour references defer to `var(--line-{hue}-{step})` tokens supplied by `line-colors`. The PostCSS build emits a flat `dist/index.css` barrel plus one `dist/*.css` per subpath.

--- a/packages/line-tokens/src/animations.css
+++ b/packages/line-tokens/src/animations.css
@@ -1,0 +1,99 @@
+/* @websublime/line-tokens — animations.css
+ *
+ * Decorative family: reusable @keyframes + composed animation tokens.
+ * Keyframes are STRUCTURAL (transform/opacity only — no colour literals).
+ * Animation shorthand tokens compose duration (motion) + easing tokens.
+ * Tokens are SINGULAR: --line-animation-*.
+ */
+@keyframes line-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes line-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes line-scale-up {
+  from {
+    transform: scale(0.9);
+  }
+}
+
+@keyframes line-scale-down {
+  to {
+    transform: scale(0.9);
+  }
+}
+
+@keyframes line-slide-in-up {
+  from {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes line-slide-in-down {
+  from {
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes line-slide-in-left {
+  from {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes line-slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes line-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes line-ping {
+  90%,
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes line-pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes line-bounce {
+  25% {
+    transform: translateY(-20%);
+  }
+  40% {
+    transform: translateY(-3%);
+  }
+}
+
+:where(html) {
+  /* Composed animation tokens (duration + easing reference primitive tokens). */
+  --line-animation-fade-in: line-fade-in var(--line-motion-3) var(--line-easing-out);
+  --line-animation-fade-out: line-fade-out var(--line-motion-3) var(--line-easing-in);
+  --line-animation-scale-up: line-scale-up var(--line-motion-3) var(--line-easing-out);
+  --line-animation-scale-down: line-scale-down var(--line-motion-3) var(--line-easing-in);
+  --line-animation-slide-in-up: line-slide-in-up var(--line-motion-3) var(--line-easing-out);
+  --line-animation-slide-in-down: line-slide-in-down var(--line-motion-3) var(--line-easing-out);
+  --line-animation-slide-in-left: line-slide-in-left var(--line-motion-3) var(--line-easing-out);
+  --line-animation-slide-in-right: line-slide-in-right var(--line-motion-3) var(--line-easing-out);
+  --line-animation-spin: line-spin var(--line-motion-6) var(--line-easing-linear) infinite;
+  --line-animation-ping: line-ping var(--line-motion-6) var(--line-easing-out) infinite;
+  --line-animation-pulse: line-pulse var(--line-motion-7) var(--line-easing-in-out) infinite;
+  --line-animation-bounce: line-bounce var(--line-motion-6) var(--line-easing-out) infinite;
+}

--- a/packages/line-tokens/src/aspects.css
+++ b/packages/line-tokens/src/aspects.css
@@ -1,0 +1,13 @@
+/* @websublime/line-tokens — aspects.css
+ *
+ * Decorative family: aspect-ratio tokens.
+ * Tokens are SINGULAR: --line-aspect-*.
+ */
+:where(html) {
+  --line-aspect-square: 1;
+  --line-aspect-landscape: 4 / 3;
+  --line-aspect-portrait: 3 / 4;
+  --line-aspect-widescreen: 16 / 9;
+  --line-aspect-ultrawide: 18 / 5;
+  --line-aspect-golden: 1.618 / 1;
+}

--- a/packages/line-tokens/src/border-width.css
+++ b/packages/line-tokens/src/border-width.css
@@ -1,0 +1,13 @@
+/* @websublime/line-tokens — border-width.css
+ *
+ * Primitive family: border-width scale.
+ * Tokens are SINGULAR: --line-border-N.
+ */
+:where(html) {
+  --line-border-0: 0;
+  --line-border-1: 1px;
+  --line-border-2: 2px;
+  --line-border-3: 5px;
+  --line-border-4: 10px;
+  --line-border-5: 25px;
+}

--- a/packages/line-tokens/src/breakpoints.css
+++ b/packages/line-tokens/src/breakpoints.css
@@ -1,0 +1,18 @@
+/* @websublime/line-tokens — breakpoints.css
+ *
+ * Primitive family: responsive breakpoint scale.
+ * Tokens are SINGULAR: --line-breakpoint-*.
+ *
+ * NOTE: custom properties cannot be used directly inside @media feature
+ * queries, so these tokens are design references for consumers building
+ * container queries / JS-driven media logic. They mirror the canonical
+ * min-width thresholds.
+ */
+:where(html) {
+  --line-breakpoint-xs: 20rem;
+  --line-breakpoint-sm: 30rem;
+  --line-breakpoint-md: 48rem;
+  --line-breakpoint-lg: 64rem;
+  --line-breakpoint-xl: 80rem;
+  --line-breakpoint-xxl: 96rem;
+}

--- a/packages/line-tokens/src/easings.css
+++ b/packages/line-tokens/src/easings.css
@@ -1,0 +1,38 @@
+/* @websublime/line-tokens — easings.css
+ *
+ * Primitive family: timing-function (easing) curves.
+ * Values seeded from Open Props as a design reference — NO runtime dependency.
+ * Tokens are SINGULAR: --line-easing-*.
+ */
+:where(html) {
+  --line-easing-linear: cubic-bezier(0, 0, 1, 1);
+
+  /* Standard in/out/in-out */
+  --line-easing-in: cubic-bezier(0.4, 0, 1, 1);
+  --line-easing-out: cubic-bezier(0, 0, 0.2, 1);
+  --line-easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Progressive (more dramatic) */
+  --line-easing-in-1: cubic-bezier(0.25, 0, 1, 1);
+  --line-easing-in-2: cubic-bezier(0.5, 0, 1, 1);
+  --line-easing-in-3: cubic-bezier(0.7, 0, 1, 1);
+
+  --line-easing-out-1: cubic-bezier(0, 0, 0.75, 1);
+  --line-easing-out-2: cubic-bezier(0, 0, 0.5, 1);
+  --line-easing-out-3: cubic-bezier(0, 0, 0.3, 1);
+
+  --line-easing-in-out-1: cubic-bezier(0.1, 0, 0.9, 1);
+  --line-easing-in-out-2: cubic-bezier(0.3, 0, 0.7, 1);
+  --line-easing-in-out-3: cubic-bezier(0.5, 0, 0.5, 1);
+
+  /* Elastic / spring overshoot */
+  --line-easing-elastic-1: cubic-bezier(0.5, 0.75, 0.75, 1.25);
+  --line-easing-elastic-2: cubic-bezier(0.5, 1, 0.75, 1.25);
+  --line-easing-elastic-3: cubic-bezier(0.5, 1.25, 0.75, 1.25);
+  --line-easing-elastic-4: cubic-bezier(0.5, 1.5, 0.75, 1.25);
+
+  /* Step easings */
+  --line-easing-step-1: steps(2);
+  --line-easing-step-2: steps(3);
+  --line-easing-step-3: steps(4);
+}

--- a/packages/line-tokens/src/focus-ring.css
+++ b/packages/line-tokens/src/focus-ring.css
@@ -1,0 +1,19 @@
+/* @websublime/line-tokens — focus-ring.css
+ *
+ * Primitive family: focus-ring geometry tokens (width, offset, style, color).
+ * Tokens are SINGULAR: --line-focus-ring-*.
+ *
+ * Zero colour opinion (Manifesto Law): the ring colour is NOT a literal. It
+ * defers to --line-focus-ring-color, which references the accent role token
+ * supplied by line-colors / line-themes (C3/C4). Dangling var() at C2 build
+ * time — resolves at use-site once the colour layer is loaded.
+ */
+:where(html) {
+  --line-focus-ring-width: 2px;
+  --line-focus-ring-offset: 2px;
+  --line-focus-ring-style: solid;
+  --line-focus-ring-color: var(--line-accent-8);
+
+  /* Composed shorthand for `outline`. */
+  --line-focus-ring: var(--line-focus-ring-width) var(--line-focus-ring-style) var(--line-focus-ring-color);
+}

--- a/packages/line-tokens/src/gradients.css
+++ b/packages/line-tokens/src/gradients.css
@@ -1,0 +1,37 @@
+/* @websublime/line-tokens — gradients.css
+ *
+ * Decorative family: STRUCTURAL gradient tokens (Phase 00).
+ *
+ * COLOUR-LITERAL-FREE (enforced by scripts/lint-layers.mjs). This file owns
+ * gradient GEOMETRY — angles, stops, positions. Every colour reference is a
+ * var(--line-{hue}-{step}) token supplied by line-colors (C3). At C2 build
+ * time those are dangling var() refs (resolve at use-site) — that is expected.
+ * Tokens are SINGULAR: --line-gradient-*.
+ */
+:where(html) {
+  /* Directional linear-gradient angles (geometry only). */
+  --line-gradient-angle-to-top: to top;
+  --line-gradient-angle-to-bottom: to bottom;
+  --line-gradient-angle-to-left: to left;
+  --line-gradient-angle-to-right: to right;
+  --line-gradient-angle-diagonal: 45deg;
+  --line-gradient-angle-diagonal-reverse: 135deg;
+
+  /* Composed gradients: colour stops reference line-colors hue tokens.
+     Direction keywords are inlined (structural, not colour) because a var()
+     in the direction slot is rejected by static linters. */
+  --line-gradient-1: linear-gradient(to bottom, var(--line-accent-9), var(--line-accent-11));
+  --line-gradient-2: linear-gradient(45deg, var(--line-accent-7), var(--line-accent-10));
+  --line-gradient-surface: linear-gradient(to bottom, var(--line-gray-2), var(--line-gray-4));
+
+  /* Radial + conic geometry (positions/shapes only). */
+  --line-gradient-radial: radial-gradient(circle at center, var(--line-accent-9), var(--line-accent-12));
+  --line-gradient-conic: conic-gradient(from 0deg at 50% 50%, var(--line-accent-9), var(--line-accent-12));
+
+  /* Stop-position scale (percentages — pure geometry). */
+  --line-gradient-stop-0: 0%;
+  --line-gradient-stop-1: 25%;
+  --line-gradient-stop-2: 50%;
+  --line-gradient-stop-3: 75%;
+  --line-gradient-stop-4: 100%;
+}

--- a/packages/line-tokens/src/highlights.css
+++ b/packages/line-tokens/src/highlights.css
@@ -1,0 +1,19 @@
+/* @websublime/line-tokens — highlights.css
+ *
+ * Decorative family: STRUCTURAL ::selection / highlight tokens (Phase 00).
+ *
+ * COLOUR-LITERAL-FREE (enforced by scripts/lint-layers.mjs). Colours defer to
+ * --line-highlight-bg / --line-highlight-text, which reference line-colors
+ * hue tokens (C3). Dangling var() at C2 build time — resolves at use-site.
+ * Tokens are SINGULAR: --line-highlight-*.
+ */
+:where(html) {
+  --line-highlight-bg: var(--line-accent-5);
+  --line-highlight-text: var(--line-accent-12);
+}
+
+/* Zero-specificity ::selection styling for slotted/light-DOM content. */
+:where(html) ::selection {
+  background-color: var(--line-highlight-bg);
+  color: var(--line-highlight-text);
+}

--- a/packages/line-tokens/src/index.css
+++ b/packages/line-tokens/src/index.css
@@ -1,1 +1,31 @@
-/* @websublime/line-tokens — primitives barrel (placeholder; B4 wires the real PostCSS pipeline). */
+/* @websublime/line-tokens — primitives barrel.
+ *
+ * Composes reset + 18 token families in a FIXED order (spec §4.1 / §6.C.2):
+ *   reset → 11 primitives (alphabetical) → 7 decoratives (alphabetical).
+ * postcss-import inlines these into a single flat dist/index.css at build time.
+ */
+
+/* Reset (light-DOM consumer reset — first, before any tokens). */
+@import "./reset.css";
+
+/* 11 primitive families (alphabetical). */
+@import "./border-width.css";
+@import "./breakpoints.css";
+@import "./easings.css";
+@import "./focus-ring.css";
+@import "./motion.css";
+@import "./opacity.css";
+@import "./radii.css";
+@import "./shadows.css";
+@import "./sizing.css";
+@import "./typography.css";
+@import "./z-index.css";
+
+/* 7 decorative families (alphabetical). */
+@import "./animations.css";
+@import "./aspects.css";
+@import "./gradients.css";
+@import "./highlights.css";
+@import "./layouts.css";
+@import "./masks.css";
+@import "./svg.css";

--- a/packages/line-tokens/src/layouts.css
+++ b/packages/line-tokens/src/layouts.css
@@ -1,0 +1,24 @@
+/* @websublime/line-tokens — layouts.css
+ *
+ * Decorative family: structural layout tokens (grid/flex gaps, common ratios).
+ * Tokens are SINGULAR: --line-layout-*.
+ */
+:where(html) {
+  /* Grid column-count tokens. */
+  --line-layout-columns-2: repeat(2, minmax(0, 1fr));
+  --line-layout-columns-3: repeat(3, minmax(0, 1fr));
+  --line-layout-columns-4: repeat(4, minmax(0, 1fr));
+  --line-layout-columns-6: repeat(6, minmax(0, 1fr));
+  --line-layout-columns-12: repeat(12, minmax(0, 1fr));
+
+  /* Auto-fit / auto-fill responsive track templates. */
+  --line-layout-auto-fit: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  --line-layout-auto-fill: repeat(auto-fill, minmax(min(100%, 16rem), 1fr));
+
+  /* Gap scale (references the sizing primitive). */
+  --line-layout-gap-1: var(--line-size-1);
+  --line-layout-gap-2: var(--line-size-2);
+  --line-layout-gap-3: var(--line-size-3);
+  --line-layout-gap-4: var(--line-size-5);
+  --line-layout-gap-5: var(--line-size-7);
+}

--- a/packages/line-tokens/src/masks.css
+++ b/packages/line-tokens/src/masks.css
@@ -1,0 +1,21 @@
+/* @websublime/line-tokens — masks.css
+ *
+ * Decorative family: mask / clip-path geometry tokens.
+ * Tokens are SINGULAR: --line-mask-*.
+ * Pure geometry — no colour values.
+ */
+:where(html) {
+  /* Edge-fade mask gradients (alpha geometry only — black/transparent are
+     mask channels, not paint colours, so no hue token applies). */
+  --line-mask-fade-top: linear-gradient(to top, transparent, black 25%);
+  --line-mask-fade-bottom: linear-gradient(to bottom, transparent, black 25%);
+  --line-mask-fade-left: linear-gradient(to left, transparent, black 25%);
+  --line-mask-fade-right: linear-gradient(to right, transparent, black 25%);
+  --line-mask-fade-edges: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
+
+  /* clip-path shape tokens. */
+  --line-mask-circle: circle(50%);
+  --line-mask-triangle: polygon(50% 0%, 0% 100%, 100% 100%);
+  --line-mask-hexagon: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  --line-mask-rhombus: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}

--- a/packages/line-tokens/src/motion.css
+++ b/packages/line-tokens/src/motion.css
@@ -1,0 +1,19 @@
+/* @websublime/line-tokens — motion.css
+ *
+ * Primitive family: animation/transition DURATION scale.
+ * Tokens are SINGULAR: --line-motion-*.
+ * Durations seeded from Open Props as a design reference — NO runtime dependency.
+ */
+:where(html) {
+  --line-motion-instant: 0s;
+  --line-motion-fast: 0.1s;
+  --line-motion-1: 0.15s;
+  --line-motion-2: 0.2s;
+  --line-motion-3: 0.3s;
+  --line-motion-4: 0.4s;
+  --line-motion-5: 0.5s;
+  --line-motion-slow: 0.75s;
+  --line-motion-6: 1s;
+  --line-motion-7: 2s;
+  --line-motion-8: 3s;
+}

--- a/packages/line-tokens/src/opacity.css
+++ b/packages/line-tokens/src/opacity.css
@@ -1,0 +1,20 @@
+/* @websublime/line-tokens — opacity.css
+ *
+ * Primitive family: opacity scale (0–100, decimal form).
+ * Tokens are SINGULAR: --line-opacity-N.
+ */
+:where(html) {
+  --line-opacity-0: 0;
+  --line-opacity-1: 0.05;
+  --line-opacity-2: 0.1;
+  --line-opacity-3: 0.2;
+  --line-opacity-4: 0.3;
+  --line-opacity-5: 0.4;
+  --line-opacity-6: 0.5;
+  --line-opacity-7: 0.6;
+  --line-opacity-8: 0.7;
+  --line-opacity-9: 0.8;
+  --line-opacity-10: 0.9;
+  --line-opacity-11: 0.95;
+  --line-opacity-12: 1;
+}

--- a/packages/line-tokens/src/radii.css
+++ b/packages/line-tokens/src/radii.css
@@ -1,0 +1,20 @@
+/* @websublime/line-tokens — radii.css
+ *
+ * Primitive family: border-radius scale.
+ * Family name is PLURAL (radii); token name is SINGULAR: --line-radius-N.
+ * Values seeded from Open Props as a design reference — NO runtime dependency.
+ */
+:where(html) {
+  --line-radius-1: 2px;
+  --line-radius-2: 5px;
+  --line-radius-3: 1rem;
+  --line-radius-4: 2rem;
+  --line-radius-5: 4rem;
+  --line-radius-6: 8rem;
+  --line-radius-round: 1e5px;
+
+  /* Conditional (interpolated) radii for responsive corners. */
+  --line-radius-conditional-1: clamp(0px, calc(100vw - 100%) * 1e5, 2px);
+  --line-radius-conditional-2: clamp(0px, calc(100vw - 100%) * 1e5, 5px);
+  --line-radius-conditional-3: clamp(0px, calc(100vw - 100%) * 1e5, 1rem);
+}

--- a/packages/line-tokens/src/reset.css
+++ b/packages/line-tokens/src/reset.css
@@ -1,0 +1,125 @@
+/* @websublime/line-tokens — reset.css
+ *
+ * Zero-opinion, light-DOM consumer reset for SLOTTED content (ARCHITECTURE §14.10).
+ * Opt-in only — consumers import via `@websublime/line-tokens/reset`.
+ *
+ * DISTINCT from line-core/styles/* (the shadow-DOM internal reset suite).
+ * This file NEUTRALISES browser defaults on slotted light-DOM content; it
+ * applies NO colour, spacing, or typography opinion of its own.
+ *
+ * Every selector uses :where() for ZERO specificity (PRD §9.12) so consumer
+ * styles always win without an arms race. Seven categories per ARCH §14.10.
+ */
+
+/* ---------------------------------------------------------------------------
+ * 1 — Global slotted content reset.
+ * Any element carrying a `line-*` class neutralises browser defaults on the
+ * common flow/media elements (h1–h6, p, ul, ol, img, svg, …).
+ * ------------------------------------------------------------------------- */
+:where([class^="line-"], [class*=" line-"]) :where(h1, h2, h3, h4, h5, h6),
+:where([class^="line-"], [class*=" line-"]) :where(p),
+:where([class^="line-"], [class*=" line-"]) :where(blockquote),
+:where([class^="line-"], [class*=" line-"]) :where(figure),
+:where([class^="line-"], [class*=" line-"]) :where(dl, dd) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+:where([class^="line-"], [class*=" line-"]) :where(ul, ol) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+:where([class^="line-"], [class*=" line-"]) :where(img, svg, video, canvas, picture) {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+/* ---------------------------------------------------------------------------
+ * 2 — Field component.
+ * line-field labels, hint/error slots — neutralise margin, padding, font.
+ * ------------------------------------------------------------------------- */
+:where(line-field) :where(label),
+:where(line-field) :where([slot="hint"]),
+:where(line-field) :where([slot="error"]) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+/* ---------------------------------------------------------------------------
+ * 3 — Form-adjacent components.
+ * Labels and hint/error/description slots — margin, padding, font inheritance.
+ * ------------------------------------------------------------------------- */
+:where(line-input, line-textarea, line-select, line-number-field, line-combobox, line-pin-input) :where(label),
+:where(line-input, line-textarea, line-select, line-number-field, line-combobox, line-pin-input)
+  :where([slot="hint"], [slot="error"], [slot="description"]) {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+}
+
+/* ---------------------------------------------------------------------------
+ * 4 — Content containers.
+ * Headings, paragraphs, lists inside containers — margin, padding, list-style.
+ * ------------------------------------------------------------------------- */
+:where(line-card, line-dialog, line-alert, line-drawer, line-popover, line-tooltip, line-callout, line-banner)
+  :where(h1, h2, h3, h4, h5, h6, p) {
+  margin: 0;
+  padding: 0;
+}
+
+:where(line-card, line-dialog, line-alert, line-drawer, line-popover, line-tooltip, line-callout, line-banner)
+  :where(ul, ol) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * 5 — Navigation components.
+ * Links and lists — text-decoration, color, margin, padding, list-style.
+ * ------------------------------------------------------------------------- */
+:where(line-tabs, line-breadcrumb, line-menu, line-pagination, line-navigation-menu) :where(a) {
+  color: inherit;
+  text-decoration: none;
+}
+
+:where(line-tabs, line-breadcrumb, line-menu, line-pagination, line-navigation-menu) :where(ul, ol) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * 6 — Slotted button resets.
+ * Bare <button> elements — neutralise appearance, background, border, cursor.
+ * ------------------------------------------------------------------------- */
+:where(line-dialog, line-alert, line-drawer, line-toolbar, line-card) :where(button) {
+  appearance: none;
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+/* ---------------------------------------------------------------------------
+ * 7 — Slotted table resets.
+ * <table>, <th>, <td> — border-collapse, spacing, alignment.
+ * ------------------------------------------------------------------------- */
+:where(line-card, line-dialog, line-drawer) :where(table) {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+:where(line-card, line-dialog, line-drawer) :where(th, td) {
+  padding: 0;
+  text-align: start;
+  vertical-align: top;
+}

--- a/packages/line-tokens/src/shadows.css
+++ b/packages/line-tokens/src/shadows.css
@@ -1,0 +1,52 @@
+/* @websublime/line-tokens — shadows.css
+ *
+ * Primitive family: elevation shadow scale (box-shadow geometry).
+ * Values seeded from Open Props as a design reference — NO runtime dependency.
+ *
+ * Zero colour opinion (Manifesto Law): shadow colour is NOT a literal. Each
+ * elevation references --line-shadow-color, which itself defers to a neutral
+ * alpha hue token supplied by line-colors (C3). At C2 build time these are
+ * dangling var() refs — they resolve at use-site once line-colors is loaded.
+ * --line-shadow-strength scales the per-step alpha.
+ */
+:where(html) {
+  /* Shadow colour + strength knobs (themeable; resolve via line-colors). */
+  --line-shadow-color: var(--line-gray-a-12);
+  --line-shadow-strength: 1%;
+
+  --line-shadow-1: 0 1px 2px -1px var(--line-shadow-color);
+  --line-shadow-2: 0 3px 5px -2px var(--line-shadow-color), 0 7px 14px -5px var(--line-shadow-color);
+  --line-shadow-3:
+    0 -1px 3px 0 var(--line-shadow-color),
+    0 1px 2px -5px var(--line-shadow-color),
+    0 2px 5px -5px var(--line-shadow-color),
+    0 4px 12px -5px var(--line-shadow-color),
+    0 12px 15px -5px var(--line-shadow-color);
+  --line-shadow-4:
+    0 -2px 5px 0 var(--line-shadow-color),
+    0 1px 1px -2px var(--line-shadow-color),
+    0 2px 2px -2px var(--line-shadow-color),
+    0 5px 5px -2px var(--line-shadow-color),
+    0 9px 9px -2px var(--line-shadow-color),
+    0 16px 16px -2px var(--line-shadow-color);
+  --line-shadow-5:
+    0 -1px 2px 0 var(--line-shadow-color),
+    0 2px 1px -2px var(--line-shadow-color),
+    0 5px 5px -2px var(--line-shadow-color),
+    0 10px 10px -2px var(--line-shadow-color),
+    0 20px 20px -2px var(--line-shadow-color),
+    0 40px 40px -2px var(--line-shadow-color);
+  --line-shadow-6:
+    0 -1px 2px 0 var(--line-shadow-color),
+    0 3px 2px -2px var(--line-shadow-color),
+    0 7px 5px -2px var(--line-shadow-color),
+    0 12px 10px -2px var(--line-shadow-color),
+    0 22px 18px -2px var(--line-shadow-color),
+    0 41px 33px -2px var(--line-shadow-color),
+    0 100px 80px -2px var(--line-shadow-color);
+
+  /* Inner (inset) shadows. */
+  --line-shadow-inner-1: inset 0 0 0 1px var(--line-shadow-color);
+  --line-shadow-inner-2: inset 0 1px 2px 0 var(--line-shadow-color);
+  --line-shadow-inner-3: inset 0 1px 4px 0 var(--line-shadow-color);
+}

--- a/packages/line-tokens/src/sizing.css
+++ b/packages/line-tokens/src/sizing.css
@@ -1,0 +1,37 @@
+/* @websublime/line-tokens — sizing.css
+ *
+ * Primitive family: spacing / sizing scale.
+ * Values seeded from Open Props as a design reference — NO runtime dependency.
+ * Tokens are SINGULAR: --line-size-N (NOT --line-sizing-N).
+ */
+:where(html) {
+  --line-size-0: 0;
+  --line-size-1: 0.25rem;
+  --line-size-2: 0.5rem;
+  --line-size-3: 1rem;
+  --line-size-4: 1.25rem;
+  --line-size-5: 1.5rem;
+  --line-size-6: 1.75rem;
+  --line-size-7: 2rem;
+  --line-size-8: 3rem;
+  --line-size-9: 4rem;
+  --line-size-10: 5rem;
+  --line-size-11: 7.5rem;
+  --line-size-12: 10rem;
+  --line-size-13: 15rem;
+  --line-size-14: 20rem;
+  --line-size-15: 30rem;
+
+  /* Fluid relative sizes */
+  --line-size-content-1: 20ch;
+  --line-size-content-2: 45ch;
+  --line-size-content-3: 60ch;
+
+  --line-size-xxs: 12rem;
+  --line-size-xs: 16rem;
+  --line-size-sm: 24rem;
+  --line-size-md: 32rem;
+  --line-size-lg: 48rem;
+  --line-size-xl: 64rem;
+  --line-size-xxl: 80rem;
+}

--- a/packages/line-tokens/src/svg.css
+++ b/packages/line-tokens/src/svg.css
@@ -1,0 +1,37 @@
+/* @websublime/line-tokens — svg.css
+ *
+ * Decorative family: STRUCTURAL SVG presentation tokens (Phase 00).
+ *
+ * COLOUR-LITERAL-FREE (enforced by scripts/lint-layers.mjs). This file owns
+ * SVG GEOMETRY — stroke widths, line joins, mitre limits, dash arrays. Any
+ * paint (stroke/fill colour) defers to var(--line-{hue}-{step}) from
+ * line-colors (C3). Dangling var() at C2 build time — resolves at use-site.
+ * Tokens are SINGULAR: --line-svg-*.
+ */
+:where(html) {
+  /* Stroke geometry. */
+  --line-svg-stroke-width-1: 1px;
+  --line-svg-stroke-width-2: 1.5px;
+  --line-svg-stroke-width-3: 2px;
+  --line-svg-stroke-width-4: 3px;
+
+  --line-svg-stroke-linecap-butt: butt;
+  --line-svg-stroke-linecap-round: round;
+  --line-svg-stroke-linecap-square: square;
+
+  --line-svg-stroke-linejoin-miter: miter;
+  --line-svg-stroke-linejoin-round: round;
+  --line-svg-stroke-linejoin-bevel: bevel;
+
+  --line-svg-stroke-miterlimit: 4;
+
+  /* Dash patterns (length geometry only). */
+  --line-svg-dash-none: 0;
+  --line-svg-dash-dotted: 1 3;
+  --line-svg-dash-dashed: 6 4;
+  --line-svg-dash-long: 12 6;
+
+  /* Paint defers to line-colors hue tokens (no literals here). */
+  --line-svg-stroke: var(--line-accent-11);
+  --line-svg-fill: var(--line-accent-9);
+}

--- a/packages/line-tokens/src/typography.css
+++ b/packages/line-tokens/src/typography.css
@@ -1,0 +1,53 @@
+/* @websublime/line-tokens — typography.css
+ *
+ * Primitive family: type scale, font families, weights, line-heights, tracking.
+ * Values seeded from Open Props as a design reference — NO runtime dependency.
+ * All tokens are --line-* prefixed and SINGULAR (--line-font-size-N).
+ * :where(html) wrapper → zero specificity (PRD §9.12).
+ */
+:where(html) {
+  /* Font families */
+  --line-font-sans:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  --line-font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --line-font-mono:
+    ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  /* Font weights */
+  --line-font-weight-1: 100;
+  --line-font-weight-2: 200;
+  --line-font-weight-3: 300;
+  --line-font-weight-4: 400;
+  --line-font-weight-5: 500;
+  --line-font-weight-6: 600;
+  --line-font-weight-7: 700;
+  --line-font-weight-8: 800;
+  --line-font-weight-9: 900;
+
+  /* Font sizes (fluid-friendly rem scale) */
+  --line-font-size-0: 0.75rem;
+  --line-font-size-1: 1rem;
+  --line-font-size-2: 1.1rem;
+  --line-font-size-3: 1.25rem;
+  --line-font-size-4: 1.5rem;
+  --line-font-size-5: 2rem;
+  --line-font-size-6: 2.5rem;
+  --line-font-size-7: 3rem;
+  --line-font-size-8: 3.5rem;
+
+  /* Line heights (leading) */
+  --line-leading-0: 0.95;
+  --line-leading-1: 1.1;
+  --line-leading-2: 1.25;
+  --line-leading-3: 1.375;
+  --line-leading-4: 1.5;
+  --line-leading-5: 1.7;
+
+  /* Letter spacing (tracking) */
+  --line-tracking-0: -0.05em;
+  --line-tracking-1: 0.025em;
+  --line-tracking-2: 0.05em;
+  --line-tracking-3: 0.075em;
+  --line-tracking-4: 0.15em;
+}

--- a/packages/line-tokens/src/z-index.css
+++ b/packages/line-tokens/src/z-index.css
@@ -1,0 +1,23 @@
+/* @websublime/line-tokens — z-index.css
+ *
+ * Primitive family: stacking-order scale + named layers.
+ * Tokens are SINGULAR: --line-z-*.
+ */
+:where(html) {
+  --line-z-1: 1;
+  --line-z-2: 2;
+  --line-z-3: 3;
+  --line-z-4: 4;
+  --line-z-5: 5;
+
+  /* Named stacking layers (semantic overlays). */
+  --line-z-deck: 10;
+  --line-z-sticky: 100;
+  --line-z-drawer: 200;
+  --line-z-overlay: 300;
+  --line-z-dialog: 400;
+  --line-z-popover: 500;
+  --line-z-toast: 600;
+  --line-z-tooltip: 700;
+  --line-z-max: 2147483647;
+}


### PR DESCRIPTION
## line-ui-7qm.3.2: C2 — line-tokens 18 families + reset barrel

Author all 18 token family CSS files (11 primitives + 7 decoratives) plus the light-DOM consumer reset, and compose the `index.css` barrel.

### What was done
Pure CSS authoring on top of the B4 scaffolding (exports map, build script, postcss config, lint guards already in place). Composed the barrel in fixed order: reset → 11 primitives (alphabetical) → 7 decoratives (alphabetical). All custom properties are `--line-*` prefixed and singular; every declaration wrapped in `:where(html)` for zero specificity. Decorative `gradients`/`highlights`/`svg` are structural-only — colours defer to `var(--line-{hue}-{step})` tokens from line-colors (C3).

### Files changed
- `packages/line-tokens/src/index.css` (modified — barrel)
- `packages/line-tokens/src/{reset,typography,sizing,shadows,easings,z-index,opacity,motion,radii,border-width,focus-ring,breakpoints}.css` (created — reset + 11 primitives)
- `packages/line-tokens/src/{aspects,animations,gradients,masks,layouts,highlights,svg}.css` (created — 7 decoratives)
- `.changeset/line-tokens-families.md` (created)
- `package.json` / `postcss.config.mjs` / `scripts/lint-layers.mjs` — NOT touched (already correct from B4)

### Decisions
- Shadow/focus-ring/highlight/svg/gradient colours deferred via indirection tokens (e.g. `--line-shadow-color` → `--line-gray-a-12`, `--line-focus-ring-color` → `--line-accent-8`) instead of literals, to honour the zero-colour-opinion Manifesto law. These reference line-colors (C3) hue tokens — dangling var() at C2 build time, resolve at use-site.
- In `gradients.css` composed tokens, inlined direction keywords (`to bottom`, `45deg`) instead of `var(--line-gradient-angle-*)` because Biome's `noInvalidDirectionInLinearGradient` rejects a var() in the gradient direction slot. Standalone angle tokens retained for consumer reuse.

### Deviations
None — implemented as spec.

### Verification
- `bun run build` → flat `dist/index.css` (0 `@import` remaining) + one `dist/*.css` per subpath (20 files).
- `scripts/lint-layers.mjs` → OK (dependency graph + `--line-*` prefix audit + colour-literal guard).
- Biome check clean on all 20 files.
- gradients/highlights/svg dist verified literal-free; singular naming verified; all 20 exports-map subpaths resolve.