### PR TITLE
line-ui-7qm.4.3: D3 — Metadata mixin static members

### DIFF
--- a/.changeset/line-core-metadata-mixin.md
+++ b/.changeset/line-core-metadata-mixin.md
@@ -1,0 +1,5 @@
+---
+"@websublime/line-core": minor
+---
+
+Implement the `MetadataMixin` (D3) for `LineElement`. The mixin replaces its D1 identity stub with the four static metadata members every line://ui component carries (spec §6.D.3): `version` (semver string), `docs` (documentation URL), `qa` (`string[]` of tags), and `scope` (string). Components override them declaratively, e.g. `static version = '0.1.0'`. The mixin owns the DECLARATION only — surfacing the members as host attributes (`data-line-version`, `data-line-docs`, …) remains the Inspector mixin's (D2) responsibility, which reads them defensively off `this.constructor`. The export name, file path, and generic signature stay byte-stable from the stub (`.d.ts`-determinism invariant).

--- a/packages/line-core/__tests__/metadata.test.ts
+++ b/packages/line-core/__tests__/metadata.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Metadata mixin unit tests (D3, spec §6.D.3).
+ *
+ * The Metadata mixin declares the four static metadata members
+ * (`version`, `docs`, `qa`, `scope`) every line://ui component carries.
+ * Surfacing them as host attributes is the Inspector mixin's (D2) job — this
+ * suite asserts ONLY the declaration contract:
+ *   1. defaults are present on a bare host;
+ *   2. component overrides take precedence;
+ *   3. the members survive mixin composition and stay readable off the
+ *      constructor (the shape the Inspector reads defensively).
+ *
+ * Note: lit-html cannot interpolate a tag name into element position
+ * (`<${tag}>` is parsed as text, not an element), so fixtures use static `html`
+ * templates with the literal tags registered below.
+ *
+ * Runs on F2's harness: `bun-test-preload.ts` registers happy-dom globally and
+ * wires `@open-wc/testing-helpers` `fixtureCleanup` afterEach.
+ *
+ * @module __tests__/metadata
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { fixture, html } from '@open-wc/testing-helpers';
+import { LitElement } from 'lit';
+import { MetadataMixin } from '../src/mixins/metadata.js';
+
+/** Bare host with the metadata mixin only — exercises the defaults. */
+class BareMetadataHost extends MetadataMixin(LitElement) {}
+
+/** Host overriding every metadata member (the component-author contract). */
+class FullMetadataHost extends MetadataMixin(LitElement) {
+  static override version = '1.2.3';
+  static override docs = 'https://example.test/docs';
+  static override qa: string[] = ['stable', 'a11y'];
+  static override scope = 'forms';
+}
+
+customElements.define('metadata-host-bare', BareMetadataHost);
+customElements.define('metadata-host-full', FullMetadataHost);
+
+/** Read a static member off the host's constructor, the way the Inspector does. */
+function ctor<T>(el: Element, key: string): T {
+  return (el.constructor as unknown as Record<string, T>)[key] as T;
+}
+
+describe('MetadataMixin', () => {
+  test('provides metadata defaults on a bare host', async () => {
+    const el = await fixture(html`<metadata-host-bare></metadata-host-bare>`);
+    expect(ctor<string>(el, 'version')).toBe('0.0.0');
+    expect(ctor<string>(el, 'docs')).toBe('');
+    expect(ctor<string[]>(el, 'qa')).toEqual([]);
+    expect(ctor<string>(el, 'scope')).toBe('');
+  });
+
+  test('honours component overrides for every member', async () => {
+    const el = await fixture(html`<metadata-host-full></metadata-host-full>`);
+    expect(ctor<string>(el, 'version')).toBe('1.2.3');
+    expect(ctor<string>(el, 'docs')).toBe('https://example.test/docs');
+    expect(ctor<string[]>(el, 'qa')).toEqual(['stable', 'a11y']);
+    expect(ctor<string>(el, 'scope')).toBe('forms');
+  });
+
+  test('exposes the members statically on the composed class (no instance needed)', () => {
+    // The Inspector reads `this.constructor.version` etc. — assert the same
+    // surface is present directly on the class.
+    expect(BareMetadataHost.version).toBe('0.0.0');
+    expect(BareMetadataHost.docs).toBe('');
+    expect(BareMetadataHost.qa).toEqual([]);
+    expect(BareMetadataHost.scope).toBe('');
+    expect(FullMetadataHost.qa).toEqual(['stable', 'a11y']);
+  });
+
+  test('qa is a distinct array per host class (no shared mutable default)', () => {
+    expect(BareMetadataHost.qa).not.toBe(FullMetadataHost.qa);
+    expect(FullMetadataHost.scope).toBe('forms');
+    // The bare host keeps its empty default regardless of subclass overrides.
+    expect(BareMetadataHost.qa).toEqual([]);
+  });
+});

