### PR TITLE
line-ui-7qm.4.1: D1 — LineElement base class in line-core

### DIFF
--- a/.changeset/line-core-line-element.md
+++ b/.changeset/line-core-line-element.md
@@ -1,0 +1,5 @@
+---
+"@websublime/line-core": minor
+---
+
+Add the `LineElement` base class for all line://ui web components. `LineElement` composes the Direction, Metadata, and Inspector mixins over Lit's `LitElement`, establishing the mixin composition pattern (D1). It exposes a static `version` string and a protected `reflectState(name, active)` hook (overridden by the FormAssociated mixin). Per spec §6.D.1 it does NOT auto-inject `commonReset` and does NOT bake in `FormAssociated` — both stay opt-in. Ships identity (pass-through) stubs for the Inspector/Metadata/Direction mixins whose behaviour lands in D2/D3/D4.

--- a/packages/line-core/src/index.ts
+++ b/packages/line-core/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { LineElement } from './line-element.js';

--- a/packages/line-core/src/line-element.ts
+++ b/packages/line-core/src/line-element.ts
@@ -1,0 +1,33 @@
+import { LitElement } from 'lit';
+import { DirectionMixin } from './mixins/direction.js';
+import { InspectorMixin } from './mixins/inspector.js';
+import { MetadataMixin } from './mixins/metadata.js';
+
+/**
+ * `LineElement` — the base class for every line://ui web component.
+ *
+ * Composes the Inspector, Metadata, and Direction mixins over `LitElement`.
+ * Per spec §6.D.1 it intentionally:
+ *
+ * - **does NOT** auto-inject `commonReset` (every component declares its
+ *   resets explicitly — ARCHITECTURE §14.6 invariant), and
+ * - **does NOT** bake in `FormAssociated` (that mixin is opt-in per component,
+ *   e.g. `class LineInput extends FormAssociated(LineElement) {}`).
+ *
+ * @see docs/specs/00-spec-design-system.md §6.D.1
+ */
+export class LineElement extends DirectionMixin(MetadataMixin(InspectorMixin(LitElement))) {
+  /** Static version string surfaced by the Inspector mixin. */
+  static version = '0.0.0';
+
+  /**
+   * Hook for sub-classes / mixins to declare reflected state, e.g. for
+   * `CustomStateSet`. The `FormAssociated` mixin (D5) overrides this under
+   * `noImplicitOverride` — the signature must stay exactly as declared here.
+   *
+   * @see docs/specs/00-spec-design-system.md §6.D.5
+   */
+  protected reflectState(_name: string, _active: boolean): void {
+    /* see §6.D.5 */
+  }
+}

--- a/packages/line-core/src/mixins/direction.ts
+++ b/packages/line-core/src/mixins/direction.ts
@@ -1,0 +1,25 @@
+import type { LitElement } from 'lit';
+
+/**
+ * Generic constructor type used for Lit mixin composition.
+ * Matches the shape declared in spec §6.D.5.
+ */
+// biome-ignore lint/complexity/noBannedTypes: `{}` is the conventional mixin base constraint.
+// biome-ignore lint/suspicious/noExplicitAny: spec §6.D.5 mandates `any[]` for the mixin constructor signature.
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+/**
+ * Direction mixin (D4 — LTR/RTL direction management).
+ *
+ * D1 ships an identity (pass-through) stub so `LineElement` can compose the
+ * full mixin chain, type-check, build, and export now. D4 (line-ui-7qm.4.4)
+ * replaces the BODY of {@link DirectionElement} with the real `dir` reflection
+ * and `MutationObserver` wiring. The file path, export name, and signature must
+ * remain stable.
+ *
+ * @see docs/specs/00-spec-design-system.md §6.D.4
+ */
+export function DirectionMixin<T extends Constructor<LitElement>>(Base: T): T & Constructor<LitElement> {
+  class DirectionElement extends Base {}
+  return DirectionElement;
+}

