### PR TITLE
chore: Stream C review cleanups (line-ui-7qm.3.10, line-ui-7qm.3.11)

### DIFF
--- a/.changeset/stream-c-review-cleanups.md
+++ b/.changeset/stream-c-review-cleanups.md
@@ -1,0 +1,9 @@
+---
+"@websublime/line-schemas": patch
+"@websublime/line-colors": patch
+---
+
+Stream C review cleanups (line-ui-7qm.3.10, line-ui-7qm.3.11):
+
+- **line-schemas — `StepSchema` derived from `STEPS`**: `StepSchema` is now built from the canonical `STEPS` tuple (a mapped tuple of `z.literal`s) instead of a hand-maintained 12-arm `z.union`, restoring the single-source-of-truth const+schema+type pattern used by every other contract module. The exported `Step` type and runtime validation behaviour are unchanged — it accepts exactly `1..12` and rejects everything else.
+- **`scripts/verify-palettes-fresh.mjs` — multi-file drift reporting**: on failure the guard now reports a per-file differing-line count and an up-front tally (`N drifting files (M differing lines)`, plus any file-set violations), so a multi-hue `@radix-ui/colors` bump surfaces every affected file in a single CI run rather than one line at a time across successive runs. Pass/fail semantics are unchanged — any drift still exits non-zero.

--- a/packages/line-schemas/src/steps.ts
+++ b/packages/line-schemas/src/steps.ts
@@ -2,22 +2,26 @@ import { z } from 'zod';
 
 /**
  * The 12 palette steps (Radix-style scale). Every hue exposes these 12 steps.
+ *
+ * This is the canonical source of truth: {@link Step} and {@link StepSchema} are
+ * both derived from this tuple, mirroring the const+schema+type pattern used by
+ * every other contract module in the package (see e.g. `hues.ts`). `STEPS` is a
+ * numeric tuple, so the schema is a `z.union` of numeric literals mapped over the
+ * tuple rather than a `z.enum` (which is string-only in Zod).
  */
 export const STEPS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 
 export type Step = (typeof STEPS)[number];
 
-export const StepSchema = z.union([
-  z.literal(1),
-  z.literal(2),
-  z.literal(3),
-  z.literal(4),
-  z.literal(5),
-  z.literal(6),
-  z.literal(7),
-  z.literal(8),
-  z.literal(9),
-  z.literal(10),
-  z.literal(11),
-  z.literal(12),
-]);
+/**
+ * Map the readonly `STEPS` tuple to the tuple of `z.literal` schemas that
+ * `z.union` expects, preserving each element's literal type so the inferred
+ * output of {@link StepSchema} is exactly {@link Step}.
+ */
+type LiteralSchemas<T extends readonly number[]> = {
+  [K in keyof T]: z.ZodLiteral<T[K]>;
+};
+
+const stepLiterals = STEPS.map((step) => z.literal(step)) as unknown as LiteralSchemas<typeof STEPS>;
+
+export const StepSchema = z.union(stepLiterals);

--- a/scripts/verify-palettes-fresh.mjs
+++ b/scripts/verify-palettes-fresh.mjs
@@ -125,9 +125,8 @@ function diffSummary(committed, fresh, name) {
     };
   }
 