--- a/packages/line-core/src/mixins/metadata.ts
+++ b/packages/line-core/src/mixins/metadata.ts
@@ -9,17 +9,43 @@ import type { LitElement } from 'lit';
 type Constructor<T = {}> = new (...args: any[]) => T;
 
 /**
- * Metadata mixin (D3 — element metadata and lifecycle hooks).
+ * Metadata mixin (D3 — static element metadata members).
  *
- * D1 ships an identity (pass-through) stub so `LineElement` can compose the
- * full mixin chain, type-check, build, and export now. D3 (line-ui-7qm.4.3)
- * replaces the BODY of {@link MetadataElement} with the real metadata members
- * (`docs`, `qa`, `scope`, …). The file path, export name, and signature must
- * remain stable.
+ * Declares the four static metadata members every line://ui component carries
+ * (spec §6.D.3):
+ *
+ * - `version` — the component's semver string (mirrors / defaults the value the
+ *   Inspector mixin surfaces as `data-line-version`).
+ * - `docs` — a URL string pointing at the component's documentation.
+ * - `qa` — an array of QA tags (`string[]`).
+ * - `scope` — a string naming the component's scope.
+ *
+ * Components override the members declaratively, e.g. `static version = '0.1.0'`.
+ *
+ * SURFACING the members as host attributes (`data-line-version`,
+ * `data-line-docs`, …) is the Inspector mixin's (D2) responsibility — it reads
+ * these static members defensively off `this.constructor`. This mixin owns the
+ * DECLARATION only; it does not touch the DOM.
+ *
+ * The file path, export name, and generic signature remain stable from the D1
+ * stub (`.d.ts`-determinism invariant; the `LineElement` composition chain in
+ * `line-element.ts` depends on them).
  *
  * @see docs/specs/00-spec-design-system.md §6.D.3
  */
 export function MetadataMixin<T extends Constructor<LitElement>>(Base: T): T & Constructor<LitElement> {
-  class MetadataElement extends Base {}
+  class MetadataElement extends Base {
+    /** Component semver string. Surfaced by the Inspector as `data-line-version`. */
+    static version = '0.0.0';
+
+    /** Documentation URL. Surfaced by the Inspector as `data-line-docs` when set. */
+    static docs = '';
+
+    /** QA tags for the component. */
+    static qa: string[] = [];
+
+    /** Component scope identifier. */
+    static scope = '';
+  }
   return MetadataElement;
 }


### PR DESCRIPTION
## line-ui-7qm.4.3: D3 — Metadata mixin static members

Replaces the D1 identity stub of `MetadataMixin` with the four static metadata members declared in spec §6.D.3.

### What was done
Declared `version`, `docs` (URL), `qa` (`string[]`), and `scope` static members on the mixin's class body. Members-only scope; host-attribute surfacing stays with the Inspector mixin (D2) per orchestrator decision (follow-up: line-ui-4jc). Body-only edit — export name, file path, and generic signature are byte-stable from the stub, preserving the `.d.ts`-determinism invariant.

### Files changed
- `packages/line-core/src/mixins/metadata.ts` (modified)
- `packages/line-core/__tests__/metadata.test.ts` (created)
- `.changeset/line-core-metadata-mixin.md` (created)

### Decisions
None — implemented per the orchestrator decision verbatim.

### Deviations
None — implemented as spec.

### Tests
`bun test packages/line-core/__tests__/` → 21 pass / 0 fail. `typecheck` → exit 0. `biome check` → clean. `build` → exit 0, emitted `metadata.d.ts` signature unchanged.