--- a/packages/line-core/src/mixins/inspector.ts
+++ b/packages/line-core/src/mixins/inspector.ts
@@ -1,0 +1,24 @@
+import type { LitElement } from 'lit';
+
+/**
+ * Generic constructor type used for Lit mixin composition.
+ * Matches the shape declared in spec §6.D.5.
+ */
+// biome-ignore lint/complexity/noBannedTypes: `{}` is the conventional mixin base constraint.
+// biome-ignore lint/suspicious/noExplicitAny: spec §6.D.5 mandates `any[]` for the mixin constructor signature.
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+/**
+ * Inspector mixin (D2 — dev-mode element inspection).
+ *
+ * D1 ships an identity (pass-through) stub so `LineElement` can compose the
+ * full mixin chain, type-check, build, and export now. D2 (line-ui-7qm.4.2)
+ * replaces the BODY of {@link InspectorElement} with the real inspector
+ * behaviour. The file path, export name, and signature must remain stable.
+ *
+ * @see docs/specs/00-spec-design-system.md §6.D.2
+ */
+export function InspectorMixin<T extends Constructor<LitElement>>(Base: T): T & Constructor<LitElement> {
+  class InspectorElement extends Base {}
+  return InspectorElement;
+}

--- a/packages/line-core/src/mixins/metadata.ts
+++ b/packages/line-core/src/mixins/metadata.ts
@@ -1,0 +1,25 @@
+import type { LitElement } from 'lit';
+
+/**
+ * Generic constructor type used for Lit mixin composition.
+ * Matches the shape declared in spec §6.D.5.
+ */
+// biome-ignore lint/complexity/noBannedTypes: `{}` is the conventional mixin base constraint.
+// biome-ignore lint/suspicious/noExplicitAny: spec §6.D.5 mandates `any[]` for the mixin constructor signature.
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+/**
+ * Metadata mixin (D3 — element metadata and lifecycle hooks).
+ *
+ * D1 ships an identity (pass-through) stub so `LineElement` can compose the
+ * full mixin chain, type-check, build, and export now. D3 (line-ui-7qm.4.3)
+ * replaces the BODY of {@link MetadataElement} with the real metadata members
+ * (`docs`, `qa`, `scope`, …). The file path, export name, and signature must
+ * remain stable.
+ *
+ * @see docs/specs/00-spec-design-system.md §6.D.3
+ */
+export function MetadataMixin<T extends Constructor<LitElement>>(Base: T): T & Constructor<LitElement> {
+  class MetadataElement extends Base {}
+  return MetadataElement;
+}


### PR DESCRIPTION
## line-ui-7qm.4.1: D1 — LineElement base class

Implements `LineElement` extending `LitElement` as the base class for all line://ui web components, and establishes the mixin composition pattern (spec §6.D.1).

### What was done
- Added `LineElement` = `DirectionMixin(MetadataMixin(InspectorMixin(LitElement)))` with a static `version` string and the protected `reflectState(name, active)` hook (exact signature for the D5 FormAssociated override under `noImplicitOverride`).
- Shipped identity (pass-through) mixin stubs for Inspector/Metadata/Direction (Path A per orchestrator decision) so the full chain type-checks, builds, and exports now; D2/D3/D4 replace the stub bodies. Named return classes + explicit return types keep the emitted `.d.ts` stable.
- Re-exported `LineElement` from the package `.` entry (`src/index.ts`).
- No `commonReset` auto-inject and no `FormAssociated` baked in — both stay opt-in per §6.D.1.

### Files changed
- `packages/line-core/src/line-element.ts` (new)
- `packages/line-core/src/mixins/{inspector,metadata,direction}.ts` (new)
- `packages/line-core/src/index.ts` (replaced `export {}` stub)
- `.changeset/line-core-line-element.md` (new — minor)

### Decisions
- Base `reflectState` params underscore-prefixed (`_name`/`_active`) to satisfy `noUnusedParameters`; override compatibility is by type, so D5's named override stays valid.

### Deviations
None — implemented as spec §6.D.1 (Path A).

### Verification
`bun run typecheck` clean; `bun run build` succeeds (stable `.d.ts`); built ESM import exposes `LineElement` with `version '0.0.0'`; `biome check` exits 0.