### PR TITLE
line-ui-7qm.3.7: C7 — line-utils contrast + mix helpers

### DIFF
--- a/.changeset/line-utils-contrast-mix.md
+++ b/.changeset/line-utils-contrast-mix.md
@@ -1,0 +1,8 @@
+---
+"@websublime/line-utils": minor
+---
+
+Author `@websublime/line-utils` helpers (spec §6.C.5): `contrast.ts` and `mix.ts`, re-exported from the package barrel and via the `./contrast` / `./mix` subpath exports.
+
+- **`contrast.ts` — WCAG 2.1 contrast helpers**: `hexToRgb`, `srgbToLinear`, `relativeLuminance`, `contrastRatio`, plus the `THRESHOLD` (3) and `SOLID_STEP` (9) constants. These are the single source of truth for the WCAG math previously inlined in `scripts/validate-contrast.mjs`; that validator now imports them from this module (via its `.ts` source path, matching the existing `line-schemas` source imports, to avoid a build-order hazard since the validator runs inside `line-colors`' build). The math is ported verbatim — the validator's output stays byte-identical (exit 0, the two documented orange allowlist warnings, and the "62 step-9/contrast pairs … meet ≥ 3:1" line).
+- **`mix.ts` — CSS `color-mix()` string builders**: `mix(a, b, weight?, options?)`, `withAlpha(color, alphaPercent, options?)`, `tint(color, amount, options?)`, and `shade(color, amount, options?)`. All are pure string builders (no parsing or evaluation) that accept an optional `{ colorSpace }` (default `srgb`) drawn from the CSS `<color-interpolation-method>` spaces. `withAlpha('var(--c)', 40)` yields `color-mix(in srgb, transparent 60%, var(--c))` (40% opaque); `tint`/`shade` mix toward `white`/`black`.

--- a/packages/line-utils/src/contrast.ts
+++ b/packages/line-utils/src/contrast.ts
@@ -1,0 +1,83 @@
+// @websublime/line-utils — WCAG 2.1 contrast helpers.
+//
+// Relative-luminance and contrast-ratio math per WCAG 2.1, shared between
+// runtime consumers and `scripts/validate-contrast.mjs`. This is the single
+// source of truth: the validator imports these helpers rather than inlining its
+// own copy (see bead line-ui-7qm.3.7). The math is ported verbatim from the
+// former inline implementation — any float change would shift computed ratios
+// and could flip the documented orange step-9 boundary, so it must stay exact.
+
+/**
+ * WCAG AA large-text / non-text-UI contrast floor (AM-014, spec §6.C.3).
+ *
+ * The design system's step-9 solid surfaces are engineered to clear this 3:1
+ * bar against their paired contrast token, not the stricter 4.5:1 normal-text
+ * floor (which the verbatim-adopted Radix palette cannot satisfy across all 62
+ * hue × mode pairs).
+ */
+export const THRESHOLD = 3;
+
+/**
+ * Step 9 is the solid brand anchor a contrast token is paired against
+ * (PRD §9.6). Hard-coded rather than imported from line-schemas `STEPS` because
+ * the contrast token is, by construction, the on-color for step 9 specifically.
+ */
+export const SOLID_STEP = 9;
+
+/**
+ * Parse a CSS hex color (`#rgb`, `#rrggbb`, with or without leading `#`) into
+ * 0-255 channels. Throws on any unparseable input so a malformed token surfaces
+ * loudly rather than computing a bogus ratio. Covers both the 6-digit Radix
+ * step-9 hexes and the 3-digit contrast tokens (`#000` / `#fff`).
+ */
+export function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.trim().replace(/^#/, '');
+  let full: string;
+  if (h.length === 3) {
+    full = h
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  } else if (h.length === 6) {
+    full = h;
+  } else {
+    throw new Error(`unparseable hex color "${hex}" (expected #rgb or #rrggbb)`);
+  }
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) {
+    throw new Error(`unparseable hex color "${hex}" (non-hex digits)`);
+  }
+  return {
+    r: Number.parseInt(full.slice(0, 2), 16),
+    g: Number.parseInt(full.slice(2, 4), 16),
+    b: Number.parseInt(full.slice(4, 6), 16),
+  };
+}
+
+/**
+ * Linearize one sRGB channel (0-255) per the WCAG 2.1 definition.
+ */
+export function srgbToLinear(channel8: number): number {
+  const c = channel8 / 255;
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/**
+ * WCAG 2.1 relative luminance of an sRGB hex color.
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+export function relativeLuminance(hex: string): number {
+  const { r, g, b } = hexToRgb(hex);
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+/**
+ * WCAG 2.1 contrast ratio between two sRGB hex colors, in [1, 21].
+ * https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+ */
+export function contrastRatio(hexA: string, hexB: string): number {
+  const la = relativeLuminance(hexA);
+  const lb = relativeLuminance(hexB);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/packages/line-utils/src/index.ts
+++ b/packages/line-utils/src/index.ts
@@ -1,1 +1,15 @@
-export {};
+// @websublime/line-utils — framework-agnostic helper utilities.
+//
+// This barrel re-exports the contrast and mix helper modules. Each is also
+// available via a subpath export (`./contrast`, `./mix`) — see package.json.
+
+export {
+  contrastRatio,
+  hexToRgb,
+  relativeLuminance,
+  SOLID_STEP,
+  srgbToLinear,
+  THRESHOLD,
+} from './contrast.js';
+export type { ColorSpace, MixOptions } from './mix.js';
+export { mix, shade, tint, withAlpha } from './mix.js';

--- a/packages/line-utils/src/mix.ts
+++ b/packages/line-utils/src/mix.ts
@@ -1,0 +1,112 @@
+// @websublime/line-utils — CSS `color-mix()` string builders.
+//
+// Pure string builders that compose CSS `color-mix()` expressions. They never
+// parse, evaluate, or resolve colors — they emit the CSS text a stylesheet (or
+// inline style) will hand to the browser, which does the actual interpolation.
+// API surface is fixed per the C7 pre-implementation decision (bead
+// line-ui-7qm.3.7): mix / withAlpha / tint / shade only. lighten/darken,
+// multi-stop mixing, and component helpers (cn/mergeRefs) are out of scope for
+// Phase 00.
+
+/**
+ * CSS `<color-interpolation-method>` color spaces accepted by `color-mix()`.
+ * The list mirrors the CSS Color 5 specification; `srgb` is the library
+ * default. Rectangular and polar spaces are both included — callers pass the
+ * string verbatim into the emitted `in <space>` clause.
+ */
+export type ColorSpace =
+  | 'srgb'
+  | 'srgb-linear'
+  | 'display-p3'
+  | 'a98-rgb'
+  | 'prophoto-rgb'
+  | 'rec2020'
+  | 'lab'
+  | 'oklab'
+  | 'xyz'
+  | 'xyz-d50'
+  | 'xyz-d65'
+  | 'hsl'
+  | 'hwb'
+  | 'lch'
+  | 'oklch';
+
+/**
+ * Shared options for every mix helper.
+ */
+export interface MixOptions {
+  /** Color-interpolation space for the emitted `color-mix()`. Defaults to `srgb`. */
+  colorSpace?: ColorSpace;
+}
+
+const DEFAULT_COLOR_SPACE: ColorSpace = 'srgb';
+
+/**
+ * Resolve the color space from caller options, falling back to the library
+ * default. Centralised so every builder shares identical default semantics.
+ */
+function resolveSpace(options?: MixOptions): ColorSpace {
+  return options?.colorSpace ?? DEFAULT_COLOR_SPACE;
+}
+
+/**
+ * Build a CSS `color-mix()` of two colors.
+ *
+ * When `weight` is provided it is attached to `colorA` as a percentage; the
+ * second percentage is omitted, letting CSS infer it (`100% - weight`). When
+ * `weight` is omitted both colors are mixed at their default (equal) ratio.
+ *
+ * @example
+ * mix('red', 'blue')        // 'color-mix(in srgb, red, blue)'
+ * mix('red', 'blue', 30)    // 'color-mix(in srgb, red 30%, blue)'
+ * mix('red', 'blue', 30, { colorSpace: 'oklch' })
+ *                           // 'color-mix(in oklch, red 30%, blue)'
+ */
+export function mix(colorA: string, colorB: string, weight?: number, options?: MixOptions): string {
+  const space = resolveSpace(options);
+  const first = weight === undefined ? colorA : `${colorA} ${weight}%`;
+  return `color-mix(in ${space}, ${first}, ${colorB})`;
+}
+
+/**
+ * Apply an opacity to a color by mixing it with `transparent`.
+ *
+ * `alphaPercent` is the desired opacity (0-100): `withAlpha('var(--c)', 40)`
+ * yields a color that is 40% opaque. This is expressed as a mix of
+ * `transparent` at `100 - alphaPercent` with the color, so the color's own
+ * weight is the remaining `alphaPercent`.
+ *
+ * @example
+ * withAlpha('var(--c)', 40)  // 'color-mix(in srgb, transparent 60%, var(--c))'
+ */
+export function withAlpha(color: string, alphaPercent: number, options?: MixOptions): string {
+  const space = resolveSpace(options);
+  const transparentWeight = 100 - alphaPercent;
+  return `color-mix(in ${space}, transparent ${transparentWeight}%, ${color})`;
+}
+
+/**
+ * Lighten a color by mixing it toward `white`.
+ *
+ * `amount` (0-100) is the percentage of `white` blended in.
+ *
+ * @example
+ * tint('var(--c)', 20)  // 'color-mix(in srgb, white 20%, var(--c))'
+ */
+export function tint(color: string, amount: number, options?: MixOptions): string {
+  const space = resolveSpace(options);
+  return `color-mix(in ${space}, white ${amount}%, ${color})`;
+}
+
+/**
+ * Darken a color by mixing it toward `black`.
+ *
+ * `amount` (0-100) is the percentage of `black` blended in.
+ *
+ * @example
+ * shade('var(--c)', 20)  // 'color-mix(in srgb, black 20%, var(--c))'
+ */
+export function shade(color: string, amount: number, options?: MixOptions): string {
+  const space = resolveSpace(options);
+  return `color-mix(in ${space}, black ${amount}%, ${color})`;
+}

--- a/scripts/validate-contrast.mjs
+++ b/scripts/validate-contrast.mjs
@@ -38,13 +38,17 @@
  * read, both keyed `{H}9` (the object name carries the Dark variant, the step
  * key does not — AM-011).
  *
- * WCAG MATH IS INLINED (SPEC_DRIFT-4): the shared contrast helper named by
- * §6.C.5 (line-utils/contrast.ts) is owned by C7 (line-ui-7qm.3.7), which is not
- * yet built (line-utils is `export {}`). C5 has no dependency on C7, so this
- * validator implements its own WCAG 2.1 relative-luminance + ratio inline — the
- * same self-contained convention as generate-palettes.mjs / verify-palettes-
- * fresh.mjs, neither of which imports from line-utils. C7 later extracts the
- * shared helper.
+ * WCAG MATH IS SHARED (C7, line-ui-7qm.3.7): the WCAG 2.1 relative-luminance,
+ * contrast-ratio, hex parsing, and the THRESHOLD / SOLID_STEP constants now live
+ * in the shared helper named by §6.C.5 (packages/line-utils/src/contrast.ts).
+ * This validator imports them from that source module — the single source of
+ * truth — rather than inlining its own copy. The helpers are imported via their
+ * `.ts` SOURCE path (not the `@websublime/line-utils` package specifier),
+ * matching the line-schemas source imports below: there is no line-utils symlink
+ * in root node_modules, and this validator runs inside line-colors' build
+ * (a leaf package with no dependency on line-utils), so line-utils/dist is not
+ * guaranteed to exist at validate time. Importing the source removes that
+ * build-order hazard while preserving the no-inline-copy intent.
  *
  * CI WIRING — out of scope here (spec §6.C.3 line 674, AM-014): .github/
  * workflows/checks.yml is owned by Stream F → F4 (line-ui-7qm.6.4,
@@ -58,18 +62,7 @@
 import * as radixColors from '@radix-ui/colors';
 import { PER_HUE_CONTRAST } from '../packages/line-schemas/src/contrast-table.ts';
 import { HUES } from '../packages/line-schemas/src/hues.ts';
-
-/**
- * WCAG AA large-text / non-text-UI contrast floor (AM-014, spec §6.C.3 line 668).
- */
-const THRESHOLD = 3;
-
-/**
- * Step 9 is the solid brand anchor a contrast token is paired against
- * (PRD §9.6). Hard-coded rather than imported from line-schemas STEPS because
- * the contrast token is, by construction, the on-color for step 9 specifically.
- */
-const SOLID_STEP = 9;
+import { contrastRatio, SOLID_STEP, THRESHOLD } from '../packages/line-utils/src/contrast.ts';
 
 /**
  * Documented upstream allowlist (AM-014, spec §6.C.3 line 669). EXACTLY one
@@ -124,73 +117,6 @@ function step(obj, objName, key) {
     throw new Error(`@radix-ui/colors ${objName}.${key} is undefined`);
   }
   return value;
-}
-
-/**
- * Parse a CSS hex color (`#rgb`, `#rrggbb`, with or without leading `#`) into
- * 0-255 channels. Throws on any unparseable input so a malformed token surfaces
- * loudly rather than computing a bogus ratio. Covers both the 6-digit Radix
- * step-9 hexes and the 3-digit contrast tokens (`#000` / `#fff`).
- * @param {string} hex
- * @returns {{ r: number; g: number; b: number }}
- */
-function hexToRgb(hex) {
-  const h = hex.trim().replace(/^#/, '');
-  let full;
-  if (h.length === 3) {
-    full = h
-      .split('')
-      .map((c) => c + c)
-      .join('');
-  } else if (h.length === 6) {
-    full = h;
-  } else {
-    throw new Error(`unparseable hex color "${hex}" (expected #rgb or #rrggbb)`);
-  }
-  if (!/^[0-9a-fA-F]{6}$/.test(full)) {
-    throw new Error(`unparseable hex color "${hex}" (non-hex digits)`);
-  }
-  return {
-    r: Number.parseInt(full.slice(0, 2), 16),
-    g: Number.parseInt(full.slice(2, 4), 16),
-    b: Number.parseInt(full.slice(4, 6), 16),
-  };
-}
-
-/**
- * Linearize one sRGB channel (0-255) per the WCAG 2.1 definition.
- * @param {number} channel8
- * @returns {number}
- */
-function srgbToLinear(channel8) {
-  const c = channel8 / 255;
-  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
-}
-
-/**
- * WCAG 2.1 relative luminance of an sRGB hex color.
- * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
- * @param {string} hex
- * @returns {number}
- */
-function relativeLuminance(hex) {
-  const { r, g, b } = hexToRgb(hex);
-  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
-}
-
-/**
- * WCAG 2.1 contrast ratio between two sRGB hex colors, in [1, 21].
- * https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
- * @param {string} hexA
- * @param {string} hexB
- * @returns {number}
- */
-function contrastRatio(hexA, hexB) {
-  const la = relativeLuminance(hexA);
-  const lb = relativeLuminance(hexB);
-  const lighter = Math.max(la, lb);
-  const darker = Math.min(la, lb);
-  return (lighter + 0.05) / (darker + 0.05);
 }
 
 /**


### PR DESCRIPTION
## line-ui-7qm.3.7: C7 — line-utils contrast and color-mix helper utilities

Authors `@websublime/line-utils` source (contrast + mix helpers) per spec §6.C.5, and migrates the WCAG contrast math out of `scripts/validate-contrast.mjs` into the shared helper so there is a single source of truth.

### What was done
- **`packages/line-utils/src/contrast.ts`** (new): WCAG 2.1 `hexToRgb`, `srgbToLinear`, `relativeLuminance`, `contrastRatio` + `THRESHOLD` (3) / `SOLID_STEP` (9) constants — ported verbatim from the validator's inline copy.
- **`packages/line-utils/src/mix.ts`** (new): pure `color-mix()` string builders `mix` / `withAlpha` / `tint` / `shade`, each accepting optional `{ colorSpace }` (default `srgb`).
- **`packages/line-utils/src/index.ts`**: barrel re-export (replaced the `export {}` stub).
- **`scripts/validate-contrast.mjs`**: removed the inline WCAG functions + constants, now imports them from the line-utils `.ts` source. `ALLOWLIST` / `evaluatePair` / `collectResults` unchanged — output is byte-identical (AM-014).
- **`.changeset/line-utils-contrast-mix.md`** (new): `@websublime/line-utils` minor.

### Files changed
packages/line-utils/src/contrast.ts, packages/line-utils/src/mix.ts, packages/line-utils/src/index.ts, scripts/validate-contrast.mjs, .changeset/line-utils-contrast-mix.md

### Decisions
- Changeset bumped `minor` (first real public API for the package), matching line-schemas' initial-authoring precedent.
- `noBarrelFile` warning on `index.ts` left unsuppressed — identical to line-schemas' barrel; `biome.json` configures it as `warn`, so `biome check` exits 0.

### Deviations
- The validator imports the helpers from the `.ts` source path (`../packages/line-utils/src/contrast.ts`), not the `@websublime/line-utils` package specifier the literal acceptance text names. Per the recorded pre-/do decision: the validator runs inside `line-colors`' build (a leaf package with no dep on line-utils), so `line-utils/dist` is not guaranteed to exist; the source import matches existing line-schemas source imports and removes the build-order hazard. Single-source-of-truth intent fully satisfied.

### Verification
- `bun --filter '@websublime/line-utils' build` → exit 0, emits contrast/mix/index `.js`+`.d.ts` matching the exports map.
- `bun run scripts/validate-contrast.mjs` → exit 0, byte-identical baseline (two orange WARNs + "62 step-9/contrast pairs … 2 allowlisted warning(s)" OK line).
- `bun --filter '@websublime/line-colors' build` → exit 0 (validator runs inside it).
- `bun run build` → exit 0 across all packages. `biome check` → exit 0.