-  const plural = diffLines === 1 ? '' : 's';
   const ctx = [
-    `  --- committed ${name}:${firstDiff + 1} (${diffLines} differing line${plural} in this file)`,
+    `  --- committed ${name}:${firstDiff + 1} (${diffLines} differing line${diffLines === 1 ? '' : 's'} in this file)`,
     `  - ${a[firstDiff] ?? '(missing line)'}`,
     '  +++ freshly generated',
     `  + ${b[firstDiff] ?? '(missing line)'}`,

--- a/scripts/verify-palettes-fresh.mjs
+++ b/scripts/verify-palettes-fresh.mjs
@@ -90,29 +90,49 @@ async function listCssFiles(dir) {
 }
 
 /**
- * Render a compact unified-style diff (first divergent region) between two file
- * contents, to point the contributor at WHERE the drift is. Kept dependency-free.
+ * Compare two file contents line-by-line and report (a) the first divergent
+ * region — to point the contributor at WHERE the drift starts — plus (b) the
+ * total number of differing lines in this file, so a multi-line drift within a
+ * single hue (e.g. a @radix-ui/colors bump touching many steps) is quantified
+ * rather than implied by a single sample line. Kept dependency-free.
+ *
+ * This is diagnostics only: callers already decide pass/fail on raw byte
+ * inequality (`committed !== fresh`); this function never gates that.
  * @param {string} committed
  * @param {string} fresh
  * @param {string} name
- * @returns {string}
+ * @returns {{ text: string; diffLines: number }}
  */
-function firstDiffRegion(committed, fresh, name) {
+function diffSummary(committed, fresh, name) {
   const a = committed.split('\n');
   const b = fresh.split('\n');
   const max = Math.max(a.length, b.length);
+
+  let firstDiff = -1;
+  let diffLines = 0;
   for (let i = 0; i < max; i++) {
     if (a[i] !== b[i]) {
-      const ctx = [];
-      ctx.push(`  --- committed ${name}:${i + 1}`);
-      ctx.push(`  - ${a[i] ?? '(missing line)'}`);
-      ctx.push('  +++ freshly generated');
-      ctx.push(`  + ${b[i] ?? '(missing line)'}`);
-      return ctx.join('\n');
+      if (firstDiff === -1) firstDiff = i;
+      diffLines++;
     }
   }
-  // Contents differ only by trailing-newline / length with no line-level mismatch.
-  return `  (content length differs: committed ${committed.length}B vs fresh ${fresh.length}B)`;
+
+  if (firstDiff === -1) {
+    // Contents differ only by trailing-newline / length with no line-level mismatch.
+    return {
+      text: `  (content length differs: committed ${committed.length}B vs fresh ${fresh.length}B)`,
+      diffLines: 0,
+    };
+  }
+
+  const plural = diffLines === 1 ? '' : 's';
+  const ctx = [
+    `  --- committed ${name}:${firstDiff + 1} (${diffLines} differing line${plural} in this file)`,
+    `  - ${a[firstDiff] ?? '(missing line)'}`,
+    '  +++ freshly generated',
+    `  + ${b[firstDiff] ?? '(missing line)'}`,
+  ];
+  return { text: ctx.join('\n'), diffLines };
 }
 
 /**
@@ -120,12 +140,14 @@ function firstDiffRegion(committed, fresh, name) {
  * return the list of freshness violations (empty when fresh). Checks file-set
  * equality in both directions, then byte-for-byte content of files on both sides.
  * @param {string} tmpDir
- * @returns {Promise<{ errors: string[]; committedCount: number }>}
+ * @returns {Promise<{ errors: string[]; committedCount: number; driftFiles: number; driftLines: number }>}
  */
 async function collectDrift(tmpDir) {
   const committedFiles = await listCssFiles(COMMITTED_DIR);
   const freshFiles = await listCssFiles(tmpDir);
   const errors = [];
+  let driftFiles = 0;
+  let driftLines = 0;
 
   // 1. File-SET equality, both directions.
   for (const name of committedFiles) {
@@ -151,11 +173,14 @@ async function collectDrift(tmpDir) {
       readFile(join(tmpDir, name), 'utf8'),
     ]);
     if (committed !== fresh) {
-      errors.push(`drift: '${name}' differs from a fresh generation.\n${firstDiffRegion(committed, fresh, name)}`);
+      driftFiles++;
+      const { text, diffLines } = diffSummary(committed, fresh, name);
+      driftLines += diffLines;
+      errors.push(`drift: '${name}' differs from a fresh generation.\n${text}`);
     }
   }
 
-  return { errors, committedCount: committedFiles.size };
+  return { errors, committedCount: committedFiles.size, driftFiles, driftLines };
 }
 
 /**
@@ -186,7 +211,7 @@ async function main() {
   const tmpDir = await mkdtemp(join(tmpdir(), 'line-palettes-fresh-'));
   try {
     runGenerator(tmpDir);
-    const { errors, committedCount } = await collectDrift(tmpDir);
+    const { errors, committedCount, driftFiles, driftLines } = await collectDrift(tmpDir);
 
     if (errors.length === 0) {
       console.info(
@@ -195,7 +220,18 @@ async function main() {
       return;
     }
 
-    process.stderr.write(`\nverify-palettes-fresh: FAIL — ${errors.length} freshness violation(s):\n`);
+    // Tally line: content-drift counts (files + lines) plus any file-set
+    // violations (stale/missing), so a multi-hue bump is quantified up front
+    // rather than read one error at a time.
+    const setViolations = errors.length - driftFiles;
+    const tally = [
+      `${driftFiles} drifting file${driftFiles === 1 ? '' : 's'} (${driftLines} differing line${driftLines === 1 ? '' : 's'})`,
+      setViolations > 0 ? `${setViolations} file-set violation${setViolations === 1 ? '' : 's'}` : null,
+    ]
+      .filter(Boolean)
+      .join(', ');
+
+    process.stderr.write(`\nverify-palettes-fresh: FAIL — ${errors.length} freshness violation(s) [${tally}]:\n`);
     for (const err of errors) {
       process.stderr.write(`  - ${err}\n`);
     }


### PR DESCRIPTION
Bulk implementation of two P3 [semantic] review-cleanup beads under epic line-ui-7qm.3 (Stream C), on one shared branch / one PR (user-authorized).

## line-ui-7qm.3.10 — derive `StepSchema` from `STEPS`
`packages/line-schemas/src/steps.ts`: replaced the hand-maintained 12-arm `z.union` of literals with a schema derived from the canonical `STEPS` tuple (a mapped tuple of `z.literal`s), restoring the single-source-of-truth const+schema+type pattern used by every other contract module in the package. Exported `Step` type and runtime validation are unchanged — accepts exactly `1..12`, rejects everything else (verified).

## line-ui-7qm.3.11 — multi-file diff reporting in the palette freshness guard
`scripts/verify-palettes-fresh.mjs`: the failure output now reports a per-file differing-line count and an up-front tally (`N drifting files (M differing lines)`, plus any file-set violations). A multi-hue `@radix-ui/colors` bump now surfaces every affected file in one CI run instead of one line at a time across successive runs. Pass/fail semantics unchanged — any drift still exits non-zero.

## Verification
- `bun run build` green; `bun run lint` (biome) exits 0 (the 1 warning/1 info are pre-existing, on `biome.json` + the untouched `index.ts` barrel).
- Schema: runtime check confirms accepts `1..12`, rejects `0/13/-1/1.5/'1'/null/undefined`; `tsc --noEmit` clean.
- Guard: clean tree exits 0 (no false drift); single hand-edit fails loud naming the file; three simultaneously edited hues surface all three in one run.

## Changeset
One changeset (`.changeset/stream-c-review-cleanups.md`): `@websublime/line-schemas` patch (A) + `@websublime/line-colors` patch (B, mirroring the C4 script-only precedent that attributed `verify-palettes-fresh.mjs` to line-colors).

Beads: line-ui-7qm.3.10, line-ui-7qm.3.11 — left in-review for the orchestrator's review + QA gates.